### PR TITLE
HU 2019-11-03

### DIFF
--- a/src/app/patterns/body/elements/BuildIDComparison.svelte
+++ b/src/app/patterns/body/elements/BuildIDComparison.svelte
@@ -12,6 +12,8 @@ import GraphicBody from '../../../../components/data-graphics/GraphicBody.svelte
 import BuildIDRollover from '../../../../components/data-graphics/rollovers/BuildIDRollover.svelte';
 import Line from '../../../../components/data-graphics/LineMultiple.svelte';
 
+import FirefoxReleaseVersionMarkers from './FirefoxReleaseVersionMarkers.svelte';
+
 import Marker from '../../../../components/data-graphics/Marker.svelte';
 
 import {
@@ -164,18 +166,6 @@ fill="var(--cool-gray-100)" />
  {/if}
 
 
-
-
- {#if markers && markers.length && topPlot}
-    {#each markers.map(({ date, label }) => ({ label, date: dateToBuildID(xScale, date) })).filter((d) => d.date !== undefined) as {label, date}, i (date)}
-      <Marker location={date}>{label}</Marker>
-    {/each}
-    <!-- <g class=markers>
-    {#each markers.map(({ date, label }) => ({ label, date: dateToBuildID(xScale, date) })).filter((d) => d.date !== undefined) as {label, date}, i (date)}
-      <line y1={topPlot} y2={bottomPlot} x1={xScale(date)} x2={xScale(date)} stroke-dasharray='1,1' stroke='var(--cool-gray-500)' />
-      <text x={xScale(date)} y={topPlot - margins.buffer} font-size=11 text-anchor='middle' fill='var(--cool-gray-500)'>{label}</text>
-    {/each}
-    </g> -->
- {/if}
+  <FirefoxReleaseVersionMarkers />
 
 </DataGraphic>

--- a/src/app/patterns/body/elements/FirefoxReleaseVersionMarkers.svelte
+++ b/src/app/patterns/body/elements/FirefoxReleaseVersionMarkers.svelte
@@ -1,0 +1,22 @@
+<script>
+import { getContext } from 'svelte';
+import Marker from '../../../../components/data-graphics/Marker.svelte';
+import { firefoxVersionMarkers as markers } from '../../../store/product-versions';
+
+import {
+  dateToBuildID,
+} from '../../../../components/data-graphics/utils/build-id-utils';
+
+const xScale = getContext('xScale');
+const topPlot = getContext('topPlot');
+
+</script>
+
+
+<g class='firefox-release-version-markers'>
+  {#if $markers && $markers.length && $topPlot}
+    {#each $markers.map(({ date, label }) => ({ label, date: dateToBuildID(xScale, date) })).filter((d) => d.date !== undefined) as {label, date}, i (date)}
+      <Marker location={date}>{label}</Marker>
+    {/each}
+  {/if}
+</g>

--- a/src/app/patterns/body/elements/FirefoxReleaseVersionMarkers.svelte
+++ b/src/app/patterns/body/elements/FirefoxReleaseVersionMarkers.svelte
@@ -1,21 +1,22 @@
 <script>
 import { getContext } from 'svelte';
 import Marker from '../../../../components/data-graphics/Marker.svelte';
-import { firefoxVersionMarkers as markers } from '../../../store/product-versions';
+import { firefoxVersionMarkers } from '../../../store/product-versions';
 
 import {
   dateToBuildID,
 } from '../../../../components/data-graphics/utils/build-id-utils';
 
 const xScale = getContext('xScale');
-const topPlot = getContext('topPlot');
 
+let markers = [];
+firefoxVersionMarkers.subscribe((m) => { markers = m; });
 </script>
 
 
 <g class='firefox-release-version-markers'>
-  {#if $markers && $markers.length && $topPlot}
-    {#each $markers.map(({ date, label }) => ({ label, date: dateToBuildID(xScale, date) })).filter((d) => d.date !== undefined) as {label, date}, i (date)}
+  {#if markers && markers.length}
+    {#each markers.map(({ date, label }) => ({ label, date: dateToBuildID(xScale, date) })).filter((d) => d.date !== undefined) as {label, date}, i (date)}
       <Marker location={date}>{label}</Marker>
     {/each}
   {/if}

--- a/src/app/store/product-versions.js
+++ b/src/app/store/product-versions.js
@@ -1,0 +1,39 @@
+import { readable, derived } from 'svelte/store';
+import { store } from './store';
+
+
+// not sure what to export here.
+
+export const productDetails = readable(undefined, async (set) => {
+  // if (!hasLoaded) {
+  const request = await fetch('https://product-details.mozilla.org/1.0/all.json');
+  const data = await request.json();
+  set(data.releases);
+  return () => undefined;
+});
+
+
+export const firefoxReleases = derived([store, productDetails], ([$store, $pd]) => {
+  // get $usage for optionSet.
+  // console.log($store.channel);
+  const { channel } = $store;
+  if ($pd === undefined) return undefined;
+  return Object.entries($pd).filter(([key, { category }]) => category === 'major' && key.includes('firefox')).sort(([_a, { date: ad }], [_b, { date: bd }]) => {
+    if (ad > bd) return 1;
+    if (ad < bd) return -1;
+    return 0;
+  }).map(([_, info]) => {
+    info.str = info.date;
+    info.date = new Date(info.date);
+    let version = parseInt(info.version);
+    if (version >= 4) version = ~~version;
+    if (channel === 'nightly') version += 2;
+    if (channel === 'beta') version += 1;
+    // version = `${version}`;
+    info.label = version;
+    return info;
+  })
+    .filter((info) => info.str > '2016-06-01');
+});
+
+export const firefoxVersionMarkers = derived(firefoxReleases, ($releases) => ($releases ? $releases.map((r) => ({ label: r.label, date: r.date })) : []));

--- a/src/components/data-graphics/LineMultiple.svelte
+++ b/src/components/data-graphics/LineMultiple.svelte
@@ -29,6 +29,5 @@ const lineGenerator = SHAPE.line()
     stroke-width={strokeWidth}
     fill=none 
     in:draw={lineDrawAnimation}
-    out:fade={{ duration: 50 }}
     d={lineGenerator(data)} />
 </g>

--- a/src/components/data-graphics/Marker.svelte
+++ b/src/components/data-graphics/Marker.svelte
@@ -3,10 +3,11 @@ let orders = {};
 </script>
 
 <script>
-import { getContext, onMount } from 'svelte';
+import {
+  getContext, onMount, onDestroy,
+} from 'svelte';
 import { cubicOut as easing } from 'svelte/easing';
 import { tweened } from 'svelte/motion';
-import { fade } from 'svelte/transition';
 
 export let location;
 export let direction = 'vertical';
@@ -15,11 +16,11 @@ export let lineThickness = 1;
 export let lineColor = 'var(--cool-gray-500)';
 export let textColor = lineColor;
 
-
 const key = getContext('key');
 
 if (!(key in orders)) orders[key] = 0;
 const ORDER = orders[key];
+
 orders[key] += 1;
 
 export let margins = getContext('margins');
@@ -35,7 +36,7 @@ const animate = true;
 
 let pixelDirection = direction === 'vertical' ? 1 : -1;
 
-const scaling = tweened(pixelDirection, { duration: animate ? 500 : 0, delay: ORDER * 50, easing });
+let scaling = tweened(pixelDirection, { duration: animate ? 500 : 0, delay: ORDER * 50, easing });
 
 let lineEndCoord;
 let lineStartCoord;
@@ -46,14 +47,14 @@ $: lineStartCoord = $rootLocation;
 $: locationCoord = scale(location);
 $: textEndCoord = $endLocation + (-pixelDirection) * margins.buffer + ($distance / 2) * $scaling;
 
-let x1;
-let x2;
-let y1;
-let y2;
-let textX;
-let textY;
-let textAnchor;
-let dy;
+let x1 = 0;
+let x2 = 0;
+let y1 = 0;
+let y2 = 0;
+let textX = 0;
+let textY = 0;
+let textAnchor = 0;
+let dy = 0;
 
 $: x1 = direction === 'vertical' ? locationCoord : lineStartCoord;
 $: x2 = direction === 'vertical' ? locationCoord : lineEndCoord;
@@ -64,17 +65,21 @@ $: textY = direction === 'vertical' ? textEndCoord : locationCoord;
 $: textAnchor = direction === 'vertical' ? 'middle' : 'start';
 $: dy = direction === 'vertical' ? 0 : '.35em';
 
-
 // let mounted = false;
 onMount(() => {
-  // mounted = true;
   scaling.set(0);
+});
+
+onDestroy(() => {
+  orders[key] -= 1;
+  if (orders[key] === 0) delete orders[key];
 });
 
 </script>
 
 
   <g style="opacity: {1 - Math.abs($scaling)}"  class=marker>
+
       <line 
         y1={y1} 
         y2={y2} 

--- a/stories/data-graphics/distribution-plots/Histogram.stories.js
+++ b/stories/data-graphics/distribution-plots/Histogram.stories.js
@@ -5,7 +5,7 @@ import GenericProportionView from './GenericProportionView.svelte';
 import '../../../public/global.css';
 import './shared.css';
 
-storiesOf('Data Graphics|Quantile Plot', module)
+storiesOf('Data Graphics|GLAM Body Elements', module)
   .add('Quantile Explorer (numeric hists, scalar aggregations)', () => ({
     Component: GenericQuantileView,
   }))


### PR DESCRIPTION

![Kapture 2019-11-02 at 10 25 44](https://user-images.githubusercontent.com/95735/68074693-2a988280-fd5b-11e9-88ca-77144a1ef59a.gif)

- [x] creates `FirefoxReleaseVersionMarkers.svelte`, which uses the new markers + product release derived store