### PR TITLE
HU 2019-10-24

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -82,6 +82,7 @@
     --space-8x: calc(var(--space-base) * 8);
     --space-12x: calc(var(--space-base) * 12);
     --space-16x: calc(var(--space-base) * 16);
+    --space-20x: calc(var(--space-base) * 20);
     --space-24x: calc(var(--space-base) * 24);
     --space-32x: calc(var(--space-base) * 32);
     --space-40x: calc(var(--space-base) * 40);
@@ -306,6 +307,7 @@ button:focus {
 }
 
 header {
+    min-width: var(--space-24x);
     width: 100%;
     height: var(--header-height);
     background-color: var(--blue-slate-700);
@@ -404,8 +406,14 @@ main .main-content {
 }
 
 main .main-action {
+    background-color: var(--blue-slate-700);
+
     position: relative;
     width: 100%;
+    display: grid;
+    grid-auto-flow: column;
+    justify-content: start;
+    grid-column-gap: var(--space-2x);
 }
 
 main .details {

--- a/src/app/TelemetryApp.svelte
+++ b/src/app/TelemetryApp.svelte
@@ -9,7 +9,9 @@ import Main from '../components/sections/Main.svelte';
 import MainActionBar from '../components/sections/MainActionBar.svelte';
 import Content from '../components/sections/Content.svelte';
 
+import TelemetryAppBar from './sections/TelemetryAppBar.svelte';
 import TelemetryControls from './sections/TelemetryControls.svelte';
+import TelemetryMainFilters from './sections/TelemetryMainFilters.svelte';
 import ProbeDetails from './sections/ProbeDetails.svelte';
 
 import { currentQuery } from './store/store';
@@ -42,11 +44,13 @@ div.inner-body {
 </style>
 <App>
     <!-- <TelemetryAppBar /> -->
-    <TelemetryControls />
+    <!-- <TelemetryControls /> -->
 
     <Main>
         <MainActionBar>
+                <TelemetryAppBar />
                 <Search />
+                <TelemetryMainFilters />
         </MainActionBar>
         <Content>
 

--- a/src/app/config.json
+++ b/src/app/config.json
@@ -8,7 +8,7 @@
       "title": "Operating System",
       "key": "os",
       "values": [
-        {"key": "ALL", "label": "All", "keyTransform": "NULL"},
+        {"key": "ALL", "label": "All OSes", "keyTransform": "NULL"},
         {"key": "Windows", "label": "Windows"},
         {"key": "Mac", "label": "Mac"},
         {"key": "Linux", "label": "Linux"}
@@ -27,8 +27,8 @@
       "title": "Aggregation Level",
       "key": "aggregationLevel",
       "values": [
-        {"key": "version", "label": "major version"},
-        {"key": "build_id", "label": "build id"}
+        {"key": "version", "label": "by major version"},
+        {"key": "build_id", "label": "by build id"}
       ]
     },
     "versions" : {

--- a/src/app/patterns/body/histograms/NumericHistogramSmallMultiple.svelte
+++ b/src/app/patterns/body/histograms/NumericHistogramSmallMultiple.svelte
@@ -1,6 +1,7 @@
 <script>
 import { writable, derived } from 'svelte/store';
 import { tweened } from 'svelte/motion';
+import { cubicOut as easing } from 'svelte/easing';
 import { format } from 'd3-format';
 import { symbol, symbolTriangle } from 'd3-shape';
 
@@ -117,13 +118,17 @@ $: if (dataGraphicMounted) {
 let latest = data[data.length - 1];
 let fmt = format(',.2r');
 
-function tidyToObject(tidy) {
-  let out = {};
-  tidy.forEach((t) => {
-    out[`p${t.bin}`] = nearestBelow(t.value, latest.histogram.map((h) => h.bin));
-  });
-  return out;
-}
+// function tidyToObject(tidy) {
+//   let out = {};
+//   tidy.forEach((t) => {
+//     out[`p${t.bin}`] = nearestBelow(t.value, latest.histogram.map((h) => h.bin));
+//   });
+//   return out;
+// }
+
+const movingAudienceSize = tweened(0, { duration: 1000, easing });
+
+$: movingAudienceSize.set(latest.audienceSize);
 
 </script>
 
@@ -220,7 +225,7 @@ h4 {
   </div>
   <div class=bignum>
     <div class=bignum__label>Affected Clients</div>
-    <div class=bignum__value>{countFmt(latest.audienceSize)}</div>
+    <div class=bignum__value>{countFmt($movingAudienceSize)}</div>
   </div>
 
 </div>

--- a/src/app/patterns/body/rollovers/DistributionComparison.svelte
+++ b/src/app/patterns/body/rollovers/DistributionComparison.svelte
@@ -1,5 +1,9 @@
 <script>
 import { onMount, getContext } from 'svelte';
+import { fade } from 'svelte/transition';
+import {
+  line, curveStep, symbol, symbolTriangle,
+} from 'd3-shape';
 import DataGraphic from '../../../../components/data-graphics/DataGraphic.svelte';
 import GraphicBody from '../../../../components/data-graphics/GraphicBody.svelte';
 import BottomAxis from '../../../../components/data-graphics/BottomAxis.svelte';
@@ -41,6 +45,7 @@ onMount(() => {
   T.subscribe((t) => { topPlot = t; });
   B.subscribe((b) => { bottomPlot = b; });
 });
+
 </script>
 
 <DataGraphic
@@ -54,7 +59,7 @@ onMount(() => {
   bind:topPlot={T}
   bind:bottomPlot={B}
   bind:yScale={yScale}
-  left={0}
+  left={10}
   right={40}
 >
   <rect 
@@ -68,7 +73,40 @@ onMount(() => {
 
   <!-- <LeftAxis tickCount=6 />
   <BottomAxis  ticks={ticks} tickFormatter={tickFormatter} /> -->
+
+  {#if leftPercentiles && rightPercentiles}
+  {#each leftPercentiles as leftP, i}
+    <!-- <path 
+    d={line().curve(curveStep)([
+      [leftPlot, yScale(nearestBelow(leftP.value, yDomain))],
+    [rightPlot, yScale(nearestBelow(rightPercentiles[i].value, yDomain))]])}
+    stroke={percentileLineColorMap(leftP.bin)}
+    fill="none"
+    /> -->
+    <line 
+      x1={leftPlot}
+      x2={rightPlot}
+      y1={yScale(nearestBelow(leftP.value, yDomain))}
+      y2={yScale(nearestBelow(rightPercentiles[i].value, yDomain))}
+      stroke={percentileLineColorMap(leftP.bin)}
+    />
+    <circle 
+      cx={leftPlot} 
+      cy={yScale(nearestBelow(leftP.value, yDomain))} 
+      r=2
+      fill={percentileLineColorMap(leftP.bin)}
+    />
+    <g style="transform:translate({rightPlot}px, {yScale(nearestBelow(rightPercentiles[i].value, yDomain))}px)">
+      <path 
+        d={symbol().type(symbolTriangle).size(20)()} 
+        fill={percentileLineColorMap(leftP.bin)}
+      />
+  </g>
+  {/each}
+{/if}
+
   {#if leftDistribution}
+  <g transition:fade={{ duration: 50 }}>
     <Violin 
       showLeft={false}
       xp={(rightPlot - leftPlot) / 2 + leftPlot - 1}
@@ -81,6 +119,7 @@ onMount(() => {
       areaColor="var(--digital-blue-400)"
       lineColor="var(--digital-blue-500)"
     />
+  </g>
   {/if}
     {#if rightDistribution}
       <Violin 
@@ -100,17 +139,7 @@ onMount(() => {
     <RightAxis tickCount=6 />
     <BottomAxis ticks={['hovered', 'latest']}  />
 
-    {#if leftPercentiles && rightPercentiles}
-      {#each leftPercentiles as leftP, i}
-        <line 
-          x1={leftPlot}
-          x2={rightPlot}
-          y1={yScale(nearestBelow(leftP.value, yDomain))}
-          y2={yScale(nearestBelow(rightPercentiles[i].value, yDomain))}
-          stroke={percentileLineColorMap(leftP.bin)}
-        />
-      {/each}
-    {/if}
+
     <!-- {#if leftPercentiles}
       {#each leftPercentiles as percentile, i}
         <line 

--- a/src/app/patterns/body/rollovers/DistributionComparison.svelte
+++ b/src/app/patterns/body/rollovers/DistributionComparison.svelte
@@ -1,0 +1,136 @@
+<script>
+import { onMount, getContext } from 'svelte';
+import DataGraphic from '../../../../components/data-graphics/DataGraphic.svelte';
+import GraphicBody from '../../../../components/data-graphics/GraphicBody.svelte';
+import BottomAxis from '../../../../components/data-graphics/BottomAxis.svelte';
+import LeftAxis from '../../../../components/data-graphics/LeftAxis.svelte';
+import RightAxis from '../../../../components/data-graphics/RightAxis.svelte';
+import BuildIDRollover from '../../../../components/data-graphics/rollovers/BuildIDRollover.svelte';
+import Line from '../../../../components/data-graphics/LineMultiple.svelte';
+import Violin from '../../../../components/data-graphics/ViolinPlotMultiple.svelte';
+import { percentileLineColorMap } from '../../../../components/data-graphics/utils/color-maps';
+
+import { nearestBelow } from '../../../../utils/stats';
+
+export let leftDistribution;
+export let rightDistribution;
+export let leftLabel;
+export let rightLabel;
+export let leftPercentiles;
+export let rightPercentiles;
+export let xDomain;
+export let yDomain;
+export let width;
+export let height;
+
+const margins = getContext('margins');
+
+let L;
+let R;
+let T;
+let B;
+let leftPlot;
+let rightPlot;
+let topPlot;
+let bottomPlot;
+let yScale;
+
+onMount(() => {
+  L.subscribe((l) => { leftPlot = l; });
+  R.subscribe((r) => { rightPlot = r; });
+  T.subscribe((t) => { topPlot = t; });
+  B.subscribe((b) => { bottomPlot = b; });
+});
+</script>
+
+<DataGraphic
+  xDomain={xDomain}
+  yDomain={yDomain}
+  yType="scalePoint"
+  width={width}
+  height={height}
+  bind:leftPlot={L}
+  bind:rightPlot={R}
+  bind:topPlot={T}
+  bind:bottomPlot={B}
+  bind:yScale={yScale}
+  left={0}
+  right={40}
+>
+  <rect 
+    x={leftPlot}
+    y={topPlot}
+    width={rightPlot - leftPlot}
+    height={bottomPlot - topPlot}
+    fill="var(--cool-gray-200)"
+    opacity=.25
+  />
+
+  <!-- <LeftAxis tickCount=6 />
+  <BottomAxis  ticks={ticks} tickFormatter={tickFormatter} /> -->
+  {#if leftDistribution}
+    <Violin 
+      showLeft={false}
+      xp={(rightPlot - leftPlot) / 2 + leftPlot - 1}
+      key={leftLabel}
+      opacity=.9
+      y={leftDistribution} 
+      densityAccessor='value'
+      valueAccessor='bin'
+      densityRange={[0, 30]}
+      areaColor="var(--digital-blue-400)"
+      lineColor="var(--digital-blue-500)"
+    />
+  {/if}
+    {#if rightDistribution}
+      <Violin 
+      showRight={false}
+      xp={(rightPlot - leftPlot) / 2 + leftPlot + 1}
+      opacity=.9
+      key={rightLabel}
+      y={rightDistribution} 
+      densityAccessor='value'
+      valueAccessor='bin'
+      densityRange={[0, 30]}
+      areaColor="var(--digital-blue-400)"
+      lineColor="var(--digital-blue-500)"
+      />
+    {/if}
+
+    <RightAxis tickCount=6 />
+    <BottomAxis ticks={['hovered', 'latest']}  />
+
+    {#if leftPercentiles && rightPercentiles}
+      {#each leftPercentiles as leftP, i}
+        <line 
+          x1={leftPlot}
+          x2={rightPlot}
+          y1={yScale(nearestBelow(leftP.value, yDomain))}
+          y2={yScale(nearestBelow(rightPercentiles[i].value, yDomain))}
+          stroke={percentileLineColorMap(leftP.bin)}
+        />
+      {/each}
+    {/if}
+    <!-- {#if leftPercentiles}
+      {#each leftPercentiles as percentile, i}
+        <line 
+          x1={leftPlot + margins.buffer * 2} 
+          x2={leftPlot}
+          y1={yScale(nearestBelow(percentile.value, yDomain))}
+          y2={yScale(nearestBelow(percentile.value, yDomain))}
+          stroke={percentileLineColorMap(percentile.bin)}
+          stroke-width=2 />
+      {/each}
+    {/if}
+    {#if rightPercentiles}
+      {#each rightPercentiles as percentile, i}
+        <line 
+          x1={rightPlot - margins.buffer * 2} 
+          x2={rightPlot}
+          y1={yScale(nearestBelow(percentile.value, yDomain))}
+          y2={yScale(nearestBelow(percentile.value, yDomain))}
+          stroke={percentileLineColorMap(percentile.bin)}
+          stroke-width=2 />
+      {/each}
+    {/if} -->
+</DataGraphic>    

--- a/src/app/patterns/body/rollovers/DistributionComparison.svelte
+++ b/src/app/patterns/body/rollovers/DistributionComparison.svelte
@@ -26,6 +26,10 @@ export let xDomain;
 export let yDomain;
 export let width;
 export let height;
+export let xType;
+export let yType;
+export let xAccessor = 'bin';
+export let yAccessor = 'value';
 
 const margins = getContext('margins');
 
@@ -46,12 +50,18 @@ onMount(() => {
   B.subscribe((b) => { bottomPlot = b; });
 });
 
+
+function placeShapeY(value) {
+  if (yScale.type !== 'scalePoint') return yScale(value);
+  return yScale(nearestBelow(value, yDomain));
+}
+
 </script>
 
 <DataGraphic
   xDomain={xDomain}
   yDomain={yDomain}
-  yType="scalePoint"
+  yType={yType}
   width={width}
   height={height}
   bind:leftPlot={L}
@@ -76,30 +86,23 @@ onMount(() => {
 
   {#if leftPercentiles && rightPercentiles}
   {#each leftPercentiles as leftP, i}
-    <!-- <path 
-    d={line().curve(curveStep)([
-      [leftPlot, yScale(nearestBelow(leftP.value, yDomain))],
-    [rightPlot, yScale(nearestBelow(rightPercentiles[i].value, yDomain))]])}
-    stroke={percentileLineColorMap(leftP.bin)}
-    fill="none"
-    /> -->
     <line 
       x1={leftPlot}
       x2={rightPlot}
-      y1={yScale(nearestBelow(leftP.value, yDomain))}
-      y2={yScale(nearestBelow(rightPercentiles[i].value, yDomain))}
-      stroke={percentileLineColorMap(leftP.bin)}
+      y1={placeShapeY(leftP[yAccessor])}
+      y2={placeShapeY(rightPercentiles[i][yAccessor])}
+      stroke={percentileLineColorMap(leftP[xAccessor])}
     />
     <circle 
       cx={leftPlot} 
-      cy={yScale(nearestBelow(leftP.value, yDomain))} 
+      cy={placeShapeY(leftP[yAccessor])} 
       r=2
-      fill={percentileLineColorMap(leftP.bin)}
+      fill={percentileLineColorMap(leftP[xAccessor])}
     />
-    <g style="transform:translate({rightPlot}px, {yScale(nearestBelow(rightPercentiles[i].value, yDomain))}px)">
+    <g style="transform:translate({rightPlot}px, {placeShapeY(rightPercentiles[i][yAccessor])}px)">
       <path 
         d={symbol().type(symbolTriangle).size(20)()} 
-        fill={percentileLineColorMap(leftP.bin)}
+        fill={percentileLineColorMap(leftP[xAccessor])}
       />
   </g>
   {/each}
@@ -138,28 +141,4 @@ onMount(() => {
 
     <RightAxis tickCount=6 />
     <BottomAxis ticks={['hovered', 'latest']}  />
-
-
-    <!-- {#if leftPercentiles}
-      {#each leftPercentiles as percentile, i}
-        <line 
-          x1={leftPlot + margins.buffer * 2} 
-          x2={leftPlot}
-          y1={yScale(nearestBelow(percentile.value, yDomain))}
-          y2={yScale(nearestBelow(percentile.value, yDomain))}
-          stroke={percentileLineColorMap(percentile.bin)}
-          stroke-width=2 />
-      {/each}
-    {/if}
-    {#if rightPercentiles}
-      {#each rightPercentiles as percentile, i}
-        <line 
-          x1={rightPlot - margins.buffer * 2} 
-          x2={rightPlot}
-          y1={yScale(nearestBelow(percentile.value, yDomain))}
-          y2={yScale(nearestBelow(percentile.value, yDomain))}
-          stroke={percentileLineColorMap(percentile.bin)}
-          stroke-width=2 />
-      {/each}
-    {/if} -->
 </DataGraphic>    

--- a/src/app/patterns/body/rollovers/FiveNum.svelte
+++ b/src/app/patterns/body/rollovers/FiveNum.svelte
@@ -1,0 +1,88 @@
+<script>
+import { getContext } from 'svelte';
+import { percentileLineColorMap, percentileLineStrokewidthMap } from '../../../../components/data-graphics/utils/color-maps';
+
+
+const xScale = getContext('xScale');
+const yScale = getContext('yScale');
+const margins = getContext('margins');
+const T = getContext('topPlot');
+const H = getContext('bodyHeight');
+let topPlot;
+let bodyHeight;
+
+T.subscribe((t) => { topPlot = t; });
+H.subscribe((h) => { bodyHeight = h; });
+
+export let x;
+export let numbers;
+
+export let p5;
+export let p25;
+export let p50;
+export let p75;
+export let p95;
+
+export let valueAccessor = 'y';
+export let numberAccessor = 'yi';
+
+let interleaved = [];
+
+$: if (x) {
+  // interleaved = [
+  //   [numbers[0], numbers[1], percentileLineColorMap(numbers[0][numberAccessor])],
+  //   [numbers[1], numbers[2], percentileLineColorMap(numbers[1][numberAccessor])],
+  //   [numbers[2], numbers[3], percentileLineColorMap(numbers[3][numberAccessor])],
+  //   [numbers[3], numbers[4], percentileLineColorMap(numbers[4][numberAccessor])],
+  // ];
+  interleaved = [
+    [p5, p25, percentileLineColorMap(5)],
+    [p25, p50, percentileLineColorMap(25)],
+    [p50, p75, percentileLineColorMap(75)],
+    [p75, p95, percentileLineColorMap(95)],
+  ];
+}
+
+[p5, p25, p50, p75, p95].forEach((p) => {
+  console.log(yScale(p));
+});
+
+// function interleave(data) {
+//   // in: [1,2,3,4] out [[1,2], [2,3], [3,4]]
+//   let interleaved = Array.from({ length: data.length - 1 }).map((_, i) => [data[i], data[i + 1]]);
+//   interleaved.reverse();
+//   return interleaved;
+// }
+
+</script>
+
+<g>
+{#each interleaved as [a, b, color], i}
+  <!-- <rect 
+    x={xScale(x) - xScale.step() / 2} 
+    y={yScale(b[valueAccessor])}
+    width={xScale.step()}
+    height={yScale(a[valueAccessor]) - yScale(b[valueAccessor])}
+    fill={color} /> -->
+    <rect 
+    x={xScale(x) - xScale.step() / 2} 
+    y={yScale(b)}
+    width={xScale.step()}
+    height={yScale(a) - yScale(b)}
+    fill={color} />
+{/each}
+<rect 
+x={xScale(x) + xScale.step() / 2}
+y={topPlot}
+width={50}
+height={bodyHeight}
+fill='white' opacity=.8 
+/>
+{#each [[p5, '5%'], [p25, '25%'], [p50, 'median'], [p75, '75%'], [p95, '95%']]
+as [p, l], i (p)}
+  <text 
+    text-anchor=end
+    font-size=12 x={xScale(x) - xScale.step() / 2 - margins.buffer} dy='.35em' y={yScale(p)} fill='black'>{l}</text>
+    <text font-size=12 x={xScale(x) + xScale.step() / 2 + margins.buffer} dy='.35em' y={yScale(p)} fill='black'>{p}</text>
+{/each}
+</g>

--- a/src/app/patterns/body/scalars/ScalarAggregationSmallMultiple.svelte
+++ b/src/app/patterns/body/scalars/ScalarAggregationSmallMultiple.svelte
@@ -1,7 +1,19 @@
 <script>
 import { writable, derived } from 'svelte/store';
+import { tweened } from 'svelte/motion';
+import { cubicOut as easing } from 'svelte/easing';
+import { format } from 'd3-format';
+import { symbol, symbolTriangle } from 'd3-shape';
+
+let valueFmt = format(',.4r');
+let countFmt = format(',d');
+let pFmt = format('.0%');
 
 export let data;
+
+// FIXME: after demo remove this requirement
+data = data.slice(0, -1);
+export let title;
 export let key;
 export let resolution = 'ALL_TIME';
 export let percentiles = [50];
@@ -14,12 +26,15 @@ import BuildIDRollover from '../../../../components/data-graphics/rollovers/Buil
 import Line from '../../../../components/data-graphics/LineMultiple.svelte';
 import ComparisonSummary from '../../../../components/data-graphics/ComparisonSummary.svelte';
 
-import { percentileLineColorMap } from '../../../../components/data-graphics/utils/color-maps';
+import DistributionComparison from '../rollovers/DistributionComparison.svelte';
+
+import { percentileLineColorMap, percentileLineStrokewidthMap } from '../../../../components/data-graphics/utils/color-maps';
+import { nearestBelow } from '../../../../utils/stats';
+import { extractPercentiles } from '../../../../components/data-graphics/utils/percentiles';
 
 import {
   buildIDToDate, firstOfMonth, buildIDToMonth, mondays, getFirstBuildOfDays,
 } from '../../../../components/data-graphics/utils/build-id-utils';
-import { extractPercentiles } from '../../../../components/data-graphics/utils/percentiles';
 
 let domain = writable(data.map((d) => d.label));
 
@@ -40,9 +55,11 @@ let percentileData = [];
 $: percentileData = extractPercentiles(percentiles, data.filter((d) => $domain.includes(d.label)))
   .map((ps, i) => [ps, percentiles[i]]);
 
-
 let [upperDomain] = extractPercentiles([95], data.filter((d) => $domain.includes(d.label)));
 upperDomain = Math.max(...upperDomain.map((o) => o.originalPercentileValue));
+
+// let [upperDomain] = extractPercentiles([95], data.filter((d) => $domain.includes(d.label)));
+// upperDomain = Math.max(...upperDomain.map((o) => o.originalPercentileValue));
 
 let tickFormatter = buildIDToMonth;
 let ticks = firstOfMonth;
@@ -72,32 +89,146 @@ function initiateRollover(rolloverStore) {
   });
 }
 
+let WIDTH = 450;
+let HEIGHT = 350;
+
 let margins;
 let dataGraphicMounted = false;
 let xScale;
+let yScale;
 let T;
 let H;
+let GW;
+let R;
+let graphicWidth;
 let topPlot;
+let rightPlot;
 let bodyHeight;
 
 $: if (dataGraphicMounted) {
   initiateRollover(dgRollover);
   T.subscribe((t) => { topPlot = t; });
   H.subscribe((h) => { bodyHeight = h; });
+  R.subscribe((r) => { rightPlot = r; });
+  GW.subscribe((gw) => { graphicWidth = gw; });
 }
 
+// FIXME: this is for demo purposes. use better build data.
 let latest = data[data.length - 1];
+let fmt = format(',.2r');
 
+$: console.log(latest.percentiles.filter((p) => percentiles.includes(p.bin)));
+
+// function tidyToObject(tidy) {
+//   let out = {};
+//   tidy.forEach((t) => {
+//     out[`p${t.bin}`] = nearestBelow(t.value, latest.histogram.map((h) => h.bin));
+//   });
+//   return out;
+// }
+
+const movingAudienceSize = tweened(0, { duration: 1000, easing });
+
+$: movingAudienceSize.set(latest.audienceSize);
 </script>
 
 <style>
 .graphic-and-summary {
   display: grid;
-  grid-template-columns: max-content auto;
-  grid-column-gap: var(--space-2x);
+  grid-template-columns: max-content max-content auto;
+  /* grid-column-gap: var(--space-2x); */
+}
+
+table {
+  border-spacing: 0px;
+  font-size: 16px;
+  /* justify-self: end; */
+}
+
+th {
+  font-weight: 600;
+}
+
+td, th {
+  font-size: 12px;
+  text-align: right;
+  min-width: var(--space-6x);
+}
+
+.color-label {
+  display:inline-block;
+  width: var(--space-base);
+  height: var(--space-base);
+  margin-right: var(--space-1h);
+  border-radius: var(--space-1q);
+}
+
+.bold {
+  font-weight: bold;
+}
+
+.summary {
+  display:grid;
+  grid-auto-flow:column;
+  /* width: max-content; */
+  justify-content: end;
+  font-size: 14px;
+}
+
+.summary-miniature {
+  display:grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  outline:1px solid black;
+}
+
+h4 {
+  padding: 0px;
+  margin:0px;
+  text-transform: uppercase;
+  color: var(--cool-gray-500);
+}
+
+.title-and-summary {
+  display:grid;
+  grid-template-columns: auto max-content max-content;
+  grid-column-gap: var(--space-4x);
+  justify-items: start;
+  margin-bottom: var(--space-4x);
+}
+
+.bignum {
+  width: max-content;
+  justify-self: end;
+}
+
+.bignum__label {
+  font-size: var(--text-015);
+  text-transform: uppercase;
+  color: var(--cool-gray-500);
+}
+
+.bignum__value {
+  font-size: var(--text-06);
+  text-align: right;
 }
 </style>
 
+
+<div class='title-and-summary'>
+  <div style="padding-left:{margins ? margins.left : 0}px;">
+    <h4>{title}</h4>
+  </div>
+  <div class=bignum>
+    <div class=bignum__label>Latest Median (50th perc.)</div>
+    <div class=bignum__value>{valueFmt(latest.percentiles.find((p) => p.bin === 50).value)}</div>
+  </div>
+  <div class=bignum>
+    <div class=bignum__label>Affected Clients</div>
+    <div class=bignum__value>{countFmt($movingAudienceSize)}</div>
+  </div>
+
+</div>
 
 <div class=graphic-and-summary>
   <DataGraphic
@@ -105,18 +236,33 @@ let latest = data[data.length - 1];
     xDomain={$domain}
     yDomain={[0, upperDomain]}
     yType="log"
-    width=600
-    height=250
+    width={WIDTH}
+    height={HEIGHT}
     bind:dataGraphicMounted={dataGraphicMounted}
     bind:margins={margins}
     bind:rollover={dgRollover}
     bind:xScale={xScale}
+    bind:yScale={yScale}
     bind:bodyHeight={H}
     bind:topPlot={T}
+    bind:graphicWidth={GW}
+    bind:rightPlot={R}
+    right={16}
     key={key}
 
   >
-    <LeftAxis />
+
+  {#if rollover.x && xScale && topPlot && bodyHeight}
+  <BuildIDRollover 
+    x={rollover.x}
+    label={rollover.datum.label}
+  />
+  <rect x={xScale(rollover.x) - xScale.step() / 2} y={topPlot} width={xScale.step()} height={bodyHeight}
+  fill="var(--cool-gray-100)" />
+  <rect x={xScale(latest.label) - xScale.step() / 2} y={topPlot} width={xScale.step()} height={bodyHeight}
+  fill="var(--cool-gray-100)" />
+{/if}
+    <LeftAxis tickCount=6 />
     <BottomAxis  ticks={ticks} tickFormatter={tickFormatter} />
 
     <GraphicBody>
@@ -127,22 +273,54 @@ let latest = data[data.length - 1];
           lineDrawAnimation={{ duration: 300 }} 
           xAccessor="label"
           yAccessor="originalPercentileValue"
+          strokeWidth={percentileLineStrokewidthMap(pi)}
           color={percentileLineColorMap(pi)}
           data={percentile} />
         {/each}
+        {#if rollover.datum}
+          {#each rollover.datum.percentiles as percentile, i}
+          {#if percentiles.includes(percentile.bin)}
+          <circle 
+            cx={xScale(rollover.datum.label)}
+            cy={yScale(percentile.value)}
+            r=2
+            stroke="none"
+            fill={percentileLineColorMap(percentile.bin)}
+            />
+            <g style="transform:translate({xScale(latest.label)}px, {yScale(latest.percentiles[i].value)}px)">
+                <path 
+                  d={symbol().type(symbolTriangle).size(20)()} 
+                  fill={percentileLineColorMap(latest.percentiles[i].bin)}
+                />
+              </g>
+            {/if}
+            {/each}
+        {/if}
     </GraphicBody>
 
-    {#if rollover.x && xScale && topPlot && bodyHeight}
-      <BuildIDRollover 
-        x={rollover.x}
-        label={rollover.datum.label}
-      />
-      <rect x={xScale(rollover.x) - xScale.step() / 2} y={topPlot} width={xScale.step()} height={bodyHeight}
-      fill="var(--cool-gray-700)" opacity=.2 />
-    {/if}
+
   </DataGraphic>
-  <!-- <ComparisonSummary 
+  <DistributionComparison 
+    width={125}
+    height={HEIGHT}
+    yType="log"
+    yAccessor={'value'}
+    leftDistribution={rollover.datum ? rollover.datum.histogram : undefined}
+    leftLabel={rollover.x}
+    rightDistribution={latest.histogram}
+    rightLabel={latest.label}
+    leftPercentiles={rollover.datum ? rollover.datum.percentiles.filter((p) => percentiles.includes(p.bin)) : undefined}
+    rightPercentiles={latest.percentiles.filter((p) => percentiles.includes(p.bin))}
+    xDomain={['hovered', 'latest']}
+    yDomain={[0, upperDomain]}
+    yFocus={rollover.y}
+  />
+  <ComparisonSummary 
     left={rollover.datum} 
-    right={latest} 
-    percentiles={percentiles} /> -->
+    right={latest}
+    yAccessor={'originalPercentileValue'}
+    leftLabel={rollover.x}
+    rightLabel={latest.label}
+    percentiles={percentiles} />
 </div>
+    

--- a/src/app/sections/TelemetryControls.svelte
+++ b/src/app/sections/TelemetryControls.svelte
@@ -46,7 +46,7 @@ const resetFilters = () => {
 </script>
 
 <LeftDrawer {visible}>
-    <TelemetryAppBar />
+    <!-- <TelemetryAppBar /> -->
     <div class=left-drawer__header>
         {#if !$hasDefaultControlFields}
             <div transition:fly={{ y: -10, duration: 200 }}

--- a/src/app/sections/TelemetryMainFilters.svelte
+++ b/src/app/sections/TelemetryMainFilters.svelte
@@ -1,0 +1,81 @@
+<script>
+import { getContext } from 'svelte';
+import MenuButton from '../../components/menu/MenuButton.svelte';
+import MenuList from '../../components/menu/MenuList.svelte';
+import MenuListItem from '../../components/menu/MenuListItem.svelte';
+import DownCarat from '../../components/icons/DownCarat.svelte';
+import CONFIG from '../config.json';
+
+import {
+  store,
+  getFieldValueLabel,
+  updateChannel, updateOS, updateAggregationLevel,
+} from '../store/store';
+
+
+const OFFSET = 10;
+const COMPACT = true;
+</script>
+
+<style>
+.main-filters {
+  display:grid;
+  grid-auto-flow: column;
+  grid-column-gap:var(--space-base);
+  align-items: center;
+  margin-left: var(--space-4x);
+}
+
+.main-filter__label {
+  display: grid;
+  grid-auto-flow: column;
+  align-items: center;
+  grid-column-gap: var(--space-1h);
+}
+
+.pull-right-edge {
+  margin-right: calc(var(--space-1h) * -1);
+  display:grid;
+  align-items: center;
+}
+
+</style>
+
+<div class='main-filters'>
+  <MenuButton compact={COMPACT} offset={OFFSET} position='top-right'>
+    <div class=main-filter__label slot="label">{getFieldValueLabel('channel', $store.channel)} <div class=pull-right-edge><DownCarat size=14 /></div></div>
+    <div slot="menu">
+      <MenuList on:selection={(event) => { store.dispatch(updateChannel(event.detail.key)); }}>
+          {#each CONFIG.fields.channel.values as {key, label}, i (key)}
+          <!-- <RadioSelector value={key} label={label} group={$store.channel} /> -->
+            <MenuListItem  key={key} value={key}><span class='story-label
+              first'></span>{label}</MenuListItem>
+            {/each}
+        </MenuList>
+    </div>
+    </MenuButton>
+    <MenuButton compact={COMPACT} offset={OFFSET}  position='top-right'>
+        <div class=main-filter__label slot="label">{getFieldValueLabel('os', $store.os)}<div class=pull-right-edge><DownCarat size=14 /></div></div>
+        <div slot="menu">
+            <MenuList on:selection={(event) => { store.dispatch(updateOS(event.detail.key)); }}>
+              {#each CONFIG.fields.os.values as {key, label}, i (key)}
+              <!-- <RadioSelector value={key} label={label} group={$store.channel} /> -->
+                <MenuListItem  key={key} value={key}><span class='story-label
+                  first'></span>{label}</MenuListItem>
+                {/each}
+            </MenuList>
+        </div>
+      </MenuButton>
+      <MenuButton compact={COMPACT}  offset={OFFSET}  position='top-right'>
+          <div class=main-filter__label slot="label">{getFieldValueLabel('aggregationLevel', $store.aggregationLevel)}<div class=pull-right-edge><DownCarat size=14 /></div></div>
+          <div slot="menu">
+              <MenuList on:selection={(event) => { store.dispatch(updateAggregationLevel(event.detail.key)); }}>
+                  {#each CONFIG.fields.aggregationLevel.values as {key, label}, i (key)}
+                <!-- <RadioSelector value={key} label={label} group={$store.channel} /> -->
+                  <MenuListItem  key={key} value={key}><span class='story-label
+                    first'></span>{label}</MenuListItem>
+                  {/each}
+              </MenuList>
+          </div>
+        </MenuButton>
+</div>

--- a/src/components/data-graphics/ComparisonSummary.svelte
+++ b/src/components/data-graphics/ComparisonSummary.svelte
@@ -151,7 +151,7 @@ td, th {
                 6)}-{right.label.slice(6, 8)}{' '}</div> 
               {right.label.slice(8, 10)}:{right.label.slice(10, 12)}:{right.label.slice(12, 14)} -->
           </th>
-          <th></th>
+          <th>Diff.</th>
       </tr>
     </thead>
     <tbody>

--- a/src/components/data-graphics/ComparisonSummary.svelte
+++ b/src/components/data-graphics/ComparisonSummary.svelte
@@ -4,7 +4,8 @@ import { format } from 'd3-format';
 import { percentileLineColorMap } from './utils/color-maps';
 
 
-let fmt = format(',.2r');
+let fmt = format(',.4r');
+let countFmt = format(',d');
 let pFmt = format('.0%');
 
 export let left;
@@ -33,31 +34,67 @@ function createNewPercentiles() {
   });
 }
 
-$: if (leftLabel || rightLabel) displayValues = createNewPercentiles();
+$: if (leftLabel || rightLabel || percentiles) displayValues = createNewPercentiles();
 
 </script>
 
 <style>
 
+.summary {
+  padding-top: var(--space-2x);
+  padding-bottom: var(--space-2x);
+}
+
 table {
-  font-size: var(--text-02);
+  font-family: var(--main-mono-font);
+  font-size: var(--text-015);
+  margin-left: var(--space-base);
+  width: 100%;
+  border-spacing: 0px;
+  --heavy-border: 1px solid var(--line-gray-01);
+  --lighter-border: 1px dotted var(--bg-gray-01);
+}
+
+tbody tr td {
+  border: var(--lighter-border);
+}
+
+tbody tr td:first-child, tbody tr td:last-child {
+  border-right: var(--heavy-border);
+  border-left: var(--heavy-border);
+}
+
+tbody tr:last-child td {
+  border-bottom: var(--heavy-border);
 }
 
 th {
   line-height: 1;
+  font-weight: normal;
+  text-transform:uppercase;
+  vertical-align: top;
+  border-bottom: var(--heavy-border);
+  font-size: var(--text-01);
+  color: var(--cool-gray-500);
 }
 
 td, th {
+  padding-left: var(--space-base);
+  padding-right: var(--space-base);
+  min-width: var(--space-6x);
+  max-width: var(--space-8x);
   text-align: right;
+  padding-top: var(--space-base);
+  padding-bottom: var(--space-base);
 }
 /* 
 .label {
   font-size: 12px;
 } */
 
-.summary-label {
+/* .summary-label {
   font-size: 12px;
-}
+} */
 
 .summary-label--main-date {
   font-family: var(--main-mono-font); 
@@ -70,11 +107,25 @@ td, th {
   text-align: right;
 } */
 
+.value-label {
+  min-width: var(--space-8x);
+}
+
+.left-value, .right-value {
+  background-color: var(--cool-gray-100);
+
+}
+
 .summary-color-label {
   display: inline-block;
   width: var(--space-base);
   height: var(--space-base);
   border-radius: var(--space-1q);
+  margin-right: var(--space-1h);
+}
+
+.small-shape {
+  padding-left:var(--space-1h);
 }
 
 </style>
@@ -84,46 +135,41 @@ td, th {
   <table>
     <thead>
       <tr>
-        <th>Metric</th>
+        <th>Perc.</th>
         <th class=summary-label>
-            {#if left}
-            Hovered
+            Hovered<span class='small-shape'>●</span>
             <!-- <div class="summary-label--main-date" >
                 {left.label.slice(0, 4)}-{left.label.slice(4,
                 6)}-{left.label.slice(6, 8)}{' '}</div> 
               {left.label.slice(8, 10)}:... -->
               <!-- {left.label.slice(10, 12)}:{left.label.slice(12, 14)} -->
-            {:else}
-              <div></div>
-            {/if}
         </th>
         <th class=summary-label>
-            Latest Build
+            Latest<span class='small-shape'>▲</span>
             <!-- <div class="summary-label--main-date" >
                 {right.label.slice(0, 4)}-{right.label.slice(4,
                 6)}-{right.label.slice(6, 8)}{' '}</div> 
               {right.label.slice(8, 10)}:{right.label.slice(10, 12)}:{right.label.slice(12, 14)} -->
           </th>
+          <th></th>
       </tr>
     </thead>
     <tbody>
-          <tr>
-            <td class=value-label># clients</td>
-            <td class=value-left>{left ? fmt(left.audienceSize) : ' '}</td>
-            <td class=value-right>{right ? fmt(right.audienceSize) : ' '}</td>
-            <td class=value-right>{(left && right)
-            ? pFmt(percentChange(left.audienceSize, right.audienceSize)) : ' '}</td>
-          </tr>
+          <!-- <tr>
+            <td class=value-label style="font-size: var(--text-01);">clients</td>
+            <td class=value-left>{left ? countFmt(left.audienceSize) : ' '}</td>
+            <td class=value-right>{right ? countFmt(right.audienceSize) : ' '}</td>
+            <td></td>
+          </tr> -->
 
           {#each displayValues as {leftValue, rightValue, percentageChange, percentile}}
             <tr>
               <td class=value-label>
                 <span class='summary-color-label'
-                style="background-color:{percentileLineColorMap(percentile)}"></span>
-                {percentile}%</td>
+                style="background-color:{percentileLineColorMap(percentile)}"></span>{percentile}%</td>
               <td class=value-left>{left ? fmt(leftValue) : ' '}</td>
               <td class=value-right>{right ? fmt(rightValue) : ' '}</td>
-                  <td class=value-right>{percentageChange ? pFmt(percentageChange) : ' '}</td>
+                  <td class=value-change>{percentageChange ? pFmt(percentageChange) : ' '}</td>
             </tr>
           {/each}
           <!-- {#each percentiles as percentile}

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -11,18 +11,27 @@ export let yDomain;
 export let xType = 'scalePoint';
 export let yType = 'scalePoint';
 
+export let left = 50;
+export let right = 16;
+export let top = 20;
+export let bottom = 20;
+export let laneGap = 30;
+export let buffer = 5;
+
+let xPadding = 0.5;
+
 // if x is a function, use that to get xMin / xMax.
 // if xMin / xMax is a function, use that to calculate xMin / xMax.
 // if xMin / xMax is a string, use that to pull out values for xMin / xMax.
 // xType / yType determine what you might need, so start there?
 
 export let margins = {
-  left: 50,
-  right: 16,
-  top: 20,
-  bottom: 20,
-  laneGap: 30,
-  buffer: 5,
+  left,
+  right,
+  top,
+  bottom,
+  laneGap,
+  buffer,
 };
 
 const DEFAULTS = {
@@ -85,7 +94,7 @@ function createXPointScale(values) {
   const scale = scaleFunction()
     .domain([...values])
     .range([$leftPlot, $rightPlot])
-    .padding(0.5);
+    .padding(xPadding);
   scale.type = xType;
   return scale;
 }

--- a/src/components/data-graphics/ViolinPlotMultiple.svelte
+++ b/src/components/data-graphics/ViolinPlotMultiple.svelte
@@ -36,6 +36,9 @@ const smallBarMultipleScale = (obj, range = [0, 20]) => {
   ]).range(range);
 };
 
+let yScaleType = yScale.type;
+let yScaleAdjustment = yScaleType === 'scalePoint' ? yScale.step() / 2 : 0;
+
 let histogramScale = smallBarMultipleScale(plotY, densityRange);
 $: histogramScale = smallBarMultipleScale(plotY, densityRange);
 
@@ -44,11 +47,11 @@ let [histogramArea, inverseHistogramArea] = [1, -1].map((direction) => area()
   .x1((d) => direction * histogramScale(d.value))
   .x0(() => histogramScale(0))
   .curve(curve)
-  .y((d) => yScale(d.bin) + yScale.step() / 2));
+  .y((d) => yScale(d.bin) + yScaleAdjustment));
 
-let histogramLine = histogramArea.lineX1().y((d) => yScale(d.bin) + yScale.step() / 2);
+let histogramLine = histogramArea.lineX1().y((d) => yScale(d.bin) + yScaleAdjustment);
 let inverseHistogramLine = inverseHistogramArea
-  .lineX1().y((d) => yScale(d.bin) + yScale.step() / 2);
+  .lineX1().y((d) => yScale(d.bin) + yScaleAdjustment);
 // $: histogramArea = histogramArea(plotY);
 // $: histogramLine = histogramLine(plotY);
 // $: inverseHistogramArea = inverseHistogramArea(plotY);

--- a/src/components/data-graphics/ViolinPlotMultiple.svelte
+++ b/src/components/data-graphics/ViolinPlotMultiple.svelte
@@ -7,7 +7,9 @@ import {
 
 export let xScale = getContext('xScale');
 export let yScale = getContext('yScale');
+export let key;
 export let x;
+export let xp;
 export let y;
 export let opacity = 1;
 export let densityAccessor = 'weight';
@@ -23,8 +25,7 @@ const getValues = (data) => data.map((obj) => obj[densityAccessor]);
 let mounted = false;
 
 let plotY = y;
-
-$: if (x) {
+$: if (x || key) {
   plotY = [...y.map((obj) => ({ ...obj }))];
 }
 
@@ -60,7 +61,7 @@ onMount(() => {
 </script>
 
 {#if mounted}
-<g transform="translate({xScale(x)}, 0)" opacity={opacity}>
+<g transform="translate({xScale(x) || xp}, 0)" opacity={opacity}>
   {#if showLeft}
   <path d={histogramArea(plotY)} fill={areaColor} opacity={opacity} 
   />

--- a/src/components/icons/DownCarat.svelte
+++ b/src/components/icons/DownCarat.svelte
@@ -1,0 +1,11 @@
+<script>
+export let size = 24;
+</script>
+
+<style>
+svg {
+  fill: currentColor;
+}
+</style>
+
+<svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24"><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/><path fill="none" d="M0 0h24v24H0V0z"/></svg>

--- a/src/components/menu/FloatingMenu.svelte
+++ b/src/components/menu/FloatingMenu.svelte
@@ -77,12 +77,21 @@ $: if (parent && element) {
   position: absolute;
   width: max-content;
 }
+
+.click-area {
+  position:absolute;
+  left:0;
+  top:0;
+  width: 100vw;
+  height:100vh;
+}
 </style>
 
 <svelte:window on:keydown={handleKeypress} />
 
 
 <Portal>
+  <div on:click={() => { dispatch('cancel'); }} class=click-area></div>
   <div class=bound-menu bind:this={element} style="
     left: {left}px;
     top: {top}px;

--- a/src/components/menu/FloatingMenu.svelte
+++ b/src/components/menu/FloatingMenu.svelte
@@ -3,30 +3,67 @@
   // get the parent element location;
   // set the position of this element based off the parent element.
   // include offset.
-import { setContext, onMount } from 'svelte';
+import { setContext, onMount, createEventDispatcher } from 'svelte';
 
 import Portal from '../Portal.svelte';
 
 export let active = false;
 export let parent;
 export let offset = 0;
-export let onSelect = () => {};
+export let position = 'bottom-left';
+export let onParentSelect = () => {};
 
 let element;
 
 let elementWidth = 0;
+let elementHeight = 0;
 let parentRight;
 let parentBottom;
+let parentLeft;
+let parentTop;
 
-setContext('onChildSelect', onSelect);
+let left;
+let top;
+
+setContext('onChildSelect', onParentSelect);
+
+const dispatch = createEventDispatcher();
+
+function handleKeypress(event) {
+    const { key } = event;
+    if (key === 'Escape') {
+      dispatch('cancel');
+    }
+}
 
 function placeMenu() {
     const parentPosition = parent.getBoundingClientRect();
     const elementPosition = element.getBoundingClientRect();
+  
     // leftMarginOffset = +getComputedStyle(parent).marginLeft.slice(0, -2);
     elementWidth = elementPosition.width;
+    elementHeight = elementPosition.height;
+
     parentRight = parentPosition.right;
+    parentLeft = parentPosition.left;
+    parentTop = parentPosition.top;
     parentBottom = parentPosition.bottom;
+    if (position.startsWith('bottom')) {
+      top = parentBottom + offset;
+    } else if (position.startsWith('top')) {
+      top = parentTop - elementHeight - offset;
+    } else {
+      // FIXME: is this the right default?
+      top = parentBottom + offset;
+    }
+    if (position.endsWith('left')) {
+      left = parentLeft;
+    } else if (position.endsWith('right')) {
+      left = parentRight - elementWidth;
+    } else {
+      // FIXME: is this the right default?
+      left = parentLeft;
+    }
   }
 
 $: if (parent && element) {
@@ -42,10 +79,13 @@ $: if (parent && element) {
 }
 </style>
 
+<svelte:window on:keydown={handleKeypress} />
+
+
 <Portal>
   <div class=bound-menu bind:this={element} style="
-    left: {parentRight - elementWidth}px;
-    top: {parentBottom + offset}px;
+    left: {left}px;
+    top: {top}px;
     ">
     <slot></slot>
   </div>

--- a/src/components/menu/MenuButton.svelte
+++ b/src/components/menu/MenuButton.svelte
@@ -6,32 +6,31 @@ import FloatingMenu from './FloatingMenu.svelte';
 const dispatch = createEventDispatcher();
 
 export let active = false;
+export let position = 'top-left';
 
 function onParentSelect(kvPair) {
     active = false;
-    console.log(kvPair);
     dispatch('selection', kvPair);
 }
 
 function toggle() { active = !active; }
 let button;
-$: if (button) console.log(button.getBoundingClientRect());
 </script>
 
 <style>
 .menu-button {
-  outline: 1px solid black;
   width: max-content;
 }
+
 </style>
 
 <div class=menu-button bind:this={button}>
-<Button on:click={toggle}>
+<Button compact class=button--high on:click={toggle}>
   <slot name='label'></slot>
 </Button>
 </div>
 {#if active}
-  <FloatingMenu parent={button} onParentSelect={onParentSelect}>
+  <FloatingMenu  on:cancel={() => { active = false; }}  position='bottom-left' parent={button} onParentSelect={onParentSelect}>
     <slot name='menu'></slot>
   </FloatingMenu>
 {/if}

--- a/src/components/menu/MenuButton.svelte
+++ b/src/components/menu/MenuButton.svelte
@@ -7,6 +7,9 @@ const dispatch = createEventDispatcher();
 
 export let active = false;
 export let position = 'top-left';
+export let offset = 0;
+export let level = 'high';
+export let compact = false;
 
 function onParentSelect(kvPair) {
     active = false;
@@ -25,12 +28,12 @@ let button;
 </style>
 
 <div class=menu-button bind:this={button}>
-<Button compact class=button--high on:click={toggle}>
+<Button level={level} compact={compact} on:click={toggle}>
   <slot name='label'></slot>
 </Button>
 </div>
 {#if active}
-  <FloatingMenu  on:cancel={() => { active = false; }}  position='bottom-left' parent={button} onParentSelect={onParentSelect}>
+  <FloatingMenu offset={offset} on:cancel={() => { active = false; }}  position='bottom-left' parent={button} onParentSelect={onParentSelect}>
     <slot name='menu'></slot>
   </FloatingMenu>
 {/if}

--- a/src/components/menu/MenuList.svelte
+++ b/src/components/menu/MenuList.svelte
@@ -40,7 +40,7 @@ function next() {
 }
 
 function select() {
-    dispatch('selection', $allItems[$currentCandidate]);
+    onSelect($allItems[$currentCandidate]);
 }
 
 const handleKeypress = (event) => {

--- a/src/components/menu/MenuList.svelte
+++ b/src/components/menu/MenuList.svelte
@@ -13,11 +13,9 @@ export let onSelect = function onSelect(kvPair) {
     onParentSelect(kvPair);
   };
 
-const currentSelection = writable(undefined);
 const currentCandidate = writable(undefined);
 const allItems = writable([]);
 
-setContext('currentSelection', currentSelection);
 setContext('currentCandidate', currentCandidate);
 setContext('allItems', allItems);
 setContext('onSelect', onSelect);

--- a/src/components/menu/MenuListItem.svelte
+++ b/src/components/menu/MenuListItem.svelte
@@ -1,7 +1,6 @@
 <script>
 import { onMount, getContext } from 'svelte';
 
-const currentSelection = getContext('currentSelection');
 const currentCandidate = getContext('currentCandidate');
 const onSelect = getContext('onSelect');
 const allItems = getContext('allItems');

--- a/stories/data-graphics/distribution-plots/HistogramAggregation.svelte
+++ b/stories/data-graphics/distribution-plots/HistogramAggregation.svelte
@@ -9,7 +9,7 @@
   </script>
     
     <div class=story>
-      <div style="width: var(--space-81x);">
+      <div style="width: 900px;">
         <h1 class="story__title">probe / <span class=probe-head>gc_ms</span></h1>
         <NumericHistogramView data={gcmsByBuild} />
       </div>

--- a/stories/low-level/menu/FloatingMenuStory.svelte
+++ b/stories/low-level/menu/FloatingMenuStory.svelte
@@ -40,7 +40,7 @@ function setValue(evt) {
   <div class=parent bind:this={parent}>this is the element that the floating menu is "attached" to.</div>
 
   {#if on}
-  <FloatingMenu parent={parent} offset={+offset}>
+  <FloatingMenu on:cancel={() => { on = false; }} parent={parent} offset={+offset}>
     <MenuList on:selection={setValue}>
       <MenuListItem  key='first' value={0}>first item</MenuListItem>
       <MenuListItem  key='second' value={1}>second item</MenuListItem>

--- a/stories/low-level/menu/MenuButtonStory.svelte
+++ b/stories/low-level/menu/MenuButtonStory.svelte
@@ -3,22 +3,46 @@ import MenuButton from '../../../src/components/menu/MenuButton.svelte';
 import MenuList from '../../../src/components/menu/MenuList.svelte';
 import MenuListItem from '../../../src/components/menu/MenuListItem.svelte';
 
-let value = 0;
+let key = 'first';
 
 function setValue(event) {
-  value = event.detail.key;
+  key = event.detail.key;
 }
 
 </script>
 
+<style>
+
+
+.story-label {
+  display: inline-block;
+  width: var(--space-base);
+  height: var(--space-base);
+  margin-right: var(--space-1h);
+  border-radius: var(--space-1q);
+}
+
+.first {
+  background-color: var(--cool-gray-300);
+}
+
+.second {
+  background-color: var(--pantone-red-400);
+}
+
+.third {
+  background-color: var(--bright-yellow-400);
+}
+</style>
+
 <div class=story>
 <MenuButton>
-  <span slot="label">{value}</span>
+  <span slot="label"> <span class='story-label {key}'></span> {key}</span>
   <div slot="menu">
     <MenuList  on:selection={setValue}>
-        <MenuListItem  key='first' value={0}>first item</MenuListItem>
-        <MenuListItem  key='second' value={1}>second item</MenuListItem>
-        <MenuListItem  key='third' value={2}>third item</MenuListItem>
+        <MenuListItem  key='first' value={0}><span class='story-label first'></span>first item</MenuListItem>
+        <MenuListItem  key='second' value={1}><span class='story-label second'></span>second item</MenuListItem>
+        <MenuListItem  key='third' value={2}><span class='story-label third'></span>third item</MenuListItem>
       </MenuList>
   </div>
   </MenuButton>


### PR DESCRIPTION
![Kapture 2019-10-24 at 7 58 38](https://user-images.githubusercontent.com/95735/67499033-41412a00-f635-11e9-9148-6301709a44c4.gif)

![Kapture 2019-10-24 at 14 59 40](https://user-images.githubusercontent.com/95735/67528686-f0e6be00-f66e-11e9-8539-143ae11611a4.gif)


We reached an impasse yesterday. The two-drawer design creates a very real problem – engineers tiling their browser with the command line, which means we cannot reliably expect to have more than 900-1200px of `innerWidth`. So we have to get rid of one of the two drawers. @spasovski and I chatted about this yesterday afternoon. We came up with two options: (1) remove the right drawer (the details) and affix them to the bottom, and (2) remove the left drawer and move the filters to the app bar. As a first step, I decided to try the latter – since the left drawer is used only for three small, likely-to-not-change menu items, it feels like a bigger waste of space. This required the building-out of floating menu components done yesterday evening, and the following PR work today.

- [x] adds click area to deactivate a floating menu
- [x] experiment to move right drawer over to menu bar in order to build space to let the visualization breath.
- [x] right drawer experiment worked. Now we implement comparison charts + percentile summary.
- [x] implement new histogram comparison small multiple into histogram chart
- [x] implement big-number values (latest median, audience size)
- [x] implement percentile summary table, which gives raw values + percentage change