### PR TITLE
adds percentiles to query string

### DIFF
--- a/src/app/state/store.js
+++ b/src/app/state/store.js
@@ -136,6 +136,7 @@ function getParamsForQueryString(obj) {
     timeHorizon: obj.timeHorizon,
     proportionMetricType: obj.proportionMetricType,
     activeBuckets: obj.activeBuckets,
+    visiblePercentiles: obj.visiblePercentiles,
   };
 }
 


### PR DESCRIPTION
This was missing from the large PR from yesterday – the percentile choices were not being captured in the querystring.