### PR TITLE
HU 2019-10-31

### DIFF
--- a/src/app/patterns/KeySelectionControl.svelte
+++ b/src/app/patterns/KeySelectionControl.svelte
@@ -1,0 +1,17 @@
+<script>
+import BodyControl from './BodyControl.svelte';
+
+export let selections;
+export let colorMap = () => 'black';
+export let transformed = selections.map((opt) => ({
+  label: opt, value: opt, labelColor: colorMap(opt),
+}));
+
+</script>
+
+<BodyControl
+  options={transformed}
+    bind:selected={selections}
+    multi={true}
+    level="low"
+/>

--- a/src/app/patterns/body/BuildIDComparison.svelte
+++ b/src/app/patterns/body/BuildIDComparison.svelte
@@ -27,6 +27,7 @@ export let extractMouseoverValues;
 export let xDomain;
 export let yDomain;
 export let yScaleType;
+export let yTickFormatter;
 export let width;
 export let height;
 export let timeHorizon;
@@ -111,7 +112,7 @@ fill="var(--cool-gray-100)" />
 <rect x={xScale(reference.label) - xScale.step() / 2} y={topPlot} width={xScale.step()} height={bodyHeight}
 fill="var(--cool-gray-100)" />
 {/if}
- <LeftAxis tickCount=6 />
+ <LeftAxis tickFormatter={yTickFormatter} tickCount=6 />
  <BottomAxis  ticks={ticks} tickFormatter={tickFormatter} />
 
  <GraphicBody>

--- a/src/app/patterns/body/proportions/ProportionExplorerSmallMultiple.svelte
+++ b/src/app/patterns/body/proportions/ProportionExplorerSmallMultiple.svelte
@@ -9,8 +9,6 @@ import BuildIDComparison from '../BuildIDComparison.svelte';
 import DistributionComparison from '../rollovers/DistributionComparison.svelte';
 import ComparisonSummary from '../../../../components/data-graphics/ComparisonSummary.svelte';
 
-import { percentileLineColorMap } from '../../../../components/data-graphics/utils/color-maps';
-
 import {
   buildIDToDate,
 } from '../../../../components/data-graphics/utils/build-id-utils';
@@ -34,14 +32,17 @@ export let key;
 export let timeHorizon;
 export let proportions;
 export let activeProportions;
+export let colorMap = () => 'var(--digital-blue-500)';
 
 
 let valueFmt = format(',.4r');
 let countFmt = format(',d');
+const percentFormatter = format('.0p');
+
 
 const probeType = getContext('probeType');
 
-let yScaleType;
+let yScaleType = 'linear';
 let yDomain = [0, 1];
 let whichTransformation = 'proportions';
 // if (probeType === 'histogram') {
@@ -159,9 +160,10 @@ h4 {
     xDomain={$domain}
     yDomain={yDomain}
     timeHorizon={timeHorizon}
-    lineColorMap={percentileLineColorMap}
+    lineColorMap={colorMap}
     key={key}
-    yScaleType={'linear'}
+    yScaleType={yScaleType}
+    yTickFormatter={percentFormatter}
     width={WIDTH}
     height={HEIGHT}
     transform={(p, d) => extractProportions(p, d, whichTransformation)}
@@ -171,21 +173,23 @@ h4 {
     extractMouseoverValues={getProportion}
   />
 
-  <!-- <DistributionComparison 
+  <DistributionComparison 
     yType={yScaleType}
+    yTickFormatter={percentFormatter}
     width={125}
     height={HEIGHT}
-    leftDistribution={hovered.datum ? hovered.datum.histogram : undefined}
-    rightDistribution={reference.histogram}
+    showViolins={false}
+    leftDistribution={hovered.datum ? hovered.datum.proportions : undefined}
+    rightDistribution={reference.proportions}
     leftLabel={hovered.x}
     rightLabel={reference.label}
-    colorMap={percentileLineColorMap}
+    colorMap={colorMap}
     leftPercentiles={hovered.datum ? getAllProportions(proportions, hovered.datum) : undefined}
     rightPercentiles={getAllProportions(proportions, reference)}
     xDomain={['hovered', 'latest']}
     yDomain={yDomain}
   />
-  
+  <!-- 
   <ComparisonSummary 
     left={hovered.datum} 
     right={reference}

--- a/src/app/patterns/body/proportions/ProportionExplorerSmallMultiple.svelte
+++ b/src/app/patterns/body/proportions/ProportionExplorerSmallMultiple.svelte
@@ -189,12 +189,15 @@ h4 {
     xDomain={['hovered', 'latest']}
     yDomain={yDomain}
   />
-  <!-- 
+  
   <ComparisonSummary 
-    left={hovered.datum} 
-    right={reference}
+    left={hovered.datum ? hovered.datum.proportions : hovered.datum} 
+    right={reference.proportions}
     leftLabel={hovered.x}
     rightLabel={reference.label}
-    percentiles={proportions} /> -->
+    keySet={proportions} 
+    colorMap={colorMap}
+    valueFormatter={percentFormatter}
+    />
 </div>
     

--- a/src/app/patterns/body/proportions/ProportionExplorerView.svelte
+++ b/src/app/patterns/body/proportions/ProportionExplorerView.svelte
@@ -5,8 +5,10 @@ import {
 } from '../../../utils/probe-utils';
 
 import ProportionExplorerSmallMultiple from './ProportionExplorerSmallMultiple.svelte';
-import PercentileSelectionControl from '../../PercentileSelectionControl.svelte';
+import KeySelectionControl from '../../KeySelectionControl.svelte';
 import TimeHorizonControl from '../../TimeHorizonControl.svelte';
+
+import { createCatColorMap } from '../../../../components/data-graphics/utils/color-maps';
 
 export let data;
 export let probeType;
@@ -21,9 +23,10 @@ function getProportionKeys(tr) {
 let totalAggs = Object.keys(Object.values(transformed)[0]).length;
 
 let timeHorizon = 'MONTH';
-let percentiles = [5, 25, 50, 75, 95];
 
 let proportions = getProportionKeys(transformed);
+
+const cmp = createCatColorMap(proportions);
 
 setContext('probeType', probeType);
 
@@ -58,8 +61,9 @@ setContext('probeType', probeType);
     </div>
   
     <div class=body-control-set>
-        <label class=body-control-set--label>Probe Value Percentiles</label>
-      <PercentileSelectionControl bind:percentiles={percentiles} />
+        <label class=body-control-set--label>Keys</label>
+        <KeySelectionControl bind:selections={proportions} colorMap={cmp} />
+      <!-- <PercentileSelectionControl bind:percentiles={percentiles} /> -->
     </div>
   </div>
 
@@ -77,6 +81,7 @@ setContext('probeType', probeType);
               probeType={probeType}
               proportions={proportions}
               timeHorizon={timeHorizon}
+              colorMap={cmp}
             />
           </div>
       {/each}

--- a/src/app/patterns/body/quantiles/QuantileExplorerSmallMultiple.svelte
+++ b/src/app/patterns/body/quantiles/QuantileExplorerSmallMultiple.svelte
@@ -177,10 +177,14 @@ h4 {
   />
   
   <ComparisonSummary 
-    left={hovered.datum} 
-    right={reference}
+    left={hovered.datum ? hovered.datum.percentiles : hovered.datum} 
+    right={reference.percentiles}
     leftLabel={hovered.x}
     rightLabel={reference.label}
-    percentiles={percentiles} />
+    keySet={percentiles}
+    colorMap={percentileLineColorMap}
+    valueFormatter={valueFmt}
+    keyFormatter={(perc) => `${perc}%`}
+    />
 </div>
     

--- a/src/app/patterns/body/rollovers/DistributionComparison.svelte
+++ b/src/app/patterns/body/rollovers/DistributionComparison.svelte
@@ -4,11 +4,11 @@ import { fade } from 'svelte/transition';
 import {
   symbol, symbolStar as referenceSymbol,
 } from 'd3-shape';
+
 import DataGraphic from '../../../../components/data-graphics/DataGraphic.svelte';
 import BottomAxis from '../../../../components/data-graphics/BottomAxis.svelte';
 import RightAxis from '../../../../components/data-graphics/RightAxis.svelte';
 import Violin from '../../../../components/data-graphics/ViolinPlotMultiple.svelte';
-import { percentileLineColorMap } from '../../../../components/data-graphics/utils/color-maps';
 
 import { nearestBelow } from '../../../../utils/stats';
 
@@ -18,6 +18,7 @@ export let leftLabel;
 export let rightLabel;
 export let leftPercentiles;
 export let rightPercentiles;
+export let yTickFormatter;
 export let colorMap = () => 'black';
 export let xDomain;
 export let yDomain;
@@ -28,6 +29,7 @@ export let yType;
 export let showViolins = true;
 export let key = Math.random().toString(36).substring(7);
 export let yAccessor = 'value';
+
 
 let L;
 let R;
@@ -136,6 +138,6 @@ function placeShapeY(value) {
     />
   {/if}
 
-  <RightAxis tickCount=6 />
+  <RightAxis tickFormatter={yTickFormatter} tickCount=6 />
   <BottomAxis ticks={['hovered', 'latest']}  />
 </DataGraphic>    

--- a/src/app/patterns/body/rollovers/DistributionComparison.svelte
+++ b/src/app/patterns/body/rollovers/DistributionComparison.svelte
@@ -18,7 +18,7 @@ export let leftLabel;
 export let rightLabel;
 export let leftPercentiles;
 export let rightPercentiles;
-export let yTickFormatter;
+export let yTickFormatter = (t) => t;
 export let colorMap = () => 'black';
 export let xDomain;
 export let yDomain;

--- a/src/components/data-graphics/ComparisonSummary.svelte
+++ b/src/components/data-graphics/ComparisonSummary.svelte
@@ -1,19 +1,19 @@
 <script>
 import { format } from 'd3-format';
 
-import { percentileLineColorMap } from './utils/color-maps';
-
 
 let fmt = format(',.4r');
-let countFmt = format(',d');
 let pFmt = format('.0%');
 
+export let colorMap = () => 'black';
 export let left;
 export let right;
 export let leftLabel;
 export let rightLabel;
-export let percentiles;
+export let keySet;
 export let compareTo = 'left-right';
+export let valueFormatter = (t) => t;
+export let keyFormatter = (t) => t;
 
 function percentChange(l, r) {
   return (r - l) / l;
@@ -22,11 +22,11 @@ function percentChange(l, r) {
 let displayValues = [];
 
 function createNewPercentiles() {
-  return percentiles.map((percentile) => {
-    const leftValue = left ? left.percentiles[percentile] : undefined;// left.percentiles.find((p) => p.bin === percentile).value : undefined;
-    const rightValue = right ? right.percentiles[percentile] : undefined; // right.percentiles.find((p) => p.bin === percentile).value : undefined;
+  return keySet.map((key) => {
+    const leftValue = left ? left[key] : undefined;// left.percentiles.find((p) => p.bin === percentile).value : undefined;
+    const rightValue = right ? right[key] : undefined; // right.percentiles.find((p) => p.bin === percentile).value : undefined;
     return {
-      percentile,
+      key,
       leftValue,
       rightValue,
       percentageChange: (leftValue && rightValue) ? percentChange(leftValue, rightValue) : undefined,
@@ -34,7 +34,7 @@ function createNewPercentiles() {
   });
 }
 
-$: if (leftLabel || rightLabel || percentiles) displayValues = createNewPercentiles();
+$: if (leftLabel || rightLabel || keySet) displayValues = createNewPercentiles();
 
 </script>
 
@@ -144,13 +144,13 @@ td, th {
       </tr>
     </thead>
     <tbody>
-          {#each displayValues as {leftValue, rightValue, percentageChange, percentile}}
+          {#each displayValues as {leftValue, rightValue, percentageChange, key}}
             <tr>
               <td class=value-label>
                 <span class='summary-color-label'
-                style="background-color:{percentileLineColorMap(percentile)}"></span>{percentile}%</td>
-              <td class=value-left>{left ? fmt(leftValue) : ' '}</td>
-              <td class=value-right>{right ? fmt(rightValue) : ' '}</td>
+                style="background-color:{colorMap(key)}"></span>{keyFormatter(key)}</td>
+              <td class=value-left>{left ? valueFormatter(leftValue) : ' '}</td>
+              <td class=value-right>{right ? valueFormatter(rightValue) : ' '}</td>
               <td class=value-change>{percentageChange ? pFmt(percentageChange) : ' '}</td>
             </tr>
           {/each}

--- a/src/components/data-graphics/SimpleAxis.svelte
+++ b/src/components/data-graphics/SimpleAxis.svelte
@@ -90,18 +90,10 @@ export let tickFormatter = (t) => t;
 export let showTicks = true;
 export let showBorder = false;
 export let showLabels = true;
-/*
-- create option for long / short
-- figure out what calcs need to be made:
-  -text location: tickLocation + DIRECTION * tickLength + DIRECTION * margins.buffer;
-  -tick location:
-  -tick length:
-
-*/
 
 let mainDim = (side === 'left' || side === 'right') ? 'x' : 'y';
 let secondaryDim = (side === 'left' || side === 'right') ? 'y' : 'x';
-// for left / right, we need additional buffer. for top / bottom, we need to move down tickFontSize.
+
 let fontSizeCorrector = (side === 'bottom') ? tickFontSize : margins.buffer;
 
 let tickEnd;
@@ -144,7 +136,7 @@ $: tickEnd = lineStyle === 'long' ? $obverseDimension : $bodyDimension;
           }}
           text-anchor={textAnchor}
           font-size={tickFontSize}
-        >{tickFormatter(tick)}</text>
+        >{tickFormatter ? tickFormatter(tick) : tick}</text>
       {/if}
   {/each}
   </g>

--- a/src/components/data-graphics/utils/color-maps.js
+++ b/src/components/data-graphics/utils/color-maps.js
@@ -1,5 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
+import { schemeTableau10 } from 'd3-scale-chromatic';
+
 export function percentileLineColorMap(percentile) {
   if (percentile === 5) return 'var(--digital-blue-300)';
   if (percentile === 25) return 'var(--digital-blue-500)';
@@ -12,4 +14,17 @@ export function percentileLineColorMap(percentile) {
 export function percentileLineStrokewidthMap(percentile) {
   if (percentile === 50) return 1.5;
   return 1;
+}
+
+export function createCatColorMap(options) {
+  // array of options should
+  const getID = (value) => options.find((v) => v === value);
+  return function catColorMap(v) {
+    const i = getID(v);
+    return schemeTableau10[i];
+  };
+}
+
+export function genericCategoricalColorMap(v) {
+  return schemeTableau10[v];
 }


### PR DESCRIPTION
The main theme of the day is centered around getting the proportion explorer – the body view for categorical histograms, booleans, flags, counts, etc. – together. Because of the work done yesterday in generalizing the `QuantileExplorerView.svelte` component, we can re-use almost everything. The details will matter, however – there are some edge cases about displaying proportions that will have to be addressed. But that should be the bulk of the component work, not the actual drawing-svg parts.

- [x] adds a new key selector control for proportion explorer; creates a color generator for arbitrary numbers of keys (useful for categoricals and enumerated's)
- [x] adds a percentage tick formatter
- [x] updates the `ComparisonSummary.svelte` component to show the key / values