### PR TITLE
HU 2019-11-04

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -567,27 +567,36 @@ main .details {
 
 .body-control-row {
     display:grid;
-    grid-auto-flow: column;
-    margin-top:var(--space-2x);
-    margin-bottom:var(--space-2x);
+    width: 100%;
+    grid-template-columns: auto auto;
+    /* justify-content: stretch; */
+    justify-items: start;
+    margin-top:var(--space-base);
+    margin-bottom:var(--space-base);
+    text-align: right;
   }
 
-  .body-control-set {
+.body-control-set {
     grid-column-gap: var(--space-base);
     margin-bottom: var(--space-base);
-  }
+}
 
-  .body-control-set .body-control-set--label {
+.body-control-set .body-control-set--label {
     text-transform: uppercase;
     font-size: var(--text-01);
     padding-bottom: var(--space-1h);
     color: var(--cool-gray-500);
-  }
+}
 
-  .body-control-row .body-control-set:last-child {
+.body-control-row .body-control-set:last-child {
     justify-self: end;
-  }
+}
 
-  .body-control-row .body-control-set:last-child .body-control-set--label {
-    text-align: right;
-  }
+.body-control-row .body-control-set:first-child {
+    justify-self: start;
+}
+
+.body-control-row .body-control-set:first-child .body-control-set--label {
+    text-align: left;
+}
+

--- a/src/app/patterns/AggregationTypeSelector.svelte
+++ b/src/app/patterns/AggregationTypeSelector.svelte
@@ -71,7 +71,6 @@ label {
 </style>
 
 <div class=menu-button bind:this={button}>
-  <label>aggregation</label>
   <button class=activating-button on:click={toggle} class:active>
       <div>{aggregationInfo[currentAggregation].name}</div> <DownCarat size=16 />
   </button>

--- a/src/app/patterns/BodyControl.svelte
+++ b/src/app/patterns/BodyControl.svelte
@@ -10,6 +10,10 @@ export let sort = true;
 export let reverse = false;
 export let selected = multi ? [] : undefined;
 
+$: if (multi && sort && typeof sort === 'function') {
+  selected.sort(sort);
+}
+
 function toggle(v) {
   if (multi) {
     if (selected.includes(v)) selected = [...selected.filter((vi) => vi !== v)];

--- a/src/app/patterns/KeySelectionControl.svelte
+++ b/src/app/patterns/KeySelectionControl.svelte
@@ -2,6 +2,7 @@
 import BodyControl from './BodyControl.svelte';
 
 export let selections;
+export let sortFunction;
 export let colorMap = () => 'black';
 export let transformed = selections.map((opt) => ({
   label: opt, value: opt, labelColor: colorMap(opt),
@@ -10,8 +11,9 @@ export let transformed = selections.map((opt) => ({
 </script>
 
 <BodyControl
+  sort={sortFunction}
   options={transformed}
-    bind:selected={selections}
-    multi={true}
-    level="low"
+  bind:selected={selections}
+  multi={true}
+  level="low"
 />

--- a/src/app/patterns/KeySelectionControl.svelte
+++ b/src/app/patterns/KeySelectionControl.svelte
@@ -2,9 +2,10 @@
 import BodyControl from './BodyControl.svelte';
 
 export let selections;
+export let options;
 export let sortFunction;
 export let colorMap = () => 'black';
-export let transformed = selections.map((opt) => ({
+export let transformed = options.map((opt) => ({
   label: opt, value: opt, labelColor: colorMap(opt),
 }));
 

--- a/src/app/patterns/TimeHorizonControl.svelte
+++ b/src/app/patterns/TimeHorizonControl.svelte
@@ -1,7 +1,7 @@
 <script>
 import BodyControl from './BodyControl.svelte';
 
-export let horizon = 'ALL_TIME';
+export let horizon = 'MONTH';
 </script>
 
 <BodyControl

--- a/src/app/patterns/body/proportions/ProportionExplorerView.svelte
+++ b/src/app/patterns/body/proportions/ProportionExplorerView.svelte
@@ -37,9 +37,12 @@ const sortOrder = (a, b) => {
   return 0;
 };
 
-let proportions = getProportionKeys(transformed);
+let options = getProportionKeys(transformed);
 let cmpProportions = getProportionKeys(transformed);
 cmpProportions.sort(sortOrder);
+
+let proportions = getProportionKeys(transformed).filter((p) => cmpProportions.slice(0, 10).includes(p));
+
 
 const cmp = createCatColorMap(cmpProportions);
 
@@ -77,7 +80,7 @@ setContext('probeType', probeType);
   
     <div class=body-control-set>
         <label class=body-control-set--label>Keys</label>
-        <KeySelectionControl sortFunction={sortOrder} bind:selections={proportions} colorMap={cmp} />
+        <KeySelectionControl sortFunction={sortOrder} options={options} bind:selections={proportions} colorMap={cmp} />
     </div>
   </div>
 

--- a/src/app/patterns/body/proportions/ProportionExplorerView.svelte
+++ b/src/app/patterns/body/proportions/ProportionExplorerView.svelte
@@ -25,9 +25,23 @@ let totalAggs = Object.keys(Object.values(transformed)[0]).length;
 
 let timeHorizon = 'MONTH';
 
-let proportions = getProportionKeys(transformed);
+let latest = Object.values(Object.values(transformed)[0])[0];
 
-const cmp = createCatColorMap(proportions);
+// FIXME: slicing here for the demo.
+[latest] = latest.slice(-2);
+
+const sortOrder = (a, b) => {
+  // get latest data point and see
+  if (latest.counts[a] < latest.counts[b]) return 1;
+  if (latest.counts[a] >= latest.counts[b]) return -1;
+  return 0;
+};
+
+let proportions = getProportionKeys(transformed);
+let cmpProportions = getProportionKeys(transformed);
+cmpProportions.sort(sortOrder);
+
+const cmp = createCatColorMap(cmpProportions);
 
 setContext('probeType', probeType);
 
@@ -63,14 +77,10 @@ setContext('probeType', probeType);
   
     <div class=body-control-set>
         <label class=body-control-set--label>Keys</label>
-        <KeySelectionControl bind:selections={proportions} colorMap={cmp} />
-      <!-- <PercentileSelectionControl bind:percentiles={percentiles} /> -->
+        <KeySelectionControl sortFunction={sortOrder} bind:selections={proportions} colorMap={cmp} />
     </div>
   </div>
 
-    <!-- <div class=body-control-row class:hidden={totalAggs === 1}>
-      <InBodySelector bind:aggregationInfo={aggregationInfo} bind:currentAggregation={currentAggregation} aggregationTypes={aggregationTypes} />
-    </div> -->
   <div class=data-graphics>
     {#each Object.entries(transformed) as [key, aggs], i (key)}  
       {#each Object.entries(aggs) as [aggType, data], i (aggType + timeHorizon + probeType)}

--- a/src/app/patterns/body/quantiles/QuantileExplorerView.svelte
+++ b/src/app/patterns/body/quantiles/QuantileExplorerView.svelte
@@ -3,7 +3,7 @@ import { setContext } from 'svelte';
 import QuantileExplorerSmallMultiple from './QuantileExplorerSmallMultiple.svelte';
 import PercentileSelectionControl from '../../PercentileSelectionControl.svelte';
 import TimeHorizonControl from '../../TimeHorizonControl.svelte';
-import InBodySelector from '../../AggregationTypeSelector.svelte';
+import AggregationTypeSelector from '../../AggregationTypeSelector.svelte';
 
 import {
   byKeyAndAggregation,
@@ -18,7 +18,7 @@ const transformed = byKeyAndAggregation(data);
 
 let totalAggs = Object.keys(Object.values(transformed)[0]).length;
 
-let timeHorizon = 'ALL_TIME';
+let timeHorizon = 'MONTH';
 let percentiles = [95, 75, 50, 25, 5];
 let aggregationTypes = ['avg', 'max', 'min', 'sum'];
 let currentAggregation = aggregationTypes[0];
@@ -34,7 +34,7 @@ setContext('probeType', probeType);
   }
 
   .data-graphics {
-    margin-top: var(--space-8x);
+    margin-top: var(--space-6x);
   }
 
   .small-multiple {
@@ -62,9 +62,16 @@ setContext('probeType', probeType);
     </div>
   </div>
 
-    <div class=body-control-row class:hidden={totalAggs === 1}>
-      <InBodySelector bind:aggregationInfo={aggregationInfo} bind:currentAggregation={currentAggregation} aggregationTypes={aggregationTypes} />
-    </div>
+  {#if totalAggs > 1}
+  <div class=body-control-row>
+    <div class=body-control-set>
+      <label class=body-control-set--label>aggregation</label>
+      <AggregationTypeSelector bind:aggregationInfo={aggregationInfo} bind:currentAggregation={currentAggregation} aggregationTypes={aggregationTypes} />
+    </div>    
+  </div>
+  {/if}
+
+
 
   <div class=data-graphics>
     {#each Object.entries(transformed) as [key, aggs], i (key)}  

--- a/src/app/sections/GraphicBody.svelte
+++ b/src/app/sections/GraphicBody.svelte
@@ -1,19 +1,23 @@
 <script>
-import { onMount } from 'svelte';
 import { fade } from 'svelte/transition';
 import {
   store, dataset,
 } from '../store/store';
 
 import QuantileExplorerView from '../patterns/body/quantiles/QuantileExplorerView.svelte';
+import ProportionExplorerView from '../patterns/body/proportions/ProportionExplorerView.svelte';
 
 function isScalarData(data) {
-  return data && data[0].metadata.metric_type.includes('scalar');
+  return (data && $store.probe.type === 'scalar' && $store.probe.kind === 'uint');
 }
 
 function isNumericHistogramData(data) {
-  return data && (data[0].metadata.metric_type === 'histogram-exponential' || data[0].metadata.metric_type
-    === 'histogram-linear');
+  return data && $store.probe.type === 'histogram' && ($store.probe.kind === 'linear' || $store.probe.kind === 'exponential');
+}
+
+function isCategoricalData(data) {
+  return data && (($store.probe.type === 'histogram' && $store.probe.kind === 'enumerated')
+  || $store.probe.kind === 'categorical' || $store.probe.kind === 'flag' || $store.probe.kind === 'boolean');
 }
 
 let container;
@@ -23,8 +27,6 @@ let width;
 
 <style>
 .graphic-body-container {
-    /* padding: var(--space-4x);
-    padding-top: var(--space-2x); */
     overflow-y: auto;
     height: calc(100vh - var(--header-height));
     background-color: white;
@@ -83,6 +85,8 @@ let width;
                         <QuantileExplorerView data={data.response} probeType='scalar' />
                     {:else if isNumericHistogramData(data.response)}
                         <QuantileExplorerView data={data.response} probeType='histogram' />
+                    {:else if isCategoricalData(data.response)}
+                        <ProportionExplorerView data={data.response} probeType={`${$store.probe.type}-${$store.probe.kind}`}  />
                     {:else}
                         <pre>
                             {JSON.stringify(data, null, 2)}

--- a/src/app/utils/probe-utils.js
+++ b/src/app/utils/probe-utils.js
@@ -41,6 +41,7 @@ export const prepareForQuantilePlot = (probeData, key = 'version') => probeData.
     histogram,
     percentiles,
     transformedPercentiles,
+    version: probe.metadata.version,
     audienceSize: probe.data[0].total_users,
   };
 });
@@ -67,6 +68,7 @@ export const prepareForProportionPlot = (probeData, key = 'version', prepareArgs
   return {
     label: probe.metadata[key],
     counts,
+    version: probe.metadata.version,
     proportions,
     audienceSize: probe.data[0].total_users,
   };

--- a/src/components/ButtonGroup.svelte
+++ b/src/components/ButtonGroup.svelte
@@ -1,9 +1,13 @@
+<script>
 
+
+</script>
 
 <style>
 div {
   display:grid;
-  grid-auto-flow: column;
+  grid-template-columns: repeat(10, max-content);
+  grid-row-gap: var(--space-base);
   width: max-content;
 }
 
@@ -23,6 +27,6 @@ div :global(button:last-child) {
 
 </style>
 
-<div class=button-group>
+<div class=button-group style="">
   <slot></slot>
 </div>

--- a/src/components/data-graphics/utils/color-maps.js
+++ b/src/components/data-graphics/utils/color-maps.js
@@ -21,6 +21,9 @@ export function createCatColorMap(options) {
   const getID = (value) => options.findIndex((v) => v === value);
   return function catColorMap(v) {
     const i = getID(v);
+    if (i >= 10) {
+      return 'var(--cool-gray-200)';
+    }
     return schemeTableau10[i];
   };
 }


### PR DESCRIPTION
![Kapture 2019-11-04 at 8 19 52](https://user-images.githubusercontent.com/95735/68139320-ca324e00-fede-11e9-9278-2a5a544315db.gif)


- [x] tweaks / fixes to styling for body selectors
- [x] irons out some issues where the proportion viewer encounters a huge number of buckets (like for `gc_reason_2`) – sorts the comparison table by the latest build's values (largest first), disables far tail buckets by default (reducing first-load noise), etc.
- [x] uses the probe dict API to determine what type of explorer to use (for now)
- [x] integrates current draft of `ProportionExplorerView.svelte` into the GLAM body