### PR TITLE
HU 2019-10-21

### DIFF
--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -5,6 +5,8 @@ import { getContext } from 'svelte';
 export let level = 'high';
 export let compact = false;
 
+export let toggled = false;
+
 export let size = compact ? 'compact' : 'standard';
 export let dark = getContext('appDarkMode') || false;
 
@@ -44,7 +46,7 @@ button {
     box-shadow: var(--depth-small);
 }
 
-.button--high:active {
+.button--high:active, .button--high.toggled {
     box-shadow: none;
     background-color: var(--primary-color-dark);
 }
@@ -58,7 +60,10 @@ button {
     background-color: rgba(0,0,0,.1);
 }
 
-.button--medium:active, .button--low:active {
+.button--medium:active,
+.button--medium.toggled, 
+.button--low:active,
+.button--low.toggled {
     background-color: rgba(0,0,0,.2);
 }
 
@@ -78,7 +83,7 @@ button {
     box-shadow: var(--depth-small);
 }
 
-.dark.button--high:active {
+.dark.button--high:active, .dark.button--high.toggled {
     box-shadow: none;
     background-color: var(--primary-color-lightest);
     border-color: var(--primary-color-lightest);
@@ -94,12 +99,15 @@ button {
     background-color: var(--primary-color-dark);
 }
 
-.dark.button--medium:active, .dark.button--low:active {
+.dark.button--medium:active, 
+.dark.button--medium.toggled, 
+.dark.button--low:active,
+.dark.button--low.toggled {
     background-color: rgba(0,0,0,.2);
     color: var(--primary-color-lightest);
 }
 
-.dark.button--medium:active {
+.dark.button--medium:active, .dark.button--medium.toggled {
     border-color: var(--primary-color-lightest);
 }
 
@@ -137,6 +145,6 @@ button {
 
 </style>
 
-<button class="button--{level} button--{size} button-text--{size}" class:dark on:click>
+<button class="button--{level} button--{size} button-text--{size}" class:dark class:toggled on:click>
     <slot></slot>
 </button>

--- a/src/components/ButtonGroup.svelte
+++ b/src/components/ButtonGroup.svelte
@@ -1,0 +1,28 @@
+
+
+<style>
+div {
+  display:grid;
+  grid-auto-flow: column;
+  width: max-content;
+}
+
+div :global(button:not(:first-child):not(:last-child)) {
+  border-radius: 0px;
+}
+
+div :global(button:first-child) {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+div :global(button:last-child) {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+
+</style>
+
+<div>
+  <slot></slot>
+</div>

--- a/src/components/data-graphics/ComparisonMultiple.svelte
+++ b/src/components/data-graphics/ComparisonMultiple.svelte
@@ -1,0 +1,71 @@
+<script>
+
+export let label;
+export let buildID;
+export let active = true;
+export let datum;
+export let percentiles;
+
+</script>
+
+<style>
+
+.summary-percentiles {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  font-size: var(--text-01);
+  align-content: start;
+}
+
+.summary-percentile--full {
+  grid-column: 1 / 3;
+}
+
+.summary-percentile--bin {
+  text-align: right;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.summary-percentile--value {
+  justify-self: stretch;
+  text-align: right;
+  width: 100%;
+  height: calc(var(--text-01) * 2  * 1.5);
+}
+</style>
+
+<div class=summary-percentiles>
+    {#if active}
+      <div class='summary-percentile--full'>
+        {label}
+      </div>
+      <div class='summary-percentile--full' style="border-bottom: 1px solid var(--cool-gray-300)">
+          <span style="text-align: right;font-family: var(--main-mono-font); color: var(--cool-gray-500); font-weight: bold" >
+              {buildID.slice(0, 4)}-{buildID.slice(4,
+              6)}-{buildID.slice(6, 8)}{' '}</span> 
+            <span> {buildID.slice(8, 10)}:</span>
+            <span>{buildID.slice(10, 12)}:</span>
+            <span>{buildID.slice(12, 14)}</span>
+      </div>
+      <div class=summary-percentile--bin>
+          # profiles
+        </div>
+        <div class=summary-percentile--value>
+          {datum.audienceSize}
+        </div>
+      {#each percentiles as percentile, i (percentile)}
+        <div class=summary-percentile--bin>
+            {percentile}th %
+          </div>
+          <div class=summary-percentile--value>
+            <div>
+              {datum.percentiles.find((p) => p.bin === percentile).value}
+            </div>
+            <div>
+                {datum.percentiles.find((p) => p.bin === percentile).value}
+              </div>
+          </div>
+      {/each}
+    {/if}
+  </div>

--- a/src/components/data-graphics/ComparisonMultiple.svelte
+++ b/src/components/data-graphics/ComparisonMultiple.svelte
@@ -31,7 +31,7 @@ export let percentiles;
   justify-self: stretch;
   text-align: right;
   width: 100%;
-  height: calc(var(--text-01) * 2  * 1.5);
+  /* height: calc(var(--text-01) * 2  * 1.5); */
 }
 </style>
 
@@ -62,9 +62,6 @@ export let percentiles;
             <div>
               {datum.percentiles.find((p) => p.bin === percentile).value}
             </div>
-            <div>
-                {datum.percentiles.find((p) => p.bin === percentile).value}
-              </div>
           </div>
       {/each}
     {/if}

--- a/src/components/data-graphics/ComparisonSummary.svelte
+++ b/src/components/data-graphics/ComparisonSummary.svelte
@@ -1,0 +1,68 @@
+<script>
+import ComparisonMultiple from './ComparisonMultiple.svelte';
+
+export let left;
+export let right;
+export let percentiles;
+export let compareTo = 'left-right';
+console.log(left, right, percentiles);
+</script>
+
+<style>
+
+.summary {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-column-gap: var(--space-base);
+  width: var(--space-40x);
+}
+
+
+</style>
+<!-- 
+<div class=summary>
+    {#each [[left, 'hovered'], [right, 'latest']] as [focus, label], i}
+      <div class=summary-percentiles>
+        {#if focus}
+          <div class='summary-percentile--full'>
+            {label}
+          </div>
+          <div class='summary-percentile--full' style="border-bottom: 1px solid var(--cool-gray-300)">
+              <span style="text-align: right;font-family: var(--main-mono-font); color: var(--cool-gray-500); font-weight: bold" >
+                  {focus.label.slice(0, 4)}-{focus.label.slice(4,
+                  6)}-{focus.label.slice(6, 8)}{' '}</span> 
+                <span> {focus.label.slice(8, 10)}:</span>
+                <span>{focus.label.slice(10, 12)}:</span>
+                <span>{focus.label.slice(12, 14)}</span>
+          </div>
+          <div class=summary-percentile--bin>
+              # profiles
+            </div>
+            <div class=summary-percentile--value>
+              {focus.audienceSize}
+            </div>
+          {#each percentiles as percentile, i (percentile)}
+            <div class=summary-percentile--bin>
+                {percentile}th %
+              </div>
+              <div class=summary-percentile--value>
+                <div>
+                  {focus.percentiles.find((p) => p.bin === percentile).value}
+                </div>
+                <div>
+                    {focus.percentiles.find((p) => p.bin === percentile).value}
+                  </div>
+              </div>
+          {/each}
+        {/if}
+      </div>
+    {/each}
+  </div> -->
+
+
+<div class=summary>
+  <ComparisonMultiple label="hovered" buildID={left ? left.label : ' '} datum={left}
+  percentiles={percentiles} active={left !== undefined} />
+  <ComparisonMultiple label="latest" buildID={right.label} datum={right}
+  percentiles={percentiles} active={true} />
+  </div>

--- a/src/components/data-graphics/ComparisonSummary.svelte
+++ b/src/components/data-graphics/ComparisonSummary.svelte
@@ -11,12 +11,43 @@ console.log(left, right, percentiles);
 <style>
 
 .summary {
-  display: grid;
+  /* display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-column-gap: var(--space-base);
-  width: var(--space-40x);
+  grid-column-gap: var(--space-base); */
 }
 
+table {
+  font-size: var(--text-02);
+}
+
+th {
+  line-height: 1;
+}
+
+td, th {
+  min-width: var(--space-8x);
+  text-align: right;
+}
+/* 
+.label {
+  font-size: 12px;
+} */
+
+.summary-label {
+  font-size: 12px;
+}
+
+.summary-label--main-date {
+  text-align: right;
+  font-family: var(--main-mono-font); 
+  color: var(--cool-gray-500); 
+  font-weight: bold;
+}
+
+
+/* .value-label, .value-left, .value-right {
+  text-align: right;
+} */
 
 </style>
 <!-- 
@@ -61,8 +92,52 @@ console.log(left, right, percentiles);
 
 
 <div class=summary>
-  <ComparisonMultiple label="hovered" buildID={left ? left.label : ' '} datum={left}
+
+  <table>
+    <thead>
+      <tr>
+        <th>Metric</th>
+        <th class=summary-label>
+            {#if left}
+            Hovered
+            <!-- <div class="summary-label--main-date" >
+                {left.label.slice(0, 4)}-{left.label.slice(4,
+                6)}-{left.label.slice(6, 8)}{' '}</div> 
+              {left.label.slice(8, 10)}:... -->
+              <!-- {left.label.slice(10, 12)}:{left.label.slice(12, 14)} -->
+            {:else}
+              <div></div>
+            {/if}
+        </th>
+        <th class=summary-label>
+            Latest Build
+            <!-- <div class="summary-label--main-date" >
+                {right.label.slice(0, 4)}-{right.label.slice(4,
+                6)}-{right.label.slice(6, 8)}{' '}</div> 
+              {right.label.slice(8, 10)}:{right.label.slice(10, 12)}:{right.label.slice(12, 14)} -->
+          </th>
+      </tr>
+    </thead>
+    <tbody>
+          <tr>
+            <td class=value-label># clients</td>
+            <td class=value-left>{left ? left.audienceSize : ' '}</td>
+            <td class=value-right>{right ? right.audienceSize : ' '}</td>
+          </tr>
+          {#each percentiles as percentile}
+            <tr>
+              <td class=value-label>{percentile}%</td>
+              <td class=value-left>{left ? left.percentiles.find((p) => p.bin
+              === percentile).value : ' '}</td>
+              <td class=value-right>{right ? right.percentiles.find((p) => p.bin
+                  === percentile).value : ' '}</td>
+            </tr>
+          {/each}
+    </tbody>
+  </table>
+
+  <!-- <ComparisonMultiple label="hovered" buildID={left ? left.label : ' '} datum={left}
   percentiles={percentiles} active={left !== undefined} />
   <ComparisonMultiple label="latest" buildID={right.label} datum={right}
-  percentiles={percentiles} active={true} />
-  </div>
+  percentiles={percentiles} active={true} /> -->
+</div>

--- a/src/components/data-graphics/ComparisonSummary.svelte
+++ b/src/components/data-graphics/ComparisonSummary.svelte
@@ -5,16 +5,10 @@ export let left;
 export let right;
 export let percentiles;
 export let compareTo = 'left-right';
-console.log(left, right, percentiles);
+
 </script>
 
 <style>
-
-.summary {
-  /* display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-column-gap: var(--space-base); */
-}
 
 table {
   font-size: var(--text-02);

--- a/src/components/data-graphics/ComparisonSummary.svelte
+++ b/src/components/data-graphics/ComparisonSummary.svelte
@@ -1,5 +1,4 @@
 <script>
-import ComparisonMultiple from './ComparisonMultiple.svelte';
 
 export let left;
 export let right;
@@ -44,46 +43,6 @@ td, th {
 } */
 
 </style>
-<!-- 
-<div class=summary>
-    {#each [[left, 'hovered'], [right, 'latest']] as [focus, label], i}
-      <div class=summary-percentiles>
-        {#if focus}
-          <div class='summary-percentile--full'>
-            {label}
-          </div>
-          <div class='summary-percentile--full' style="border-bottom: 1px solid var(--cool-gray-300)">
-              <span style="text-align: right;font-family: var(--main-mono-font); color: var(--cool-gray-500); font-weight: bold" >
-                  {focus.label.slice(0, 4)}-{focus.label.slice(4,
-                  6)}-{focus.label.slice(6, 8)}{' '}</span> 
-                <span> {focus.label.slice(8, 10)}:</span>
-                <span>{focus.label.slice(10, 12)}:</span>
-                <span>{focus.label.slice(12, 14)}</span>
-          </div>
-          <div class=summary-percentile--bin>
-              # profiles
-            </div>
-            <div class=summary-percentile--value>
-              {focus.audienceSize}
-            </div>
-          {#each percentiles as percentile, i (percentile)}
-            <div class=summary-percentile--bin>
-                {percentile}th %
-              </div>
-              <div class=summary-percentile--value>
-                <div>
-                  {focus.percentiles.find((p) => p.bin === percentile).value}
-                </div>
-                <div>
-                    {focus.percentiles.find((p) => p.bin === percentile).value}
-                  </div>
-              </div>
-          {/each}
-        {/if}
-      </div>
-    {/each}
-  </div> -->
-
 
 <div class=summary>
 

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -60,6 +60,8 @@ export let rightPlot = derived(graphicWidth, ($width) => $width - margins.right)
 export let topPlot = derived(graphicHeight, () => margins.top);
 export let bottomPlot = derived(graphicHeight, ($height) => $height - margins.bottom);
 
+setContext('graphicWidth', graphicWidth);
+setContext('graphicHeight', graphicHeight);
 setContext('bodyWidth', bodyWidth);
 setContext('bodyHeight', bodyHeight);
 

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -5,7 +5,7 @@ import { scalePoint, scaleLinear } from 'd3-scale';
 
 export let data = getContext('data');
 export let svg;
-
+export let key;
 export let xDomain;
 export let yDomain;
 export let xType = 'scalePoint';
@@ -35,6 +35,8 @@ const DEFAULTS = {
 setContext('defaults', DEFAULTS);
 setContext('margins', margins);
 
+setContext('key', key);
+
 export let dataGraphic = writable({});
 
 export let width = getContext('width') || 800;
@@ -48,7 +50,8 @@ export let graphicHeight = writable(height);
 $: $graphicHeight = height;
 
 let bodyWidth = derived(graphicWidth, ($width) => $width - margins.left - margins.right);
-export let bodyHeight = derived(graphicHeight, ($height) => $height - margins.top - margins.bottom);
+let bodyHeight = derived(graphicHeight, ($height) => $height - margins.top - margins.bottom);
+
 
 // set the locations of the plot bounds
 export let leftPlot = derived(graphicWidth, () => margins.left);
@@ -174,8 +177,17 @@ $: if (dataGraphicMounted) initiateRollovers(svg);
     on:mousemove={onMousemove}
     on:mouseleave={onMouseleave}
   >
+  <clipPath id='graphic-body-{key}'>
+      <rect
+        x={$leftPlot}
+        y={$topPlot}
+        width={$bodyWidth}
+        height={$bodyHeight}
+      />
+    </clipPath>
     {#if dataGraphicMounted}
       <slot></slot>
     {/if}
+    <use clip-path="url(#graphic-body-{key})" xlink:href="#graphic-body-content={key}" fill="transparent" />
   </svg>
 </div>

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -18,8 +18,8 @@ export let yType = 'scalePoint';
 
 export let margins = {
   left: 50,
-  right: 50,
-  top: 50,
+  right: 16,
+  top: 20,
   bottom: 20,
   laneGap: 30,
   buffer: 5,

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -49,8 +49,8 @@ $: $graphicWidth = width;
 export let graphicHeight = writable(height);
 $: $graphicHeight = height;
 
-let bodyWidth = derived(graphicWidth, ($width) => $width - margins.left - margins.right);
-let bodyHeight = derived(graphicHeight, ($height) => $height - margins.top - margins.bottom);
+export let bodyWidth = derived(graphicWidth, ($width) => $width - margins.left - margins.right);
+export let bodyHeight = derived(graphicHeight, ($height) => $height - margins.top - margins.bottom);
 
 
 // set the locations of the plot bounds
@@ -126,10 +126,16 @@ function createMouseStore(parentSVG) {
         const xCandidates = xScale.domain()
           .filter((d) => (xScale(d) - step / 2) < actualX && xScale(d) < $rightPlot);
         x = xCandidates[xCandidates.length - 1];
+      } else {
+        x = xScale.invert(actualX);
       }
       if (yScale.type === 'scalePoint') {
         const yCandidates = yScale.domain().filter((d) => yScale(d) < actualY);
         [y] = yCandidates;
+      } else {
+        // here, we need to inform a y for scaleLinear.
+        // but this shoudl be easy. just reverse the value and return it as y.
+        y = yScale.invert(actualY);
       }
       set({
         x, y, px: actualX, py: actualY,

--- a/src/components/data-graphics/GraphicBody.svelte
+++ b/src/components/data-graphics/GraphicBody.svelte
@@ -1,0 +1,9 @@
+<script>
+import { getContext } from 'svelte';
+
+const key = getContext('key');
+</script>
+
+<g id='graphic-body-content-{key}' style="clip-path: url(#graphic-body-{key})">
+  <slot></slot>
+</g>

--- a/src/components/data-graphics/Heatmap.svelte
+++ b/src/components/data-graphics/Heatmap.svelte
@@ -29,12 +29,20 @@ const scale = scaleFunction()
 </script>
 <g transition:fade={{ duration: 200, easing: easeOut }}>
   {#each data as datum, i}
-    <rect 
+    <!-- <rect 
       fill={interpolateRdPu(scale(datum[heatAccessor]))}
       x={xScale(datum[xAccessor]) - xScale.step() / 2}
       y={yScale(datum[yAccessor])}
       width={xScale.step()}
       height={yScale.step()}
-    />
+    /> -->
+
+    <rect 
+    fill={interpolateRdPu(scale(datum[heatAccessor]))}
+    x={xScale(datum[xAccessor])}
+    y={yScale(datum[yAccessor])}
+    width={5}
+    height={5}
+  />
   {/each}
 </g>

--- a/src/components/data-graphics/LineMultiple.svelte
+++ b/src/components/data-graphics/LineMultiple.svelte
@@ -29,6 +29,6 @@ const lineGenerator = SHAPE.line()
     stroke-width={strokeWidth}
     fill=none 
     in:draw={lineDrawAnimation}
-    out:fade={{ duration: lineDrawAnimation.duration / 8 }}
+    out:fade={{ duration: 50 }}
     d={lineGenerator(data)} />
 </g>

--- a/src/components/data-graphics/LineMultiple.svelte
+++ b/src/components/data-graphics/LineMultiple.svelte
@@ -1,6 +1,6 @@
 <script>
 import { getContext } from 'svelte';
-import { draw } from 'svelte/transition';
+import { draw, fade } from 'svelte/transition';
 import * as SHAPE from 'd3-shape';
 
 
@@ -28,6 +28,7 @@ const lineGenerator = SHAPE.line()
     stroke={color} 
     stroke-width={strokeWidth}
     fill=none 
-    in:draw={lineDrawAnimation} 
+    in:draw={lineDrawAnimation}
+    out:fade={{ duration: lineDrawAnimation.duration / 8 }}
     d={lineGenerator(data)} />
 </g>

--- a/src/components/data-graphics/LinePlot.svelte
+++ b/src/components/data-graphics/LinePlot.svelte
@@ -17,6 +17,8 @@ import {
   buildIDToMonth,
 } from './utils/build-id-utils';
 
+import { telemetryHistogramToHeatmap } from './utils/histograms';
+
 export let data;
 
 
@@ -119,27 +121,7 @@ $: if (dataGraphicMounted) {
     btValue = bp;
   });
 }
-const telemetryHistogramToHeatmap = (dataset, normalize = false) => {
-  let out = [];
-  dataset.forEach((h) => {
-    const x = h.label;
-    let hists = h.histogram.map((hi) => ({ ...hi })).filter((hi) => hi.value > 0.0);
-    if (normalize) {
-      const heats = hists.map((hi) => hi.value);
-      const maxHeat = Math.max(...heats, 1);
-      const minHeat = Math.min(...heats, 0);
-      hists.forEach((hi) => {
-        hi.value = (hi.value - minHeat) / (maxHeat - minHeat); // eslint-disable-line
-      });
-    }
-    hists.forEach(({ bin, value }) => {
-      out.push({
-        x, y: bin, heat: value,
-      });
-    });
-  });
-  return out;
-};
+
 
 let last = Infinity;
 let xDomain = data.map((d) => d.label);

--- a/src/components/data-graphics/SimpleAxis.svelte
+++ b/src/components/data-graphics/SimpleAxis.svelte
@@ -77,23 +77,8 @@ let secondaryDim = (side === 'left' || side === 'right') ? 'y' : 'x';
 // for left / right, we need additional buffer. for top / bottom, we need to move down tickFontSize.
 let fontSizeCorrector = (side === 'bottom') ? tickFontSize : margins.buffer;
 
-let tickParams = (t) => {
-  const out = {};
-  out[`${mainDim}1`] = $bodyDimension + tickDirection * margins.buffer;
-  out[`${mainDim}2`] = lineStyle === 'long' ? $obverseDimension : $bodyDimension;
-  out[`${secondaryDim}1`] = mainScale(t);
-  out[`${secondaryDim}2`] = mainScale(t);
-  return out;
-};
-
-let borderParams = () => {
-  const out = {};
-  out[`${secondaryDim}1`] = mainScale.range()[0]; // eslint-disable-line
-  out[`${secondaryDim}2`] = mainScale.range()[1]; // eslint-disable-line
-  out[`${mainDim}1`] = $bodyDimension;
-  out[`${mainDim}2`] = $bodyDimension;
-  return out;
-};
+let tickEnd;
+$: tickEnd = lineStyle === 'long' ? $obverseDimension : $bodyDimension;
 
 let textParams = (t) => {
   const out = {};
@@ -112,20 +97,34 @@ let textParams = (t) => {
       {#if showTicks}
         <line
           class=tick
-          {...tickParams(tick)}
+          {...{
+            [`${mainDim}1`]: $bodyDimension + tickDirection * margins.buffer,
+            [`${mainDim}2`]: tickEnd,
+            [`${secondaryDim}1`]: mainScale(tick),
+            [`${secondaryDim}2`]: mainScale(tick),
+          }}
           stroke='var(--line-gray-01)'
           stroke-width=1
         />
       {/if}
       {#if showBorder}
         <line 
-          {...borderParams()}           
+          {...{
+            [`${secondaryDim}1`]: mainScale.range()[0],
+            [`${secondaryDim}2`]: mainScale.range()[1],
+            [`${mainDim}1`]: $bodyDimension,
+            [`${mainDim}2`]: $bodyDimension,
+          }}           
           stroke='var(--line-gray-01)'
           stroke-width=1 />
       {/if}
       {#if showLabels}
         <text 
-          {...textParams(tick)}
+          {...{
+            [`${mainDim}`]: $bodyDimension + tickDirection * margins.buffer + tickDirection * fontSizeCorrector,
+            [`${secondaryDim}`]: mainScale(tick),
+            dy: secondaryDim === 'y' ? '.35em' : undefined,
+          }}
           text-anchor={textAnchor}
           font-size={tickFontSize}
         >{tickFormatter(tick)}</text>

--- a/src/components/data-graphics/rollovers/BuildIDRollover.svelte
+++ b/src/components/data-graphics/rollovers/BuildIDRollover.svelte
@@ -1,0 +1,48 @@
+<script>
+import { getContext, onMount } from 'svelte';
+
+export let xScale = getContext('xScale');
+let margins = getContext('margins');
+let TOP = getContext('topPlot');
+let G = getContext('graphicWidth');
+let topPlot;
+let graphicWidth;
+TOP.subscribe((t) => { topPlot = t; });
+G.subscribe((w) => { graphicWidth = w; });
+export let x;
+export let label;
+
+let rollover;
+
+// xCorrection applies when the left or right side
+// of the
+let leftCorrection;
+let rightCorrection;
+let mounted = false;
+onMount(() => {
+  mounted = true;
+});
+
+$: if (x && mounted) {
+  let bounds = rollover.getBoundingClientRect();
+  let w = bounds.width;
+  leftCorrection = w / 2;
+  rightCorrection = graphicWidth - w / 2;
+}
+
+</script>
+
+<text
+bind:this={rollover}
+x={Math.min(Math.max(xScale(x), leftCorrection), rightCorrection)} 
+y={topPlot - margins.buffer}
+text-anchor='middle'
+font-family="var(--main-mono-font)"
+font-size='12'>
+<tspan fill="var(--cool-gray-500)" font-weight=bold>
+  {label.slice(0, 4)}-{label.slice(4,
+  6)}-{label.slice(6, 8)}{' '}</tspan> 
+<tspan> {label.slice(8, 10)}:</tspan>
+<tspan>{label.slice(10, 12)}:</tspan>
+<tspan>{label.slice(12, 14)}</tspan>
+</text>

--- a/src/components/data-graphics/utils/build-id-utils.js
+++ b/src/components/data-graphics/utils/build-id-utils.js
@@ -1,12 +1,13 @@
-import { scalePoint } from 'd3-scale';
 import { timeFormat, timeParse } from 'd3-time-format';
 
 const dtFormatter = timeFormat('%Y%m%d');
 const dtParser = timeParse('%Y%m%d');
 const parse = (build) => dtParser(build.slice(0, 8));
+
 const toBuildObj = (build) => ({ build, truncated: build.slice(0, 8), dt: parse(build) });
+
 export function buildIDToDate(buildID) {
-  return dtParser(buildID);
+  return parse(buildID);
 }
 
 export function dateToBuildID(scale, dt) {

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -1,10 +1,13 @@
 import { storiesOf } from '@storybook/svelte';
 import Buttons from './Buttons.svelte';
-
+import ButtonGroupStory from './ButtonGroupStory.svelte';
 import '../public/global.css';
 import './glean-design-stories.css';
 
 storiesOf('UX Components|Buttons', module)
   .add('Buttons', () => ({
     Component: Buttons,
+  }))
+  .add('Button Groups', () => ({
+    Component: ButtonGroupStory,
   }));

--- a/stories/ButtonGroupStory.svelte
+++ b/stories/ButtonGroupStory.svelte
@@ -1,0 +1,57 @@
+<script>
+import Button from '../src/components/Button.svelte';
+import ButtonGroup from '../src/components/ButtonGroup.svelte';
+
+let first = 0;
+
+function setFirst(v) { first = v; }
+
+let second = [];
+function setSecond(v) {
+  if (second.includes(v)) second = [...second.filter((vi) => vi !== v)];
+  else {
+    second = [...second, v];
+  }
+}
+
+</script>
+
+<style>
+div.section {
+  margin-bottom: var(--space-base);
+}
+</style>
+
+<div class=story>
+
+  <div class=section>
+    <ButtonGroup>
+      <Button toggled={first === 0} on:click={() => { setFirst(0); }}>First</Button>
+      <Button toggled={first === 1} on:click={() => { setFirst(1); }}>Second</Button>
+      <Button toggled={first === 2} on:click={() => { setFirst(2); }}>Third</Button>
+    </ButtonGroup>
+  </div>
+
+  <div class=section>
+    <h2>Each One Toggle-able</h2>
+    <ButtonGroup>
+      <Button toggled={second.includes(0)} on:click={() => { setSecond(0); }} compact>First</Button>
+      <Button toggled={second.includes(1)} on:click={() => { setSecond(1); }} compact>Second</Button>
+      <Button toggled={second.includes(2)} on:click={() => { setSecond(2); }} compact>Third</Button>
+    </ButtonGroup>
+  </div>
+  <div class=section>
+      <ButtonGroup>
+        <Button toggled={second.includes(1)} on:click={() => { setSecond(1); }}  compact level=medium>Second</Button>
+        <Button toggled={second.includes(2)} on:click={() => { setSecond(2); }}  compact level=medium>Third</Button>
+        <Button toggled={second.includes(0)} on:click={() => { setSecond(0); }}  compact level=medium>First</Button>
+      </ButtonGroup>
+    </div>
+    <div class=section>
+        <ButtonGroup>
+          <Button toggled={second.includes(2)} on:click={() => { setSecond(2); }} compact level=low>Third</Button>
+          <Button toggled={second.includes(0)} on:click={() => { setSecond(0); }} compact level=low>First</Button>
+          <Button toggled={second.includes(1)} on:click={() => { setSecond(1); }} compact level=low>Second</Button>
+        </ButtonGroup>
+      </div>
+</div>

--- a/stories/data-graphics/basics/SimpleAxisStory.svelte
+++ b/stories/data-graphics/basics/SimpleAxisStory.svelte
@@ -101,9 +101,6 @@ td input {
       {/each}
     </tr>
   {/each}
-  <!-- <div><input type=checkbox bind:checked={right}>Right Axis</div>
-  <div><input type=checkbox bind:checked={top}>Top Axis</div>
-  <div><input type=checkbox bind:checked={bottom}>Bottom Axis</div> -->
   </tbody>
 </table>
 
@@ -121,14 +118,14 @@ height=250
       showLabels={sides.left.labels}
       showTicks={sides.left.ticks}
       showBorder={sides.left.border}
-      style={sides.left.long ? 'long' : 'short'} />
+      lineStyle={sides.left.long ? 'long' : 'short'} />
   {/if}
   {#if sides.right.all}
     <RightAxis
       showLabels={sides.right.labels}
       showTicks={sides.right.ticks}
       showBorder={sides.right.border}
-      style={sides.right.long ? 'long' : 'short'}
+      lineStyle={sides.right.long ? 'long' : 'short'}
     />
   {/if}
   {#if sides.bottom.all}
@@ -138,7 +135,7 @@ height=250
       showLabels={sides.bottom.labels}
       showTicks={sides.bottom.ticks}
       showBorder={sides.bottom.border}
-      style={sides.bottom.long ? 'long' : 'short'}
+      lineStyle={sides.bottom.long ? 'long' : 'short'}
     />
   {/if}
   {#if sides.top.all}

--- a/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
+++ b/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
@@ -15,20 +15,32 @@ const aggs = Object
 
 // //////////////////////////////////////////////////////////////////////////////
 
-import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
-import BottomAxis from '../../../src/components/data-graphics/BottomAxis.svelte';
-import LeftAxis from '../../../src/components/data-graphics/LeftAxis.svelte';
-import Line from '../../../src/components/data-graphics/LineMultiple.svelte';
-import { firstOfMonth, buildIDToMonth } from '../../../src/components/data-graphics/utils/build-id-utils';
+// import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
+// import BottomAxis from '../../../src/components/data-graphics/BottomAxis.svelte';
+// import LeftAxis from '../../../src/components/data-graphics/LeftAxis.svelte';
+// import Line from '../../../src/components/data-graphics/LineMultiple.svelte';
+// import { firstOfMonth, buildIDToMonth } from '../../../src/components/data-graphics/utils/build-id-utils';
+
+// let domain = aggs[0][1].map((d) => d.label);
+// function setDomain(str) {
+//   if (str === 'WEEK') domain = aggs[0][1].slice(aggs[0][1].length - 7).map((d) => d.label);
+//   if (str === 'MONTH') domain = aggs[0][1].slice(aggs[0][1].length - 30).map((d) => d.label);
+//   if (str === 'ALL_TIME') domain = aggs[0][1].map((d) => d.label);
+//   console.log(domain);
+}
 </script>
 
 <div class=story>
+
+<button on:click={() => { setDomain('WEEK'); }}>last week</button>
+<button on:click={() => { setDomain('MONTH'); }}>last month</button>
+<button on:click={() => { setDomain('ALL_TIME'); }}>all time</button>
 
 {#each aggs as [aggType, dataset], i (aggType)}
   <h4>{aggType}</h4>
   <DataGraphic
     data={dataset}
-    xDomain={dataset.map((d) => d.label)}
+    xDomain={domain}
     yDomain={[0, 1000]}
     yType="numeric"
     width=600

--- a/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
+++ b/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
@@ -46,6 +46,8 @@ function togglePercentile(p) {
   else {
     percentiles = [...percentiles, p];
   }
+  percentiles.sort();
+  percentiles.reverse();
 }
 
 </script>

--- a/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
+++ b/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
@@ -25,6 +25,7 @@ const aggs = Object
 // //////////////////////////////////////////////////////////////////////////////
 
 import ScalarAggregationMultiple from './ScalarAggregationMultiple.svelte';
+import ButtonGroup from '../../../src/components/ButtonGroup.svelte';
 import Button from '../../../src/components/Button.svelte';
 
 
@@ -64,22 +65,27 @@ function togglePercentile(p) {
     grid-auto-flow: column;
     grid-column-gap: var(--space-base);
     width: max-content;
+    margin-bottom: var(--space-base);
   }
 </style>
 
 <div class=story>
 
 <div class=time-horizon>
-  <Button compact level=medium on:click={() => { setDomain('WEEK'); }}>last week</Button>
-  <Button compact level=medium on:click={() => { setDomain('MONTH'); }}>last month</Button>
-  <Button compact level=medium on:click={() => { setDomain('ALL_TIME'); }}>all time</Button>
+  <ButtonGroup>
+    <Button toggled={D === 'WEEK'} compact level=medium on:click={() => { setDomain('WEEK'); }}>last week</Button>
+    <Button toggled={D === 'MONTH'} compact level=medium on:click={() => { setDomain('MONTH'); }}>last month</Button>
+    <Button toggled={D === 'ALL_TIME'} compact level=medium on:click={() => { setDomain('ALL_TIME'); }}>all
+    time</Button>
+  </ButtonGroup>
 </div>
 
 <div class=time-horizon>
+  <ButtonGroup>
   {#each [5, 25, 50, 75, 95] as p, i (p)}
-    <Button compact level=low on:click={() => { togglePercentile(p); }}>{p}%
-    {percentiles.includes(p) ? 'on' : 'off'}</Button>
+    <Button toggled={percentiles.includes(p)} compact level=low on:click={() => { togglePercentile(p); }}>{p}%</Button>
   {/each}
+  </ButtonGroup>
 </div>
 
 {#each aggs as [aggType, dataset], i (aggType + D)}

--- a/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
+++ b/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
@@ -11,36 +11,70 @@ const aggs = Object
     aggType,
     makeDataset(payload, 'build_id'),
     payload,
-  ]);
+  ]).map(([aggType, dataset, payload]) => {
+    const newData = dataset.map((d) => {
+      let { percentiles } = d;
+      if (d.audienceSize < 3) {
+        percentiles = percentiles.map((p) => ({ ...p, value: 0 }));
+      }
+      return { ...d, percentiles };
+    });
+    return [aggType, newData, payload];
+  });
 
 // //////////////////////////////////////////////////////////////////////////////
 
-// import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
-// import BottomAxis from '../../../src/components/data-graphics/BottomAxis.svelte';
-// import LeftAxis from '../../../src/components/data-graphics/LeftAxis.svelte';
-// import Line from '../../../src/components/data-graphics/LineMultiple.svelte';
-// import { firstOfMonth, buildIDToMonth } from '../../../src/components/data-graphics/utils/build-id-utils';
+import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
+import GraphicBody from '../../../src/components/data-graphics/GraphicBody.svelte';
+import BottomAxis from '../../../src/components/data-graphics/BottomAxis.svelte';
+import LeftAxis from '../../../src/components/data-graphics/LeftAxis.svelte';
+import Line from '../../../src/components/data-graphics/LineMultiple.svelte';
+import Button from '../../../src/components/Button.svelte';
+import { firstOfMonth, buildIDToMonth } from '../../../src/components/data-graphics/utils/build-id-utils';
 
-// let domain = aggs[0][1].map((d) => d.label);
-// function setDomain(str) {
-//   if (str === 'WEEK') domain = aggs[0][1].slice(aggs[0][1].length - 7).map((d) => d.label);
-//   if (str === 'MONTH') domain = aggs[0][1].slice(aggs[0][1].length - 30).map((d) => d.label);
-//   if (str === 'ALL_TIME') domain = aggs[0][1].map((d) => d.label);
-//   console.log(domain);
+let domain = aggs[0][1].map((d) => d.label);
+function setDomain(str) {
+  if (str === 'WEEK') domain = aggs[0][1].slice(aggs[0][1].length - 7).map((d) => d.label);
+  if (str === 'MONTH') domain = aggs[0][1].slice(aggs[0][1].length - 30).map((d) => d.label);
+  if (str === 'ALL_TIME') domain = aggs[0][1].map((d) => d.label);
 }
+
+let readableAggs = {
+  avg: 'Average',
+  min: 'Smallest Value (per client)',
+  max: 'Largest Value (per client)',
+  sum: 'Sum (per client)',
+};
+
 </script>
+
+<style>
+  h4 {
+    margin-left: 50px;
+  }
+
+  .time-horizon {
+    display: grid;
+    grid-auto-flow: column;
+    grid-column-gap: var(--space-base);
+    width: max-content;
+  }
+</style>
 
 <div class=story>
 
-<button on:click={() => { setDomain('WEEK'); }}>last week</button>
-<button on:click={() => { setDomain('MONTH'); }}>last month</button>
-<button on:click={() => { setDomain('ALL_TIME'); }}>all time</button>
-
+<div class=time-horizon>
+  <!-- FIXME: this don't work. -->
+  <Button compact level=medium on:click={() => { setDomain('WEEK'); }}>last week</Button>
+  <Button compact level=medium on:click={() => { setDomain('MONTH'); }}>last month</Button>
+  <Button compact level=medium on:click={() => { setDomain('ALL_TIME'); }}>all time</Button>
+</div>
 {#each aggs as [aggType, dataset], i (aggType)}
-  <h4>{aggType}</h4>
+  <h4>{readableAggs[aggType]}</h4>
   <DataGraphic
-    data={dataset}
-    xDomain={domain}
+    key={aggType}
+    data={dataset.slice(dataset.length - 10)}
+    xDomain={dataset.slice(dataset.length - 10).map((d) => d.label)}
     yDomain={[0, 1000]}
     yType="numeric"
     width=600
@@ -48,17 +82,19 @@ const aggs = Object
   >
     <LeftAxis />
     <BottomAxis ticks={firstOfMonth} tickFormatter={buildIDToMonth} />
-    <!-- <TopAxis ticks={firstOfMonth} tickFormatter={buildIDToMonth} />
-    <RightAxis /> -->
-    {#each extractPercentiles([50], dataset) as percentile, i}
-      <Line
-      curve="curveStep"
-      lineDrawAnimation={{ duration: 400, delay: ((i + 1) % 2 === 0) * 400 }} 
-      xAccessor="label"
-      yAccessor="originalPercentileValue"
-      color={i === 2 ? 'var(--digital-blue-500)' : 'var(--digital-blue-400)'}
-      data={percentile} />
-    {/each}
+      <GraphicBody>
+      {#each extractPercentiles([50], dataset.slice(dataset.length - 10)) as
+      percentile, i (percentile)}
+        <Line
+        curve="curveStep"
+        lineDrawAnimation={{ duration: 400, delay: ((i + 1) % 2 === 0) * 400 }} 
+        xAccessor="label"
+        yAccessor="originalPercentileValue"
+        color={i === 2 ? 'var(--digital-blue-500)' : 'var(--digital-blue-400)'}
+        data={percentile} />
+      {/each}
+    </GraphicBody>
+
   </DataGraphic>
 {/each}
 

--- a/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
+++ b/stories/data-graphics/distribution-plots/ScalarAggregation.svelte
@@ -32,6 +32,7 @@ import BottomAxis from '../../../src/components/data-graphics/BottomAxis.svelte'
 import LeftAxis from '../../../src/components/data-graphics/LeftAxis.svelte';
 import Line from '../../../src/components/data-graphics/LineMultiple.svelte';
 import Button from '../../../src/components/Button.svelte';
+
 import { firstOfMonth, buildIDToMonth } from '../../../src/components/data-graphics/utils/build-id-utils';
 
 let D = 'WEEK';
@@ -55,7 +56,9 @@ let readableAggs = {
 
 <style>
   h4 {
+    margin:0;
     margin-left: 50px;
+    margin-top:50px;
   }
 
   .time-horizon {
@@ -77,6 +80,8 @@ let readableAggs = {
 {#if $domain}
 {#each aggs as [aggType, dataset], i (aggType + D)}
   <h4>{readableAggs[aggType]}</h4>
+
+<div class=graphic-and-summary>
   <DataGraphic
     key={aggType + D}
     data={dataset}
@@ -86,6 +91,8 @@ let readableAggs = {
     width=600
     height=150
   >
+      <!-- <Heatmap data={telemetryHistogramToHeatmap(dataset)} scaleType='log'
+      heatRange={[0.1, 0.7]} /> -->
     <LeftAxis />
     <BottomAxis ticks={firstOfMonth} tickFormatter={buildIDToMonth} />
       <GraphicBody>
@@ -102,6 +109,7 @@ let readableAggs = {
     </GraphicBody>
 
   </DataGraphic>
+</div>
 {/each}
 {/if}
 </div>

--- a/stories/data-graphics/distribution-plots/ScalarAggregationMultiple.svelte
+++ b/stories/data-graphics/distribution-plots/ScalarAggregationMultiple.svelte
@@ -1,0 +1,61 @@
+<script>
+import { writable } from 'svelte/store';
+
+export let data;
+export let key;
+export let resolution = 'ALL_TIME';
+export let percentiles = [50];
+
+import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
+import GraphicBody from '../../../src/components/data-graphics/GraphicBody.svelte';
+import BottomAxis from '../../../src/components/data-graphics/BottomAxis.svelte';
+import LeftAxis from '../../../src/components/data-graphics/LeftAxis.svelte';
+import Line from '../../../src/components/data-graphics/LineMultiple.svelte';
+
+import { firstOfMonth, buildIDToMonth } from '../../../src/components/data-graphics/utils/build-id-utils';
+import { extractPercentiles } from '../../../src/components/data-graphics/utils/percentiles';
+
+let domain = writable(data.map((d) => d.label));
+
+function setDomain(str) {
+  if (str === 'WEEK') domain.set(data.slice(data.length - 7).map((d) => d.label));
+  if (str === 'MONTH') domain.set(data.slice(data.length - 30).map((d) => d.label));
+  if (str === 'ALL_TIME') domain.set(data.map((d) => d.label));
+}
+
+$: setDomain(resolution);
+let percentileData = [];
+
+$: percentileData = extractPercentiles(percentiles, data.filter((d) => $domain.includes(d.label)))
+  .map((ps, i) => [ps, percentiles[i]]);
+
+</script>
+
+<div class=graphic-and-summary>
+  <DataGraphic
+    key={key}
+    data={data}
+    xDomain={$domain}
+    yDomain={[0, 1000]}
+    yType="numeric"
+    width=600
+    height=150
+  >
+    <LeftAxis />
+    <BottomAxis ticks={firstOfMonth} tickFormatter={buildIDToMonth} />
+
+    <GraphicBody>
+      {#each percentileData as
+        [percentile, pi], i (pi)}
+          <Line
+          curve="curveStep"
+          lineDrawAnimation={{ duration: 300 }} 
+          xAccessor="label"
+          yAccessor="originalPercentileValue"
+          color={pi === 50 ? 'var(--digital-blue-400)' : 'var(--digital-blue-300)'}
+          data={percentile} />
+        {/each}
+    </GraphicBody>
+
+  </DataGraphic>
+</div>

--- a/stories/data-graphics/distribution-plots/ScalarAggregationMultiple.svelte
+++ b/stories/data-graphics/distribution-plots/ScalarAggregationMultiple.svelte
@@ -98,6 +98,7 @@ let latest = data[data.length - 1];
 .graphic-and-summary {
   display: grid;
   grid-template-columns: max-content auto;
+  grid-column-gap: var(--space-2x);
 }
 </style>
 
@@ -114,8 +115,8 @@ let latest = data[data.length - 1];
     xDomain={$domain}
     yDomain={[0, largestPercentileValue]}
     yType="numeric"
-    width=550
-    height=250
+    width=400
+    height=150
     bind:dataGraphicMounted={dataGraphicMounted}
   >
     <LeftAxis showBorder=true />

--- a/stories/data-graphics/distribution-plots/ScalarAggregationMultiple.svelte
+++ b/stories/data-graphics/distribution-plots/ScalarAggregationMultiple.svelte
@@ -15,6 +15,7 @@ import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelt
 import GraphicBody from '../../../src/components/data-graphics/GraphicBody.svelte';
 import BottomAxis from '../../../src/components/data-graphics/BottomAxis.svelte';
 import LeftAxis from '../../../src/components/data-graphics/LeftAxis.svelte';
+import BuildIDRollover from '../../../src/components/data-graphics/rollovers/BuildIDRollover.svelte';
 import Line from '../../../src/components/data-graphics/LineMultiple.svelte';
 import ComparisonSummary from '../../../src/components/data-graphics/ComparisonSummary.svelte';
 
@@ -134,21 +135,12 @@ let latest = data[data.length - 1];
     </GraphicBody>
 
     {#if rollover.x && xScale && topPlot && bodyHeight}
+      <BuildIDRollover 
+        x={rollover.x}
+        label={rollover.datum.label}
+      />
       <rect x={xScale(rollover.x) - xScale.step() / 2} y={topPlot} width={xScale.step()} height={bodyHeight}
      fill="var(--cool-gray-700)" opacity=.2 />
-     <text 
-      x={xScale(rollover.x)} 
-      y={topPlot - margins.buffer}
-      text-anchor='middle'
-      font-family="var(--main-mono-font)"
-      font-size='12'>
-      <tspan fill="var(--cool-gray-500)" font-weight=bold>
-        {rollover.datum.label.slice(0, 4)}-{rollover.datum.label.slice(4,
-        6)}-{rollover.datum.label.slice(6, 8)}{' '}</tspan> 
-      <tspan> {rollover.datum.label.slice(8, 10)}:</tspan>
-      <tspan>{rollover.datum.label.slice(10, 12)}:</tspan>
-      <tspan>{rollover.datum.label.slice(12, 14)}</tspan>
-    </text>
     {/if}
   </DataGraphic>
   <ComparisonSummary 

--- a/stories/data-graphics/distribution-plots/ScalarAggregationMultiple.svelte
+++ b/stories/data-graphics/distribution-plots/ScalarAggregationMultiple.svelte
@@ -4,6 +4,7 @@ const largestPercentile = writable(0);
 
 <script>
 import { writable, derived } from 'svelte/store';
+import { slide } from 'svelte/transition';
 
 export let data;
 export let key;
@@ -15,6 +16,7 @@ import GraphicBody from '../../../src/components/data-graphics/GraphicBody.svelt
 import BottomAxis from '../../../src/components/data-graphics/BottomAxis.svelte';
 import LeftAxis from '../../../src/components/data-graphics/LeftAxis.svelte';
 import Line from '../../../src/components/data-graphics/LineMultiple.svelte';
+import ComparisonSummary from '../../../src/components/data-graphics/ComparisonSummary.svelte';
 
 import {
   buildIDToDate, firstOfMonth, buildIDToMonth, mondays, getFirstBuildOfDays,
@@ -96,37 +98,6 @@ let latest = data[data.length - 1];
   display: grid;
   grid-template-columns: max-content auto;
 }
-
-.summary {
-  margin-top: 20px;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-column-gap: var(--space-2x);
-}
-
-.summary-percentiles {
-  display: grid;
-  grid-template-columns: max-content auto;
-  grid-column-gap: var(--space-base);
-  font-size: var(--text-01);
-  align-content: start;
-}
-
-.summary-percentile--full {
-  grid-column: 1 / 3;
-}
-
-.summary-percentile--bin {
-  text-align: right;
-  font-weight: bold;
-  text-transform: uppercase;
-}
-
-.summary-percentile--value {
-  justify-self: stretch;
-  text-align: right;
-  width: 100%;
-}
 </style>
 
 
@@ -143,7 +114,7 @@ let latest = data[data.length - 1];
     yDomain={[0, largestPercentileValue]}
     yType="numeric"
     width=550
-    height=150
+    height=250
     bind:dataGraphicMounted={dataGraphicMounted}
   >
     <LeftAxis showBorder=true />
@@ -180,62 +151,8 @@ let latest = data[data.length - 1];
     </text>
     {/if}
   </DataGraphic>
-
-
-  <div class=summary style="padding-top:{margins ? margins.top : 0}">
-
-    {#each [rollover.datum, latest] as focus, i}
-      <div class=summary-percentiles>
-        {#if focus}
-          <div class='summary-percentile--full'>
-
-              <span style="text-align: right;font-family: var(--main-mono-font); color: var(--cool-gray-500); font-weight: bold" >
-                  {focus.label.slice(0, 4)}-{focus.label.slice(4,
-                  6)}-{focus.label.slice(6, 8)}{' '}</span> 
-                <span> {focus.label.slice(8, 10)}:</span>
-                <span>{focus.label.slice(10, 12)}:</span>
-                <span>{focus.label.slice(12, 14)}</span>
-          </div>
-          <div class=summary-percentile--bin>
-              # profiles
-            </div>
-            <div class=summary-percentile--value>
-              {focus.audienceSize}
-            </div>
-          {#each percentiles as percentile, i}
-            <div class=summary-percentile--bin>
-                {percentile}th %
-              </div>
-              <div class=summary-percentile--value>
-                {focus.percentiles.find((p) => p.bin === percentile).value}
-              </div>
-          {/each}
-        {/if}
-      </div>
-    {/each}
-    <!-- {#if rollover.datum && xScale}
-      <div class=summary-percentiles>
-      {#each percentiles as percentile, i}
-          <div class=summary-percentile--bin>
-            {percentile}th %
-          </div>
-          <div class=summary-percentile--value>
-            {rollover.datum.percentiles.find((p) => p.bin === percentile).value}
-          </div>
-      {/each}
-      </div>
-    {:else}
-      <div class=percentile></div>
-    {/if}
-      <div class=summary-percentiles>
-        {#each percentiles as percentile, i}
-            <div class=summary-percentile--bin>
-              {percentile}th %
-            </div>
-            <div class=summary-percentile--value>
-              {latest.percentiles.find((p) => p.bin === percentile).value}
-            </div>
-        {/each}
-        </div> -->
-  </div>
+  <ComparisonSummary 
+    left={rollover.datum} 
+    right={latest} 
+    percentiles={percentiles} />
 </div>

--- a/stories/data-graphics/distribution-plots/shared.js
+++ b/stories/data-graphics/distribution-plots/shared.js
@@ -22,6 +22,7 @@ export const makeDataset = (probeData, key = 'version') => probeData.map((probe)
   label: probe.metadata[key],
   histogram: responseHistogramToGraphicFormat(probe.data[0].histogram),
   percentiles: responseHistogramToGraphicFormat(probe.data[0].percentiles),
+  audienceSize: probe.data[0].total_users,
 }));
 
 


### PR DESCRIPTION
- [x] implements `clipPath` on graphic body to prevent extreme / unseen new values from overflowing into margins
- [x] creates a small multiple for scalars and implements in storybook
- [x] creates a right-hand summary view per small multiple which will be used to compare two builds / versions
- [x] implements _button groups_, which is just a fancy wrapper around a set of buttons that makes it look like they're all connected
- [x] implements `toggled` prop for buttons, which is now used in conjuction w/ button groups