### PR TITLE
add percentile table prototype as story

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -601,3 +601,10 @@ main .details {
     text-align: left;
 }
 
+.percentile-label-block {
+    display: inline-block;
+    width: var(--space-base);
+    height: var(--space-base);
+    border-radius: var(--space-1q);
+    margin-right: var(--space-1h);
+  }

--- a/src/app/patterns/ViewTypeSelector.svelte
+++ b/src/app/patterns/ViewTypeSelector.svelte
@@ -4,8 +4,8 @@ import MenuList from '../../components/menu/MenuList.svelte';
 import MenuListItem from '../../components/menu/MenuListItem.svelte';
 import DownCarat from '../../components/icons/DownCarat.svelte';
 
-export let aggregationTypes;
-export let currentAggregation;
+// export let aggregationTypes;
+export let currentView;
 export let active;
 
 let button;
@@ -17,20 +17,24 @@ function toggle() {
 }
 
 function setValue(event) {
-  currentAggregation = event.detail.key;
+  currentView = event.detail.key;
   active = false;
 }
 
-export let aggregationInfo = {
-  avg: { name: 'Average', description: 'Shows the distribution of the average scalar value per client.' },
-  min: { name: 'Minimum', description: 'Shows the distribution of the smallest scalar value per client.' },
-  max: { name: 'Maximum', description: 'Shows the distribution of the largest scalar value per client.' },
-  sum: { name: 'Sum', description: 'Shows the distribution of the sum of scalar values per client.' },
+export let viewInfo = {
+  explorer: { name: 'Explorer', description: 'Observe trends over time and compare two probes.' },
+  table: { name: 'Table', description: 'Get a table of percentile / proportion values over many builds.' },
 };
+
+$: console.log(active);
 
 </script>
 
 <style>
+
+div {
+  width: max-content;
+}
 
 .activating-button {
   padding: var(--space-1h);
@@ -66,7 +70,7 @@ export let aggregationInfo = {
 
 <div class=menu-button bind:this={button}>
   <button class=activating-button on:click={toggle} class:active>
-      <div>{aggregationInfo[currentAggregation].name}</div> <DownCarat size=16 />
+      <div>{viewInfo[currentView].name}</div> <DownCarat size=16 />
   </button>
 </div>
 
@@ -79,10 +83,10 @@ export let aggregationInfo = {
     parent={button}
   >
     <MenuList  on:selection={setValue}>
-      {#each aggregationTypes as agg, i}
-        <MenuListItem  key={agg} value={agg}>
-          <div class=menu-list-item__title>{aggregationInfo[agg].name}</div>
-          <div class=menu-list-item__description>{aggregationInfo[agg].description}</div>
+      {#each Object.entries(viewInfo) as [k, v], i}
+        <MenuListItem  key={k} value={k}>
+          <div class=menu-list-item__title>{v.name}</div>
+          <div class=menu-list-item__description>{v.description}</div>
         </MenuListItem>  
       {/each}
     </MenuList>

--- a/src/app/patterns/body/elements/BuildIDComparison.svelte
+++ b/src/app/patterns/body/elements/BuildIDComparison.svelte
@@ -2,7 +2,6 @@
 import { onMount } from 'svelte';
 import { writable, derived } from 'svelte/store';
 
-import { symbol, symbolStar as referenceSymbol } from 'd3-shape';
 
 import DataGraphic from '../../../../components/data-graphics/DataGraphic.svelte';
 import LeftAxis from '../../../../components/data-graphics/LeftAxis.svelte';
@@ -11,6 +10,7 @@ import TopAxis from '../../../../components/data-graphics/TopAxis.svelte';
 import GraphicBody from '../../../../components/data-graphics/GraphicBody.svelte';
 import BuildIDRollover from '../../../../components/data-graphics/rollovers/BuildIDRollover.svelte';
 import Line from '../../../../components/data-graphics/LineMultiple.svelte';
+import ReferenceSymbol from './ReferenceSymbol.svelte';
 
 import FirefoxReleaseVersionMarkers from './FirefoxReleaseVersionMarkers.svelte';
 
@@ -156,12 +156,7 @@ fill="var(--cool-gray-100)" />
 
   {/each}
   {#each metricKeys.map((m) => extractMouseoverValues(m, reference)) as {label, bin, value}, i (bin)}
-  <g style="transform:translate({xScale(label)}px, {yScale(value)}px)">
-      <path 
-        d={symbol().type(referenceSymbol).size(20)()} 
-        fill={lineColorMap(bin)}
-      />
-    </g>
+    <ReferenceSymbol xLocation={xScale(label)} yLocation={yScale(value)} color={lineColorMap(bin)} />
   {/each}
  {/if}
 

--- a/src/app/patterns/body/elements/ComparisonSummary.svelte
+++ b/src/app/patterns/body/elements/ComparisonSummary.svelte
@@ -114,14 +114,6 @@ td, th {
 
 }
 
-.summary-color-label {
-  display: inline-block;
-  width: var(--space-base);
-  height: var(--space-base);
-  border-radius: var(--space-1q);
-  margin-right: var(--space-1h);
-}
-
 .small-shape {
   padding-left:var(--space-1h);
 }
@@ -147,7 +139,7 @@ td, th {
           {#each displayValues as {leftValue, rightValue, percentageChange, key}}
             <tr>
               <td class=value-label>
-                <span class='summary-color-label'
+                <span class=percentile-label-block
                 style="background-color:{colorMap(key)}"></span>{keyFormatter(key)}</td>
               <td class=value-left>{left ? valueFormatter(leftValue) : ' '}</td>
               <td class=value-right>{right ? valueFormatter(rightValue) : ' '}</td>

--- a/src/app/patterns/body/elements/DistributionComparison.svelte
+++ b/src/app/patterns/body/elements/DistributionComparison.svelte
@@ -1,14 +1,12 @@
 <script>
 import { onMount } from 'svelte';
 import { fade } from 'svelte/transition';
-import {
-  symbol, symbolStar as referenceSymbol,
-} from 'd3-shape';
 
 import DataGraphic from '../../../../components/data-graphics/DataGraphic.svelte';
 import BottomAxis from '../../../../components/data-graphics/BottomAxis.svelte';
 import RightAxis from '../../../../components/data-graphics/RightAxis.svelte';
 import Violin from '../../../../components/data-graphics/ViolinPlotMultiple.svelte';
+import ReferenceSymbol from './ReferenceSymbol.svelte';
 
 import { nearestBelow } from '../../../../utils/stats';
 
@@ -108,12 +106,7 @@ $: if (leftPercentiles && leftPercentiles) {
       r=2
       fill={color}
     />
-    <g style="transform:translate({rightPlot}px, {rightY}px)">
-      <path 
-        d={symbol().type(referenceSymbol).size(20)()} 
-        fill={color}
-      />
-  </g>
+    <ReferenceSymbol xLocation={rightPlot} yLocation={rightY} color={color} />
   {/each}
 {/if}
 

--- a/src/app/patterns/body/elements/Pagination.svelte
+++ b/src/app/patterns/body/elements/Pagination.svelte
@@ -1,0 +1,34 @@
+<script>
+import { createEventDispatcher } from 'svelte';
+import Button from '../../../../components/Button.svelte';
+import LeftCarat from '../../../../components/icons/LeftCarat.svelte';
+import RightCarat from '../../../../components/icons/RightCarat.svelte';
+
+export let totalPages;
+export let currentPage;
+
+const msg = createEventDispatcher();
+
+function changePage(v) {
+  msg('page', {
+    page: Math.max(Math.min(totalPages - 1, v), 0),
+  });
+}
+
+</script>
+
+<style>
+
+div {
+  display: grid;
+  grid-template-columns: max-content max-content auto;
+  grid-column-gap: var(--space-1h);
+}
+
+</style>
+
+<div>
+  <Button on:click={() => changePage(currentPage - 1)} level=low compact><LeftCarat size={10} /></Button>
+  <Button on:click={() => changePage(currentPage + 1)} level=low compact><RightCarat size={10} /></Button>
+    page {currentPage + 1} of {totalPages}
+</div>

--- a/src/app/patterns/body/elements/Pagination.svelte
+++ b/src/app/patterns/body/elements/Pagination.svelte
@@ -21,14 +21,15 @@ function changePage(v) {
 
 div {
   display: grid;
-  grid-template-columns: max-content max-content auto;
+  grid-template-columns: auto max-content max-content;
   grid-column-gap: var(--space-1h);
+  align-items: center;
 }
 
 </style>
 
 <div>
+    page {currentPage + 1} of {totalPages}
   <Button on:click={() => changePage(currentPage - 1)} level=low compact><LeftCarat size={10} /></Button>
   <Button on:click={() => changePage(currentPage + 1)} level=low compact><RightCarat size={10} /></Button>
-    page {currentPage + 1} of {totalPages}
 </div>

--- a/src/app/patterns/body/elements/QuantileRow.svelte
+++ b/src/app/patterns/body/elements/QuantileRow.svelte
@@ -40,7 +40,7 @@ let audienceXScale;
 let mounted = false;
 
 let audienceGraph = {
-  width: 150,
+  width: 130,
   height: 16,
 };
 
@@ -123,15 +123,24 @@ tr td.data-cell--graphic:hover {
   color: var(--cool-gray-500);
   font-family: var(--main-mono-font);
 }
+
+.build-id__date {
+  font-weight: bold;
+  color: var(--cool-gray-500);
+}
 </style>
 
 <tr class:reference={isReference} on:mouseout={() => { hovered = false; }} on:mouseover={() => { hovered = true; }} on:click={() => { onClick(datum); }}>
     <td class=data-cell--main>
       <div>
-        <div class=overline--small>Firefox {datum.version}</div>
+        <!-- <div class=overline--small>Firefox {datum.version}</div> -->
         <div class=build-id>
-          <span>{datum.label.slice(0, 4)}</span>-<span>{datum.label.slice(4, 6)}</span>-<span>{datum.label.slice(6, 8)}</span>
+          <div class=build-id__date>
+            <span>{datum.label.slice(0, 4)}</span>-<span>{datum.label.slice(4, 6)}</span>-<span>{datum.label.slice(6, 8)}</span>
+          </div>
+          <div>
           {datum.label.slice(8, 10)}:{datum.label.slice(10, 12)}:{datum.label.slice(12, 14)}
+        </div>
         </div>
       </div>
     </td>

--- a/src/app/patterns/body/elements/QuantileTable.svelte
+++ b/src/app/patterns/body/elements/QuantileTable.svelte
@@ -2,8 +2,18 @@
 import DataGraphic from '../../../../components/data-graphics/DataGraphic.svelte';
 import TopAxis from '../../../../components/data-graphics/TopAxis.svelte';
 import QuantileRow from './QuantileRow.svelte';
+import Pagination from './Pagination.svelte';
+
+import { percentileLineColorMap } from '../../../../components/data-graphics/utils/color-maps';
 
 export let data;
+export let pageSize = 30;
+export let currentPage = 0;
+export let probeType = 'histogram';
+
+
+let totalPages;
+$: totalPages = Math.ceil(data.length / pageSize);
 
 let reference = data[0];
 
@@ -15,6 +25,22 @@ function setReference(r) {
 function diff(a, b) {
   return (b - a) / a;
 }
+
+function getDomain() {
+  return (probeType === 'histogram') ? data[0].histogram.map((h) => h.bin)
+    : [Math.min, Math.max].map((f) => f(...data.map((d) => f(...Object.values(d.percentiles)))));
+}
+
+let xDomain = getDomain();
+let distributionScaleType = 'log';
+if (probeType === 'histogram') {
+  distributionScaleType = 'scalePoint';
+} else if (xDomain[1] < 1000) {
+  distributionScaleType = 'linear';
+} else {
+  distributionScaleType = 'log';
+}
+
 </script>
 
 <style>
@@ -29,7 +55,7 @@ thead tr th {
   top: 0;
 }
 
-.header-cell {
+.header-cell, .footer-cell {
   border-bottom: 2px solid var(--cool-gray-200);
   background-color: white;
   text-align: right;
@@ -44,8 +70,18 @@ thead tr th {
   /* padding-top: var(--space-2x); */
 }
 
+.footer-cell {
+  border: none;
+  border-top: 2px solid var(--cool-gray-200);
+}
+
 .header-cell--text {
   padding-bottom: var(--space-base);
+}
+
+.header-cell--percentile {
+  padding-left: var(--space-base);
+  padding-right: var(--space-base);
 }
 
 .header-cell--dg-scales {
@@ -54,15 +90,18 @@ thead tr th {
 }
 
 </style>
-
-
     <table class=data-table>
       <thead>
         <tr>
-          <th class="header-cell header-cell--text"></th>
+          <th class="header-cell header-cell--text">
+            <!-- pagination goes here -->
+            {#if totalPages > 1}
+              <Pagination on:page {currentPage} {totalPages} />
+            {/if}
+          </th>
           <th class="header-cell header-cell--text">Clients</th>
           {#each Object.keys(data[0].percentiles) as p, i (p + data[0].percentiles[p])}
-            <th class="header-cell header-cell--text">{p}%</th>
+            <th class="header-cell header-cell--text header-cell--percentile"><span class=percentile-label-block style="background-color: {percentileLineColorMap(+p)}"></span>{p}%</th>
           {/each}
           <th class="header-cell header-cell--dg-scales">
               <DataGraphic
@@ -73,8 +112,9 @@ thead tr th {
               right={10}
               bottom={0}
               key="header-scale"
-              xDomain={data[0].histogram.map((d) => d.bin)}
+              xDomain={xDomain}
               yDomain={['top', 'bottom']}
+              xType={distributionScaleType}
             >
               <TopAxis tickCount=6 />
             </DataGraphic>
@@ -82,14 +122,24 @@ thead tr th {
         </tr>
       </thead>
       <tbody>
-        {#each data.slice(0, 30) as datum, i (datum.label)}
+        {#each data.slice(currentPage * pageSize, (currentPage + 1) * pageSize) as datum, i (datum.label)}
           <QuantileRow 
             datum={datum} 
             reference={reference}
             biggestAudience={biggestAudience} 
-            isReference={datum.label === reference.label} 
+            isReference={datum.label === reference.label}
+            distributionScaleType={distributionScaleType}
+            xDomain={xDomain}
             on:click={setReference} />
-          
         {/each}
+        {#if totalPages > 1}
+        <tr>
+            <td class="header-cell footer-cell header-cell--text">
+                <Pagination on:page {currentPage} {totalPages} />
+            </td>
+            <td class="header-cell footer-cell" colspan=100></td>
+          </tr>
+        {/if}
+        
       </tbody>
     </table>

--- a/src/app/patterns/body/elements/ReferenceSymbol.svelte
+++ b/src/app/patterns/body/elements/ReferenceSymbol.svelte
@@ -1,0 +1,14 @@
+<script>
+import { symbol, symbolStar as referenceSymbol } from 'd3-shape';
+
+export let xLocation;
+export let yLocation;
+export let color = 'black';
+</script>
+
+<g style="transform:translate({xLocation}px, {yLocation}px)">
+    <path 
+      d={symbol().type(referenceSymbol).size(20)()} 
+      fill={color}
+    />
+  </g>

--- a/src/app/patterns/body/quantiles/QuantileExplorerView.svelte
+++ b/src/app/patterns/body/quantiles/QuantileExplorerView.svelte
@@ -50,7 +50,6 @@ function makeSelection(type) {
   }
 </style>
 
-
 <div class=body-content>
   
   <div class=body-control-row>

--- a/src/app/sections/GraphicBody.svelte
+++ b/src/app/sections/GraphicBody.svelte
@@ -10,7 +10,6 @@ import {
 import QuantileExplorerView from '../patterns/body/quantiles/QuantileExplorerView.svelte';
 import ProportionExplorerView from '../patterns/body/proportions/ProportionExplorerView.svelte';
 
-
 import { firefoxVersionMarkers } from '../state/product-versions';
 
 function isScalarData(data) {
@@ -25,7 +24,6 @@ function isCategoricalData() {
   return (($store.probe.type === 'histogram' && $store.probe.kind === 'enumerated')
   || $store.probe.kind === 'categorical' || $store.probe.kind === 'flag' || $store.probe.kind === 'boolean');
 }
-
 
 let probeName;
 let output = Promise.resolve({});
@@ -114,7 +112,9 @@ function handleBodySelectors(event) {
 
     <div class=graphic-body__graphic-header>
     {#if $store.probe.name}
-        <h2 class='heading--03'>{$store.probe.name}</h2>
+        <h2 class='heading--03'>
+          {$store.probe.name}
+        </h2>
     {:else}
         <h2 class='heading--04'>Telemetry Prototype</h2>
     {/if}

--- a/src/components/icons/LeftCarat.svelte
+++ b/src/components/icons/LeftCarat.svelte
@@ -1,0 +1,8 @@
+<script>
+export let size = 24;
+</script>
+
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 16 16"><path fill="context-fill" d="M6.414 8l4.293-4.293a1 1 0 0 0-1.414-1.414l-5 5a1 1 0 0 0 0 1.414l5 5a1 1 0 0 0 1.414-1.414z"></path></svg>

--- a/src/components/icons/RightCarat.svelte
+++ b/src/components/icons/RightCarat.svelte
@@ -1,0 +1,8 @@
+<script>
+export let size = 24;
+</script>
+
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 16 16"><path fill="context-fill" d="M6 14a1 1 0 0 1-.707-1.707L9.586 8 5.293 3.707a1 1 0 0 1 1.414-1.414l5 5a1 1 0 0 1 0 1.414l-5 5A1 1 0 0 1 6 14z"></path></svg>

--- a/stories/data-graphics/table/QuantileTable.svelte
+++ b/stories/data-graphics/table/QuantileTable.svelte
@@ -1,24 +1,75 @@
 <script>
 import QuantileTable from '../../../src/app/patterns/body/elements/QuantileTable.svelte';
+import NAV_URL from '../../../tests/data/browser_engagement_navigation_urlbar_build_id.json';
+import ACTIVE_TICKS from '../../../tests/data/browser_engagement_active_ticks_build_id.json';
 import GCMS from '../../../tests/data/gc_ms_build_id.json';
 
-import {
-  byKeyAndAggregation,
-} from '../../../src/app/utils/probe-utils';
+import { responseToData } from '../../../src/app/state/store';
 
-let data = byKeyAndAggregation(GCMS.response)[undefined]['summed-histogram'];
+// import { firefoxVersionMarkers } from '../../../src/app/state/product-versions';
 
-data.reverse();
-data = data.slice(1);
+let which = 0;
+// only get the first key
+
+function getExampleData(data) {
+  let dataset = [...Object.values(Object.values(data)[0])[0]];
+  dataset = dataset.slice(0, -1);
+  dataset.reverse();
+  return dataset;
+}
+
+let probes = [
+
+  {
+    name: 'browser_engagement_active_ticks',
+    data: responseToData(ACTIVE_TICKS.response),
+    probeType: 'scalar',
+  }, {
+    name: 'gc_ms',
+    data: responseToData(GCMS.response),
+    probeType: 'histogram',
+  },
+
+  {
+    name: 'browser_engagement_navigation_urlbar',
+    data: responseToData(NAV_URL.response),
+    probeType: 'scalar',
+  },
+];
+
+let currentPage = 0;
+
+function updatePage(event) {
+  currentPage = event.detail.page;
+}
+
+$: if (which) currentPage = 0;
 
 </script>
 
 
 <div class=story>
-  <h1 class=story__title>
-    NOTE: this is a WIP.
-  </h1>
+    <div class='view-header'>
+        <h1>Quantile Table</h1>
+        <div class='selectors'>
+          {#each probes as {name, data}, i}
+            <label>
+              <input type=radio bind:group={which} value={i}>
+              {name}
+            </label>
+          {/each}
+          </div>
+    </div>
   <div style='width: 936px'>
-    <QuantileTable data={data} />
+    {#each probes as probe, i}
+      {#if i === which}
+        <QuantileTable 
+          on:page={updatePage} 
+          {currentPage} 
+          data={getExampleData(probe.data)}
+          probeType={probe.probeType} />
+      {/if}
+    {/each}
+    
   </div>
 </div>

--- a/stories/glean-design-stories.css
+++ b/stories/glean-design-stories.css
@@ -57,3 +57,30 @@ body  {
 hr {
   border: 1px solid var(--cool-gray-200);
 }
+
+.view-header {
+  display: grid;
+  grid-template-columns: auto max-content;
+  font-family: var(--main-mono-font);
+  border-bottom: 3px solid var(--cool-gray-200);
+  margin-bottom: var(--space-4x);
+}
+
+.view-header h1 {
+  font-weight: normal;
+  margin:0px;
+}
+
+.selectors {
+  position: relative;
+  width: max-content;
+  font-size: var(--text-02);
+  font-family: var(--main-mono-font);
+  margin-bottom: var(--space-4x);
+  padding: var(--space-4x);
+  border-radius: var(--space-base);
+  box-shadow: var(--depth-tiny);
+  z-index:1000;
+  background-color: white;
+  color: var(--blue-slate-600);
+}


### PR DESCRIPTION
![Kapture 2019-11-13 at 6 36 28](https://user-images.githubusercontent.com/95735/68773183-fab17080-05df-11ea-98c8-cedaa97becb1.gif)

This PR adds the percentile table as a story but does not integrate it. There is some UX work to be done to figure out exactly how it should be fit in the app, but I'm going to merge this as-is so that the story is there for demoing.

Future revisions forthcoming