### PR TITLE
moves build ID scales to actual date scales (vs. scalePoint)

### DIFF
--- a/src/app/patterns/elements/FirefoxReleaseVersionMarkers.svelte
+++ b/src/app/patterns/elements/FirefoxReleaseVersionMarkers.svelte
@@ -3,9 +3,6 @@ import { getContext } from 'svelte';
 import Marker from '../../../components/data-graphics/guides/Marker.svelte';
 import { firefoxVersionMarkers } from '../../state/product-versions';
 
-import {
-  dateToBuildID,
-} from '../utils/build-id-utils';
 
 export let labels = true;
 
@@ -19,8 +16,8 @@ firefoxVersionMarkers.subscribe((m) => { markers = m; });
 
 <g class='firefox-release-version-markers'>
   {#if markers && markers.length}
-    {#each markers.map(({ date, label }) => ({ label, date: dateToBuildID(xScale, date) }))
-      .filter((d) => d.date !== undefined) as {label, date}, i (date)}
+    {#each markers
+      .filter((d) => d.date !== undefined && d.date >= xScale.domain()[0] && d.date <= xScale.domain()[1]) as {label, date}, i (date)}
       <Marker location={date}>
         {#if labels}
           {label}

--- a/src/app/patterns/explorer/CompareOverTimeGraph.svelte
+++ b/src/app/patterns/explorer/CompareOverTimeGraph.svelte
@@ -77,9 +77,11 @@ let H;
 let T;
 let B;
 let L;
+let R;
 let bodyHeight;
 let topPlot;
 let leftPlot;
+let rightPlot;
 let bottomPlot;
 let dgRollover;
 let margins;
@@ -166,21 +168,26 @@ $: if (xScale) {
     refLabelPlacement = xScale(reference.label) - referenceWidth / 2;
   }
   if (aggregationLevel === 'build_id') {
-    const refPoint = g(data, reference.label, 'label', xDomain);
-    let r;
-    let prior;
-    let next;
-    if (!refPoint) {
-      prior = reference.index;
-      next = prior + 1;
-    } else {
-      r = refPoint.index;
-      prior = data[r].label <= xDomain[0] ? r : r - 1;
-      next = data[r].label >= xDomain[1] ? r : r + 1;
-    }
+    if (data.length > 1) {
+      const refPoint = g(data, reference.label, 'label', xDomain);
+      let r;
+      let prior;
+      let next;
+      if (!refPoint) {
+        prior = reference.index;
+        next = prior + 1;
+      } else {
+        r = refPoint.index;
+        prior = data[r].label <= xDomain[0] ? r : r - 1;
+        next = data[r].label >= xDomain[1] ? r : r + 1;
+      }
 
-    referenceWidth = (xScale(data[next].label) - xScale(data[prior].label)) / 2;
-    refLabelPlacement = xScale(data[prior].label) + referenceWidth / 2;
+      referenceWidth = (xScale(data[next].label) - xScale(data[prior].label)) / 2;
+      refLabelPlacement = xScale(data[prior].label) + referenceWidth / 2;
+    } else {
+      referenceWidth = rightPlot - leftPlot;
+      refLabelPlacement = leftPlot - (rightPlot - leftPlot) / 2;
+    }
   }
 }
 const refLabelSpring = spring(refLabelPlacement, { damping: 0.9, stiffness: 0.3 });
@@ -219,6 +226,7 @@ $: if (dataGraphicMounted) {
   B.subscribe((b) => { bottomPlot = b; });
   H.subscribe((h) => { bodyHeight = h; });
   L.subscribe((l) => { leftPlot = l; });
+  R.subscribe((r) => { rightPlot = r; });
 }
 
 // handle Ref element hover-over placement.
@@ -254,6 +262,7 @@ $: if (referenceTextElement && referenceBackgroundElement) {
  bind:bodyHeight={H}
  bind:topPlot={T}
  bind:leftPlot={L}
+ bind:rightPlot={R}
  bind:bottomPlot={B}
  bind:margins={margins}
  right={buildIDComparisonGraph.right}
@@ -283,7 +292,8 @@ $: if (referenceTextElement && referenceBackgroundElement) {
 
   {/if}
   <!-- this is the reference rect -->
-    {#if aggregationLevel === 'build_id'}
+  
+  {#if aggregationLevel === 'build_id'}
     <rect
       bind:this={referenceBackgroundElement}
       x={$refLabelSpring} 

--- a/src/app/patterns/explorer/CompareOverTimeGraph.svelte
+++ b/src/app/patterns/explorer/CompareOverTimeGraph.svelte
@@ -287,8 +287,19 @@ $: if (referenceTextElement && referenceBackgroundElement) {
     />
   {/if}
   <!-- this is the hovered value rect -->
-  <!-- <rect x={xScale(hovered.x) - xScale.step() / 2} y={topPlot} width={xScale.step()} height={bodyHeight}
-    fill="var(--cool-gray-100)" /> -->
+  {#if aggregationLevel === 'build_id'}
+  <rect 
+    x={(xScale(hovered.prior.label)) + (xScale(hovered.next ? hovered.next.label : hovered.x) - xScale(hovered.prior.label)) / 4}
+    y={topPlot} 
+    width={(xScale(hovered.next ? hovered.next.label : hovered.x) - xScale(hovered.prior.label)) / 2}
+    height={bodyHeight}
+    fill="var(--cool-gray-100)"
+  />
+  {:else}
+  <rect x={xScale(hovered.x) - xScale.step() / 2} y={topPlot} width={xScale.step()} height={bodyHeight}
+    fill="var(--cool-gray-100)" />
+  {/if}
+  
 
   {/if}
   <!-- this is the reference rect -->

--- a/src/app/patterns/explorer/ComparisonSummary.svelte
+++ b/src/app/patterns/explorer/ComparisonSummary.svelte
@@ -1,6 +1,6 @@
 <script>
 import { format } from 'd3-format';
-
+import Tweenable from '../../../components/data-graphics/motion/Tweenable.svelte';
 
 let fmt = format(',.4r');
 let pFmt = format('.0%');
@@ -185,11 +185,20 @@ td, th {
                 style="background-color:{colorMap(key)}"></span>{keyFormatter(key)}</td>
 
               {#if showLeft}
-              <td  class:hidden={!hovered} class=value-left>{left ? valueFormatter(leftValue) : ' '}</td>
+              <td  class:hidden={!hovered} class=value-left>
+                  {leftValue ? valueFormatter(leftValue) : ' '}
+              </td>
               {/if}
 
               {#if showRight}
-              <td class=value-right>{right ? valueFormatter(rightValue) : ' '}</td>
+              <td class=value-right>
+                  {#if rightValue}
+                  <Tweenable value={rightValue} let:tweenValue>{valueFormatter(tweenValue)}</Tweenable>
+                {:else}
+                    {' '}
+                {/if}
+                <!-- {right ? valueFormatter(rightValue) : ' '} -->
+              </td>
               {/if}
 
               {#if showDiff}

--- a/src/app/patterns/explorer/ProbeExplorer.svelte
+++ b/src/app/patterns/explorer/ProbeExplorer.svelte
@@ -14,11 +14,6 @@ import { formatBuildIDToDateString } from '../utils/formatters';
 
 import { histogramSpring } from '../utils/animation';
 
-import {
-  buildIDToDate,
-} from '../utils/build-id-utils';
-
-
 import { extractBinValues } from '../../utils/probe-utils';
 
 export let data;
@@ -78,12 +73,6 @@ $: if (aggregationLevel === 'build_id') setDomain(timeHorizon);
 
 export let hovered = !hoverActive ? { x: data[0].label, datum: data[0] } : {};
 export let reference = data[data.length - 1];
-
-// const movingAudienceSize = tweened(0, { duration: 500, easing });
-
-// const refMedian = tweened(reference.percentiles[50], { duration: 500, easing });
-// $: movingAudienceSize.set(reference.audienceSize);
-// $: refMedian.set(reference.percentiles[50]);
 
 function getBinValueFromMouseover(datum) {
   let out = {};

--- a/src/app/patterns/explorer/ProbeExplorer.svelte
+++ b/src/app/patterns/explorer/ProbeExplorer.svelte
@@ -48,17 +48,30 @@ $: hoverActive = data.length > 2;
 let insufficientData = data.length <= 2;
 $: insufficientData = data.length <= 2;
 
-let domain = writable(data.map((d) => d.label));
+let domain = writable(aggregationLevel === 'version' ? data.map((d) => d.label) : [
+  new Date(Math.min(...data.map((d) => d.label))), new Date(Math.max(...data.map((d) => d.label))),
+]);
 
 function setDomain(str) {
-  const start = buildIDToDate(data[data.length - 1].label);
-  let filtered = data;
-  let daysAgo = str === 'WEEK' ? 7 : 30;
-  if (str !== 'ALL_TIME') {
-    start.setDate(start.getDate() - daysAgo);
-    filtered = data.filter((d) => buildIDToDate(d.label) >= start);
+  if (aggregationLevel === 'build_id') {
+    const start = str === 'ALL_TIME' ? new Date(+data[0].label) : new Date(+data[data.length - 1].label);
+    const end = new Date(+data[data.length - 1].label);
+
+    let daysAgo = str === 'WEEK' ? 7 : 30;
+    if (str !== 'ALL_TIME') {
+      start.setDate(start.getDate() - daysAgo);
+    }
+    domain.set([start, end]);
+  } else {
+    const start = data[data.length - 1].label;
+    let filtered = data;
+    let daysAgo = str === 'WEEK' ? 7 : 30;
+    if (str !== 'ALL_TIME') {
+      start.setDate(start.getDate() - daysAgo);
+      filtered = data.filter((d) => d.label >= start);
+    }
+    domain.set(filtered.map((d) => d.label));
   }
-  domain.set(filtered.map((d) => d.label));
 }
 
 $: if (aggregationLevel === 'build_id') setDomain(timeHorizon);
@@ -150,6 +163,7 @@ h4 {
         timeHorizon={timeHorizon}
         lineColorMap={binColorMap}
         key={key}
+        xScaleType={aggregationLevel === 'version' ? 'scalePoint' : 'time'}
         yScaleType={yScaleType}
         transform={(p, d) => extractBinValues(p, d, overTimePointMetricType)}
         yTickFormatter={yTickFormatter}

--- a/src/app/patterns/explorer/ProbeExplorer.svelte
+++ b/src/app/patterns/explorer/ProbeExplorer.svelte
@@ -73,6 +73,7 @@ $: if (aggregationLevel === 'build_id') setDomain(timeHorizon);
 
 export let hovered = !hoverActive ? { x: data[0].label, datum: data[0] } : {};
 export let reference = data[data.length - 1];
+// $: if (timeHorizon) reference = data[data.length - 1];
 
 function getBinValueFromMouseover(datum) {
   let out = {};

--- a/src/app/patterns/utils/build-id-utils.js
+++ b/src/app/patterns/utils/build-id-utils.js
@@ -1,5 +1,19 @@
 import { timeFormat, timeParse } from 'd3-time-format';
 
+// FIXME: this actually does the conversion. Remove others & uses
+const tp = timeParse('%Y%m%d%H%M%S');
+export const fullBuildIDToDate = timeParse('%Y%m%d%H%M%S');
+
+// export const fullBuildIDToDate = (b) => {
+//   const y = +b.slice(0, 4);
+//   const m = +b.slice(4, 6) - 1;
+//   const d = +b.slice(6, 8);
+//   const H = +b.slice(8, 10);
+//   const M = +b.slice(10, 12);
+//   const S = +b.slice(12, 14);
+//   return new Date(y, m, d, H, M, S);
+// };
+
 const dtFormatter = timeFormat('%Y%m%d');
 const dtParser = timeParse('%Y%m%d');
 const parse = (build) => dtParser(build.slice(0, 8));

--- a/src/app/patterns/utils/formatters.js
+++ b/src/app/patterns/utils/formatters.js
@@ -1,6 +1,17 @@
 import { format } from 'd3-format';
+import { timeFormat } from 'd3-time-format';
 
 export const formatValue = format(',.2f');
 export const formatPercent = format('.0%');
 export const formatCount = format(',d');
-export const formatBuildIDToDateString = (b) => `${b.slice(0, 4)}-${b.slice(4, 6)}-${b.slice(6, 8)} ${b.slice(8, 10)}h`;
+// export const formatBuildIDToDateString = (b) => `${b.slice(0, 4)}-${b.slice(4, 6)}-${b.slice(6, 8)} ${b.slice(8, 10)}h`;
+export const formatBuildIDToDateString = (b) => timeFormat('%Y-%m-%d %H')(b);
+const ymd = timeFormat('%Y-%m-%d');
+export const formatBuildIDToOnlyDate = (b) => ymd(b);
+export const formatToBuildID = timeFormat('%Y%m%d%H%M%S');
+// export const formatBuildIDToOnlyDate = (b) => {
+//   const y = b.getFullYear();
+//   const m = b.getMonth() + 1;
+//   const d = b.getDate();
+//   return `${y}-${m}-${d}`;
+// };

--- a/src/app/utils/probe-utils.js
+++ b/src/app/utils/probe-utils.js
@@ -153,10 +153,7 @@ function groupBy(xs, key, transform = (_) => _) {
 }
 
 export function topKBuildsPerDay(dataset, k = 2) {
-  // const byBuildID = groupBy(dataset, 'label', (buildID) => buildID.slice(0, 8));
   const byBuildID = groupBy(dataset, 'label', formatBuildIDToOnlyDate);
-  // console.log(dataset.map((d) => [formatBuildIDToOnlyDate(d.label), d.label]).filter((d) => d[0] === '2019-09-01'));
-  // by buildID, return the top 2 of each.
   const topK = Object.entries(byBuildID).map(([_, matches]) => {
     const out = matches.filter((m) => m.audienceSize > 10);
     out.sort(sortByKey('audienceSize'));

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -14,7 +14,12 @@ export let key = Math
   .substring(2, 15) + Math.random()
   .toString(36).substring(2, 15);
 
-export let xDomain;
+export let xDomainMin;
+export let xDomainMax;
+export let xDomain = [xDomainMin, xDomainMax];
+
+let internalXDomain = writable(xDomain);
+
 export let yDomain;
 export let xType = 'scalePoint';
 export let yType = 'scalePoint';

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -308,7 +308,17 @@ $: if (dataGraphicMounted) {
 
     <!-- pass the rollover value into the scale -->
     {#if dataGraphicMounted}
-      <slot name='mouseover' value={hoverValue} xScale={xScale} yScale={yScale}></slot>
+      <slot name='mouseover' 
+        value={hoverValue} 
+        xScale={xScale} 
+        yScale={yScale}
+        left={$leftPlot}
+        right={$rightPlot}
+        top={$topPlot}
+        bottom={$bottomPlot}
+        width={$graphicWidth}
+        height={$graphicHeight}
+      ></slot>
     {/if}
 
       <!-- data graphic borders -->

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -18,7 +18,7 @@ export let xDomainMin;
 export let xDomainMax;
 export let xDomain = [xDomainMin, xDomainMax];
 
-let internalXDomain = writable(xDomain);
+// let internalXDomain = writable(xDomain);
 
 export let yDomain;
 export let xType = 'scalePoint';
@@ -30,6 +30,38 @@ export let top = 50;
 export let bottom = 20;
 export let laneGap = 30;
 export let buffer = 5;
+
+// borders
+export let borderColor = 'var(--cool-gray-200)';
+export let borderThickness = 1;
+export let borderOpacity = 1;
+export let leftBorder;
+export let rightBorder;
+export let topBorder;
+export let bottomBorder;
+export let leftBorderColor = borderColor;
+export let rightBorderColor = borderColor;
+export let topBorderColor = borderColor;
+export let bottomBorderColor = borderColor;
+export let leftBorderThickness = borderThickness;
+export let rightBorderThickness = borderThickness;
+export let topBorderThickness = borderThickness;
+export let bottomBorderThickness = borderThickness;
+export let leftBorderOpacity = borderOpacity;
+export let rightBorderOpacity = borderOpacity;
+export let topBorderOpacity = borderOpacity;
+export let bottomBorderOpacity = borderOpacity;
+
+export let backgroundColor = 'transparent';
+
+let borders = [];
+$: borders = [
+  [leftBorder, leftBorderColor, leftBorderThickness, leftBorderOpacity, $leftPlot, $leftPlot, $topPlot - topBorderThickness / 2, $bottomPlot + bottomBorderThickness / 2],
+  [rightBorder, rightBorderColor, rightBorderThickness, rightBorderOpacity, $rightPlot, $rightPlot, $topPlot - topBorderThickness / 2, $bottomPlot + bottomBorderThickness / 2],
+  [topBorder, topBorderColor, topBorderThickness, topBorderOpacity, $leftPlot, $rightPlot, $topPlot, $topPlot],
+  [bottomBorder, bottomBorderColor, bottomBorderThickness, bottomBorderOpacity, $leftPlot, $rightPlot, $bottomPlot, $bottomPlot],
+];
+
 
 let xPadding = 0.5;
 export let yPadding = 0;
@@ -243,6 +275,7 @@ $: if (dataGraphicMounted) {
 
 <div class=data-graphic-container style="width: {$graphicWidth}px; height: {$graphicHeight}px;">
   <svg
+    style="width: {$graphicWidth}px; height: {$graphicHeight}px;"
     bind:this={svg}
     shape-rendering="geometricPrecision"
     viewbox='0 0 {$graphicWidth} {$graphicHeight}'
@@ -250,6 +283,11 @@ $: if (dataGraphicMounted) {
     on:mouseleave={onMouseleave}
     on:click
   >
+  <rect 
+    x={$leftPlot} y={$topPlot} width={$bodyWidth} height={$bodyHeight}
+    fill={backgroundColor}
+  />
+
   <clipPath id='graphic-body-{key}'>
       <rect
         x={$leftPlot}
@@ -267,5 +305,12 @@ $: if (dataGraphicMounted) {
     {#if dataGraphicMounted}
       <slot name='mouseover' value={hoverValue} xScale={xScale} yScale={yScale}></slot>
     {/if}
+
+      <!-- data graphic borders -->
+    {#each borders as [showBorder, color, thickness, opacity, x1, x2, y1, y2]}
+      {#if showBorder}
+        <line x1={x1} x2={x2} y1={y1} y2={y2} stroke={color} stroke-width={thickness} opacity={opacity} />
+      {/if}
+    {/each}
   </svg>
 </div>

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -1,7 +1,9 @@
 <script>
 import { setContext, getContext, onMount } from 'svelte';
 import { writable, derived } from 'svelte/store';
-import { scalePoint, scaleLinear, scaleSymlog } from 'd3-scale';
+import {
+  scalePoint, scaleLinear, scaleSymlog, scaleTime,
+} from 'd3-scale';
 
 export let data = getContext('data');
 export let svg;
@@ -129,14 +131,17 @@ setContext('bottomPlot', bottomPlot);
 // const yScaleType = yType === 'scalePoint' ? scalePoint : scaleLinear;
 
 function getScaleFunction(type) {
+  if (type === 'time') return scaleTime;
   if (type === 'scalePoint') return scalePoint;
   if (type === 'numeric' || type === 'linear') return scaleLinear;
   if (type === 'log') return scaleSymlog;
   return scalePoint;
 }
 
+// function positionScale({domain, range, scaleType, padding = .5})
+
 function createXPointScale(values) {
-  const scaleFunction = getScaleFunction(xType);// xType === 'scalePoint' ? scalePoint : scaleLinear;
+  const scaleFunction = getScaleFunction(xType);
   let scale = scaleFunction()
     .domain(values)
     .range([$leftPlot, $rightPlot]);

--- a/src/components/data-graphics/elements/Point.svelte
+++ b/src/components/data-graphics/elements/Point.svelte
@@ -5,6 +5,10 @@ export let x;
 export let y;
 export let r = 2;
 export let opacity = 1;
+export let fillOpacity = 1;
+export let stroke = 'none';
+export let strokeWidth = 0;
+export let strokeOpacity = 1;
 export let fill = 'blue';
 
 const xScale = getContext('xScale');
@@ -17,4 +21,8 @@ const yScale = getContext('yScale');
   r={r}
   fill={fill}
   opacity={opacity}
+  fill-opacity={fillOpacity}
+  stroke={stroke}
+  stroke-width={strokeWidth}
+  stroke-opacity={strokeOpacity}
 />

--- a/src/components/data-graphics/elements/Point.svelte
+++ b/src/components/data-graphics/elements/Point.svelte
@@ -1,0 +1,20 @@
+<script>
+import { getContext } from 'svelte';
+
+export let x;
+export let y;
+export let r = 2;
+export let opacity = 1;
+export let fill = 'blue';
+
+const xScale = getContext('xScale');
+const yScale = getContext('yScale');
+</script>
+
+<circle 
+  cx={xScale(x)}
+  cy={yScale(y)}
+  r={r}
+  fill={fill}
+  opacity={opacity}
+/>

--- a/src/components/data-graphics/guides/MarginText.svelte
+++ b/src/components/data-graphics/guides/MarginText.svelte
@@ -21,4 +21,5 @@ let topPlot = getContext('topPlot');
   text-anchor={justify === 'left' ? 'start' : 'end'}
 >
   {temporaryLabel}
+  <slot></slot>
 </text>

--- a/src/components/data-graphics/guides/MarginText.svelte
+++ b/src/components/data-graphics/guides/MarginText.svelte
@@ -1,0 +1,24 @@
+<script>
+import { getContext } from 'svelte';
+
+export let fontSize = 11;
+export let fill = 'var(--cool-gray-500)';
+export let temporaryLabel = '';
+export let justify = 'left';
+export let align = 'top';
+let leftPlot = getContext('leftPlot');
+let rightPlot = getContext('rightPlot');
+// let bottomPlot = getContext('bottomPlot');
+let topPlot = getContext('topPlot');
+
+</script>
+
+<text
+  font-size={fontSize}
+  fill={fill}
+  y={$topPlot - fontSize}
+  x={justify === 'left' ? $leftPlot : $rightPlot}
+  text-anchor={justify === 'left' ? 'start' : 'end'}
+>
+  {temporaryLabel}
+</text>

--- a/src/components/data-graphics/guides/SimpleAxis.svelte
+++ b/src/components/data-graphics/guides/SimpleAxis.svelte
@@ -59,7 +59,7 @@ function symLogTicks(topVal) {
 
 
 function getDefaultTicks() {
-  if (mainScale.type === 'numeric' || mainScale.type === 'linear') {
+  if (mainScale.type === 'numeric' || mainScale.type === 'linear' || mainScale.type === 'time') {
     return mainScale.ticks(tickCount);
   } if (mainScale.type === 'log') {
     return symLogTicks(mainScale.domain()[1]);
@@ -94,7 +94,7 @@ export let fadeValues = defaults.fadeParams;
 export let tickFontSize = defaults.axisTickFontSize;
 
 export let lineStyle = (side === 'left' || side === 'right') ? 'long' : 'short';
-export let tickFormatter = (t) => t;
+export let tickFormatter = mainScale.type === 'time' ? mainScale.tickFormat(tickCount) : (t) => t;
 
 export let showTicks = true;
 export let showBorder = false;

--- a/src/components/data-graphics/motion/Springable.svelte
+++ b/src/components/data-graphics/motion/Springable.svelte
@@ -1,0 +1,13 @@
+<script>
+
+import { spring } from 'svelte/motion';
+
+export let params = { stiffness: 0.8, damping: 0.9 };
+export let value = 0;
+
+const springValue = spring(value, params);
+$: springValue.set(value);
+
+</script>
+
+<slot springValue={$springValue}></slot>

--- a/src/components/data-graphics/motion/Tweenable.svelte
+++ b/src/components/data-graphics/motion/Tweenable.svelte
@@ -1,0 +1,12 @@
+<script>
+    import { tweened } from 'svelte/motion';
+    import { cubicOut as easing } from 'svelte/easing';
+    
+    export let params = { duration: 500, easing };
+    export let value = 0;
+    
+    const tweenValue = tweened(value, params);
+    $: tweenValue.set(value);
+    </script>
+    
+    <slot tweenValue={$tweenValue}></slot>

--- a/src/components/data-graphics/motion/Tweenable.svelte
+++ b/src/components/data-graphics/motion/Tweenable.svelte
@@ -1,12 +1,14 @@
 <script>
-    import { tweened } from 'svelte/motion';
-    import { cubicOut as easing } from 'svelte/easing';
-    
-    export let params = { duration: 500, easing };
-    export let value = 0;
-    
-    const tweenValue = tweened(value, params);
-    $: tweenValue.set(value);
-    </script>
-    
-    <slot tweenValue={$tweenValue}></slot>
+
+import { tweened } from 'svelte/motion';
+import { cubicOut as easing } from 'svelte/easing';
+
+export let params = { duration: 500, easing };
+export let value = 0;
+
+const tweenValue = tweened(value, params);
+$: tweenValue.set(value);
+
+</script>
+
+<slot tweenValue={$tweenValue}></slot>

--- a/src/components/data-graphics/rollovers/BuildIDRollover.svelte
+++ b/src/components/data-graphics/rollovers/BuildIDRollover.svelte
@@ -1,5 +1,6 @@
 <script>
 import { getContext, onMount } from 'svelte';
+import { formatToBuildID } from '../../../app/patterns/utils/formatters';
 
 export let xScale = getContext('xScale');
 let margins = getContext('margins');
@@ -11,6 +12,9 @@ TOP.subscribe((t) => { topPlot = t; });
 G.subscribe((w) => { graphicWidth = w; });
 export let x;
 export let label;
+
+let parsedLabel = '';
+$: parsedLabel = formatToBuildID(label);
 
 let rollover;
 
@@ -40,9 +44,9 @@ text-anchor='middle'
 font-family="var(--main-mono-font)"
 font-size='12'>
 <tspan fill="var(--cool-gray-500)" font-weight=bold>
-  {label.slice(0, 4)}-{label.slice(4,
-  6)}-{label.slice(6, 8)}{' '}</tspan> 
-<tspan> {label.slice(8, 10)}:</tspan>
-<tspan>{label.slice(10, 12)}:</tspan>
-<tspan>{label.slice(12, 14)}</tspan>
+  {parsedLabel.slice(0, 4)}-{parsedLabel.slice(4,
+  6)}-{parsedLabel.slice(6, 8)}{' '}</tspan> 
+<tspan> {parsedLabel.slice(8, 10)}:</tspan>
+<tspan>{parsedLabel.slice(10, 12)}:</tspan>
+<tspan>{parsedLabel.slice(12, 14)}</tspan>
 </text>

--- a/stories/data-graphics/data/marvel-strength-weight.json
+++ b/stories/data-graphics/data/marvel-strength-weight.json
@@ -1,0 +1,17691 @@
+[
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zebediah_Killgrave_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 167,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Spider-Man_(Peter_Parker)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Quill_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Deadpool_(Wade_Wilson)"
+    },
+    {
+        "strength": 4,
+        "weight": 195,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wolverine_(James_%22Logan%22_Howlett)"
+    },
+    {
+        "strength": 7,
+        "weight": 640,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thor_(Thor_Odinson)"
+    },
+    {
+        "strength": 6,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Iron_Man_(Anthony_%22Tony%22_Stark)"
+    },
+    {
+        "strength": 4,
+        "weight": 124,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jessica_Jones_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 128,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Hulk_(Robert_Bruce_Banner)"
+    },
+    {
+        "strength": 7,
+        "weight": 985,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thanos_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 260,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Buchanan_Barnes_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 4.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eugene_Thompson_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 535,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ultron_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Parker_(Kaine)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Victor_von_Doom_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Stephen_Strange_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Morlun_(Earth-000)"
+    },
+    {
+        "strength": 7,
+        "weight": 300,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/En_Sabah_Nur_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 132,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wanda_Maximoff_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 167,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Otto_Octavius_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 36000,
+        "height": 28.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Galactus_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 165,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Carol_Danvers_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 131,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Natalia_Romanova_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 221,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nicholas_Fury_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Daisy_Johnson_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 1200,
+        "height": 7.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Red_Hulk_(Thaddeus_Ross)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jonathan_Storm_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/T%27Challa_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Adam_Warlock_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 260,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Edward_Brock_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Katherine_Pryde_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 278,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Namor_McKenzie_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Scott_Summers_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Max_Eisenhardt_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Samuel_Wilson_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 8000,
+        "height": 23.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Groot_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 100,
+        "height": 4.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Franklin_Richards_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Henry_Pym_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 183,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Helmut_Zemo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jean_Grey_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 480,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Baymax_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Johnathon_Blaze_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 167,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Akihiro_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 500,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Benjamin_Grimm_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Reed_Richards_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 275,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sabretooth_(Victor_Creed)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Parker_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Pietro_Maximoff_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 106,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hope_Summers_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Blackagar_Boltagon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Illyana_Rasputina_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Charles_Xavier_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ororo_Munroe_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 132,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jessica_Drew_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 425,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Luke_Cage_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 194,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Robert_Reynolds_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Matthew_Murdock_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Frank_Castle_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 350,
+        "height": 6.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nathan_Summers_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 480,
+        "height": 7.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ronan_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 119,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/May_Parker_(Earth-982)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Susan_Storm_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Reed_Richards_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cletus_Kasady_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Clinton_Barton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Laura_Kinney_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 130,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jessica_Drew_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 144,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Emma_Frost_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 105,
+        "height": 5.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/The_Other_(Multiverse)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Norman_Osborn_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Miguel_O%27Hara_(Earth-928)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Raven_Darkholme_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 101,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Margaret_Carter_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 115,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mantis_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rogue_(Anna_Marie)_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 225,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Norrin_Radd_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 300,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Vision_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 55,
+        "height": 4.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rocket_Raccoon_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 680,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Arthur_Douglas_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jennifer_Walters_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hiro_Takachiho_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Kaplan_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Richard_Rider_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elizabeth_Ross_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Richard_Jones_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Felicia_Hardy_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 650,
+        "height": 6.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Odin_Borson_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 250,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Piotr_Rasputin_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 165,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Parker_(Ben_Reilly)_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 400,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Skaar_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Daniel_Rand_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Nathaniel_Grey_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 178,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gabriel_Summers_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 155,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Elizabeth_Braddock_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 115,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Anya_Corazon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Warren_Worthington_III_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 1900,
+        "height": 9.416666666666666,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Cain_Marko_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mar-Vell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 179,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Remy_LeBeau_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 310,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mephisto_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 216,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ulysses_Klaw_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 161,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kurt_Wagner_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 640,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Thor_Odinson_(Ragnarok)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 145,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Drake_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mary_Jane_Watson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Johann_Shmidt_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Marc_Spector_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 380,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Simon_Williams_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Scott_Lang_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alexander_Summers_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Tony_Masters_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 100,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Doreen_Green_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 450,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Victor_Van_Damme_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 290,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Brock_Rumlow_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 325,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hercules_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 257,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Brian_Braddock_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 129,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Leiko_Tanaka_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 126,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Aiko_Miyazaki_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sharon_Carter_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 115,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lorna_Dane_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 285,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathaniel_Essex_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 317,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tarene_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Janet_van_Dyne_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Calvin_Zabo_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 240,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Rhodes_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 402,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Henry_McCoy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jonathan_Storm_(Earth-1610)"
+    },
+    {
+        "strength": 7,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Onslaught_(Psychic_Entity)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Steven_Rogers_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 450,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Taneleer_Tivan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rachel_Summers_(Earth-811)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ezekiel_Sims_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/David_Haller_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vlad_Dracula_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 300,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Human_Torch_(Android)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 117,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Amadeus_Cho_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathaniel_Richards_(Kang)_(Earth-6311)"
+    },
+    {
+        "strength": 2,
+        "weight": 205,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Franklin_Storm_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 215,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eric_Brooks_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 174,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Charlie_Cluster-7_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Virginia_Potts_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 129,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Quintavius_Quire_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Julia_Carpenter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Crystalia_Amaquelin_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Annihilus_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/MacDonald_Gargan_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 595,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Kallark_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 660,
+        "height": 6.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Zeus_Panhellenios_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 450,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Amora_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Medusalith_Amaquelin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Madelyne_Pryor_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 40,
+        "height": 3.3333333333333335,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Valeria_Richards_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jubilation_Lee_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Antonio_Stark_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Katherine_Bishop_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 645,
+        "height": 6.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jonathan_Garrett_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 170,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Roberto_da_Costa_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Heinrich_Zemo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Barbara_Morse_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 148,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Vanessa_Carlysle_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Neena_Thurman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Howard_Stark_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 113,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sinthea_Shmidt_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 130,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Karla_Sofen_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shiro_Yoshida_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Harold_Osborn_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 130,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Selene_Gallio_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Herbert_Wyndham_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/A%27Lars_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Susan_Storm_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Wolfgang_von_Strucker_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 500,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ares_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alison_Blaire_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Monica_Rambeau_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 157,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Absolon_Mercator_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 230,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Adam_Brashear_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 157,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joshua_Foley_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 980,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Emil_Blonsky_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Owen_Reece_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 275,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lucas_Bishop_(Earth-1191)"
+    },
+    {
+        "strength": 7,
+        "weight": 285,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thor_Odinson_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maxwell_Dillon_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 2050,
+        "height": 9.166666666666666,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tryco_Slatterus_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jericho_Drumm_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 149,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Azazel_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 106,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cassandra_Lang_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 166,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nathaniel_Richards_(Iron_Lad)_(Earth-6311)"
+    },
+    {
+        "strength": 4,
+        "weight": 125,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Adriana_Soria_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 155,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thomas_Shepherd_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 292,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Howlett_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 425,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sif_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 180,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nebula_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 150,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Heather_Douglas_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Greer_Grant_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Elektra_Natchios_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 172,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Scott_Washington_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 500,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hela_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ophelia_Sarkissian_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 110,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rahne_Sinclair_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 270,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Walker_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 475,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Brunnhilde_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 47,
+        "height": 3.8333333333333335,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Luna_Maximoff_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Maximus_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arnim_Zola_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bullseye_(Lester)_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 460,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mark_Milton_(Earth-712)"
+    },
+    {
+        "strength": 1,
+        "weight": 70,
+        "height": 1.9166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cosmo_(Dog)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Megan_Gwynn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Parker_Robbins_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 270,
+        "height": 7.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Caiera_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Silver_Sablinova_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eros_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 165,
+        "height": 4.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Harvey_Elder_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 450,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Wilson_Fisk_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 215,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Patrick_Mulligan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 250,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Keniuchio_Harada_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 270,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Carl_Creel_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jean-Paul_Beaubier_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Sebastian_Shaw_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Phillip_Coulson_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 215,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mandarin_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 650,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bor_Burison_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 7.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/En_Dwi_Gast_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Maria_Hill_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 170,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nathaniel_Richards_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 220,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lyra_(Earth-8009)"
+    },
+    {
+        "strength": 4,
+        "weight": 97,
+        "height": 4.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Molly_Hayes_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 231,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nicholas_Fury_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 710,
+        "height": 6.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Aleksei_Sytsevich_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Satana_Hellstrom_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 350,
+        "height": 7.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Proudstar_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Yelena_Belova_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Monet_St._Croix_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 1,
+        "height": 7.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Robert_Bruce_Banner_(Earth-9200)"
+    },
+    {
+        "strength": 4,
+        "weight": 165,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Noh-Varr_(Earth-200080)"
+    },
+    {
+        "strength": 2,
+        "weight": 132,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Layla_Miller_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Baldwin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bennet_du_Paris_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 144,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Samuel_Sterns_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Daniel_Ketch_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 750,
+        "height": 12.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/George_Tarleton_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hiro-Kala_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 750,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jocasta_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 260,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Isaiah_Bradley_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Steven_Rogers_(William_Burnside)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 6.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Malekith_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 181,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Samuel_Guthrie_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Clea_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wendell_Vaughn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Sean_Cassidy_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 500,
+        "height": 7.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Theodore_Sallis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Julian_Keller_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Angelica_Jones_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 320,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lorelei_(Asgardian)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 350,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathan_Summers_(Stryfe)_(Earth-4935)"
+    },
+    {
+        "strength": 3,
+        "weight": 154,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elijah_Bradley_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 123,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Martha_Franklin_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Miles_Warren_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 155,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Madrox_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Adam_Warlock_(Earth-93112)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Morgan_le_Fay_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dane_Whitman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 123,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Danielle_Moonstar_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 235,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sergei_Kravinoff_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 119,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/May_Parker_(April_Parker)_(Earth-982)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Franklin_Hall_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shang-Chi_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Norman_Osborn_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 101,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gwendolyne_Stacy_(Clone)_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Christoph_Nord_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 80,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Longshot_(Mojoverse)"
+    },
+    {
+        "strength": 4,
+        "weight": 400,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Henry_McCoy_(Earth-295)"
+    },
+    {
+        "strength": 4,
+        "weight": 425,
+        "height": 6.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arkady_Rossovich_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Alexi_Shostakov_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kuan-Yin_Xorn_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 376,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Wadey_Wilson_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jane_Foster_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 325,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gilpetperdon_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 95,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Porker_(Earth-8311)"
+    },
+    {
+        "strength": 5,
+        "weight": 525,
+        "height": 7.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Heimdall_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 625,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Kl%27rt_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_Collins_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 115,
+        "height": 5.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cassandra_Nova_Xavier_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 103,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Phyla-Vell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Donald_Gill_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 141,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Terrance_Ward_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 545,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mary_MacPherran_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 128,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Yuriko_Oyama_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tandy_Bowen_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 187,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/David_Alleyne_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Irene_Adler_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 10,
+        "height": 1.0833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Wade_Wilson_(Earth-2149)"
+    },
+    {
+        "strength": 6,
+        "weight": 450,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Baker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Victoria_Hand_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 131,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Amara_Aquilla_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 102,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Nico_Minoru_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nathaniel_Richards_(Immortus)_(Earth-6311)"
+    },
+    {
+        "strength": 6,
+        "weight": 400,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Fallen_One_(Herald)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 230,
+        "height": 6.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Peter_Parker_(Doppelganger)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Edwin_Jarvis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ruth_Aldine_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 134,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Carlie_Cooper_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Phillip_Urich_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 115,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Karolina_Dean_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Foster_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 197,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Victor_Mancha_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 380,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Leonard_Samson_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 275,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Danger_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 160,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Yao_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Roderick_Kingsley_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eric_Masterson_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 320,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Balder_Odinson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 181,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/John_Jonah_Jameson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 187,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Max_Borne_(Earth-9500)"
+    },
+    {
+        "strength": 3,
+        "weight": 225,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Georges_Batroc_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 550,
+        "height": 9.833333333333334,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nimrod_(Earth-811)"
+    },
+    {
+        "strength": 4,
+        "weight": 112,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hisako_Ichiki_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Michael_Morbius_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 375,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bastion_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 550,
+        "height": 6.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Curtis_Connors_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 95,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gaveedra_Seven_(Mojoverse)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wanda_Lensherr_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Yondu_Udonta_(Earth-691)"
+    },
+    {
+        "strength": 2,
+        "weight": 235,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Robert_Hunter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 122,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tabitha_Smith_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 372,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Frigga_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jean_Grey_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 130,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Frankie_Raye_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 137,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Noriko_Ashida_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/James_Bradley_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 179,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Forge_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 260,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Timothy_Dugan_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 1,
+        "height": 5.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lockjaw_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 225,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Erik_Josten_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 165,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Impossible_Man_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Julie_Power_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 620,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Pluto_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mary_Jane_Watson_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 116,
+        "height": 5.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Lily_Hollister_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jonothon_Starsmore_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 119,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Xi%27an_Coy_Manh_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 110,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lilandra_Neramani_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Calvin_Rankin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Eric_Williams_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jack_Russell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Melissa_Gold_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Clint_Barton_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 136,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sooraya_Qadir_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 245,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Walter_Langkowski_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_Pointer_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 155,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tyrone_Johnson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Elizabeth_Allan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 250,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jacques_Duquesne_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Abigail_Brand_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 235,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Vance_Astro_(Earth-691)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Marrow_(Sarah)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Theresa_Cassidy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Talia_Wagner_(Earth-2182)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kyle_Richmond_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Quentin_Beck_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 275,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frederick_Dukes_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 150,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Pietro_Lensherr_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gabriel_Stacy_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 250,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Karl_Mordo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 128,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Paige_Guthrie_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 173,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_van_Patrick_(Patrick)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 850,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/X-51_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 2216,
+        "height": 9.833333333333334,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Buri_(Asgardian)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 215,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tomi_Shishido_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 135,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Patricia_Walker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Graydon_Creed_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Douglas_Ramsey_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Vance_Astrovik_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 153,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rachel_Leighton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 129,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Victor_Borkowski_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 195,
+        "height": 5.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/James_Howlett_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kevin_Connor_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 110,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/May_Reilly_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arcade_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 114,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cessily_Kincaid_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 168,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eric_O%27Grady_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Steven_Rogers_(Revolutionary_War)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sage_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 135,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sharon_Ventura_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 400,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Silas_Burr_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Edward_Brock,_Jr._(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thomas_Raymond_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 750,
+        "height": 7.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Guido_Carosella_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 350,
+        "height": 7.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thundra_(Earth-715)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Julio_Richter_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 210,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Vision_(Jonas)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Meggan_Puceanu_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Erik_Lensherr_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 224,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Orb_(Zadkiel_agent)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mister_Negative_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jonathan_Richards_(Earth-967)"
+    },
+    {
+        "strength": 2,
+        "weight": 179,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Nightmask_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 181,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cal%27syee_Neramani_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 2440,
+        "height": 10.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tyrant_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cassandra_Webb_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Stick_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 150,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Armando_Mu%C3%B1oz_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Maria_Carbonell_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 6000,
+        "height": 20.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Devil_Dinosaur_(Earth-78411)"
+    },
+    {
+        "strength": 5,
+        "weight": 410,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Attuma_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 142,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Humberto_Lopez_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Abner_Jenkins_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 233,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tsu-Zana_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 485,
+        "height": 6.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gorgon_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 460,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hyperion_(Squadron_Sinister)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Genis-Vell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 390,
+        "height": 7.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ord_Zyonz_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Richard_Parker_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 173,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_van_Patrick_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 169,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Mortimer_Toynbee_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mary_Walker_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 270,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frank_Simpson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 181,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Bob_(Hydra_Agent)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 156,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Craig_Hollis_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 450,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Stakar_Ogord_(Earth-691)"
+    },
+    {
+        "strength": 1,
+        "weight": 275,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Caliban_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 136,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mercedes_Knight_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 162,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Nils_Styger_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Carmilla_Black_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 470,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mark_Milton_(Earth-4023)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Adam_Neramani_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elizabeth_Brant_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 165,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Reilly_Tyne_(Earth-982)"
+    },
+    {
+        "strength": 5,
+        "weight": 115,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Xavin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Valentina_Allegra_de_Fontaine_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 555,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Agent_X_(Nijo)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 146,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ogun_(Ninja)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 131,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alistaire_Smythe_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Roma_(Otherworld)"
+    },
+    {
+        "strength": 3,
+        "weight": 215,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kevin_Plunder_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jacob_Gallows_(Earth-928)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Marco_Scarlotti_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/James_Jaspers_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 237,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Charles_Barton_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Henry_Pym_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sarah_Stacy_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 225,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Namorita_Prentiss_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Mikhail_Rasputin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 188,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Chase_Stein_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 139,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Giuletta_Nefaria_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 283,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Piotr_Rasputin_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/The_Wizard_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 20,
+        "height": 2.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lockheed_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jonas_Graymalkin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 118,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Laurie_Collins_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Loki_Odinson_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 105,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Janet_van_Dyne_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nemesis_(Earth-295)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Adrian_Toomes_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Hudson_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 330,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Shadow_King_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 193,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joshua_Guthrie_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 230,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Obadiah_Stane_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Karnak_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 2750,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tyros_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jacob_Fury_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 80,
+        "height": 4.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ahura_Boltagon_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 181,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Karima_Shapandar_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Christopher_Summers_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hobie_Brown_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 163,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shannon_Carter_(Earth-982)"
+    },
+    {
+        "strength": 4,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Victor_Alvarez_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 175,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Benjamin_Parker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Maya_Lopez_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 285,
+        "height": 6.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Namor_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 101,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gwendolyne_Stacy_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 482,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Santo_Vaccarro_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1015,
+        "height": 7.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Predator_X_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nathaniel_Richards_(Rama-Tut)_(Earth-6311)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Super-Adaptoid_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jeanne-Marie_Beaubier_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Karl_Lykos_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 115,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frances_Barrison_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Umar_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shanna_O%27Hara_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 260,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gilgamesh_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 188,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Parker_(Tarantula)_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 136,
+        "height": 5.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Peter_Parker_(Kaine)_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Deidre_Wentworth_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 4.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sha_Shan_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 2800,
+        "height": 8.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thanos_(Earth-1610)"
+    },
+    {
+        "strength": 6,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Arno_Stark_(Earth-8410)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Barnell_Bohusk_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 520,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Blastaar_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Abigail_Boylen_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 162,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Rita_Wayword_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Jonah_Jameson_III_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alicia_Masters_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 380,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Aphrodite_Ourania_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 512,
+        "height": 6.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mojo_(Mojoverse)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Veranke_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 390,
+        "height": 6.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ayesha_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cecilia_Reyes_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jonathan_Hart_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 202,
+        "height": 5.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Peter_Parker_(Scorpion)_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 151,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Harold_Osborn_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maria_Callasantos_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gabriel_Jones_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 331,
+        "height": 7.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sleepwalker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Drusilla_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 98,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rina_Logan_(Earth-982)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/William_Stryker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Moira_Kinross_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Proudstar_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Shathra_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jack_Monroe_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 544000,
+        "height": 25.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Supreme_Intelligence_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Charles_Xavier_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Kaluu_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 151,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Alex_Wilder_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 88,
+        "height": 4.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Amiko_Kobayashi_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 235,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Brian_Falsworth_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ghost_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Herman_Schultz_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 121,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Silverfox_(Canadian)_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 160,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Abraham_Erskine_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Max_Eisenhardt_(Joseph)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 425,
+        "height": 7.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Boris_Bullski_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/White_Wolf_(Hunter)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 580,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Poseidon_Aegaeus_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Miranda_Leevald_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Matthew_Murdock_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 148,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ezekiel_Stane_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 121,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Angel_Salvadore_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Kurt_Darkholme_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 191,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Tyler_Dayspring_(Earth-4935)"
+    },
+    {
+        "strength": 4,
+        "weight": 230,
+        "height": 6.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joanna_Cargill_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 3,
+        "height": 0.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Martha_Johansson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Annihilus_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Madison_Jeffries_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 162,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sublime_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Lyja_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 240,
+        "height": 6.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Frank_Castle_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Bolivar_Trask_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Clarice_Ferguson_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jimaine_Szardos_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/St._John_Allerdyce_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 161,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Justine_Hammer_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Paladin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Glenn_Talbot_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sersi_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 189,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Aquaria_Neptunia_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 193,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Samuel_Wilson_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 260,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kioshi_Keishicho_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Marcus_Daniels_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jack_Harrison_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 450,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Todd_Arliss_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jacqueline_Falsworth_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 103,
+        "height": 4.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kristoff_Vernard_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Frank_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 128,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alexander_Power_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jason_Wyngarde_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Madeline_Joyce_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Laynia_Petrovna_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Revanche_(Kwannon)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 216,
+        "height": 6.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Robert_Herman_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 143,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Blind_Al_(Althea)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zala_Dane_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 510,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tyr_Odinson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Justin_Hammer_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 158,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Felicia_Hardy_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 105,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Celeste_Cuckoo_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 650,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Miek_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 176,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eric_Koenig_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 138,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Maya_Hansen_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Scott_Summers_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thomas_Cassidy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Bella_Donna_Boudreaux_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 96,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Amanda_Mueller_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Callisto_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Chen_Lu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Belasco_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Aarkus_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Otto_Octavius_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 151,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/James_Braddock_Jr._(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 220,
+        "height": 6.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Pyreus_Kril_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hepzibah_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 125,
+        "height": 5.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gertrude_Yorkes_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Goddess_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eric_Gitter_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 325,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Henry_Hayes_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 265,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hammerhead_(Joseph)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 440,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Athena_Parthenos_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 152,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Kyle_Gibney_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Greg_Willis_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 120,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ashley_Crawford_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 205,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mikel_Fury_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 118,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Gwen_(Daydream)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Zsaji_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 325,
+        "height": 8.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Frankenstein%27s_Monster_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 500,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Hermes_Diaktoros_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/David_Cannon_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 80,
+        "height": 3.0833333333333335,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Wade_Wilson_(Widdle_Wade)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hannibal_King_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 122,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jennifer_Kale_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 800,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Living_Brain_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 149,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Aleta_Ogord_(Earth-691)"
+    },
+    {
+        "strength": 4,
+        "weight": 221,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nicholas_Fury_(LMD)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Leech_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Marrina_Smallwood_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 480,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Garrison_Kane_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 235,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Xraven_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 145,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Narya_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 181,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tiberius_Stone_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 311,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Anthony_Druid_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 158,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Wisdom_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 355,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/M%27Baku_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Martinique_Wyngarde_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Maximillian_Coleridge_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dwayne_Taylor_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 130,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Agatha_Harkness_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 6000,
+        "height": 15.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dragon_Man_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Gwendolyne_Stacy_(Clone)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Paul_Duval_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 170,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Eisenhart_(Earth-928)"
+    },
+    {
+        "strength": 4,
+        "weight": 125,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Lilith_Drake_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 147,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Johnathon_Gallo_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 450,
+        "height": 7.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anath-Na_Mut_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 80,
+        "height": 4.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Camille_Benally_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frank_Payne_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jean_Grey_(Earth-295)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Victor_Creed_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Leland_Owlsley_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Phillip_Masters_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vertigo_(Savage_Land_Mutate)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Morgan_Stark_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Valeria_(Latverian)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 222,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gregory_Terraerton_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 150,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ruth_Bat-Seraph_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 395,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Vision_(Gah_Lak_Tus)_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 126,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Philippa_Sontag_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 475,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Karnilla_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hector_Ayala_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 350,
+        "height": 7.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mahr_Vehl_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Azura_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 400,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arkon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mad_Thinker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 158,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Janos_Quested_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Phineas_Mason_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 137,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lumina_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 400,
+        "height": 6.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sugar_Man_(Earth-295)"
+    },
+    {
+        "strength": 3,
+        "weight": 265,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Morris_Bench_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elias_Wirtham_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 146,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kevin_Ford_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Mercedes_Wilson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Delroy_Garrett_Jr._(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 395,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Seth_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 250,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Billy_Russo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Stephen_Strange,_Jr._(Earth-1610)"
+    },
+    {
+        "strength": 1,
+        "weight": 152,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Jonah_Jameson,_Sr._(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Dominikos_Petrakis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Yukio_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 230,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ikaris_(Eternal)_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 1900,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Morg_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 130,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kelsey_Leigh_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 205,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jeffrey_Mace_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 95,
+        "height": 5.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alexander_Aaron_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maxwell_Dillon_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Donald_Pierce_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 183,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/New_Sun_(Earth-9921)"
+    },
+    {
+        "strength": 4,
+        "weight": 475,
+        "height": 10.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Varnae_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 133,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Regan_Wyngarde_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Oliver_Osnick_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 18000,
+        "height": 20.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zom_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/James_Sanders_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anthony_Stark_(Earth-96020)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/John_Wraith_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/James_Taylor_James_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 202,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Emery_Schaub_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 125,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Mephista_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 250,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Norrin_Radd_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Margali_Szardos_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 460,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lonnie_Lincoln_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Albert_Malik_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 122,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sofia_Mantega_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 110,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elizabeth_%22Betsy%22_Ross_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Black_Swan_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Demogoblin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 126,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jarella_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Nasland_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 250,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Santa_Claus_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frederick_Myers_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mariko_Yashida_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Adolf_Hitler_(Clone)_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 135,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zane_Yama_(Earth-982)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bova_Ayrshire_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Opal_Luna_Saturnyne_(Earth-9)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Carina_Walters_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 173,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Michael_van_Patrick_(KIA)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 265,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kiskillilla_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 1210,
+        "height": 15.166666666666666,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cronus_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 119,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maki_Matsumoto_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 240,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Montgomery_Falsworth_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 250,
+        "height": 6.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/John_Horton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 205,
+        "height": 7.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Heather_Cameron_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/William_Cross_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Calvin_Rankin_(Earth-12)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hrimhari_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Colleen_Wing_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Vanisher_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Amenhotep_IV_(Earth-4321)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ho_Yinsen_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 575,
+        "height": 4.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bessie_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 101,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Avery_Connor_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 2000,
+        "height": 10.083333333333334,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arsenal_(Robot)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Manuel_de_la_Rocha_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 300,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/En_Sabah_Nur_(Earth-295)"
+    },
+    {
+        "strength": 5,
+        "weight": 2500,
+        "height": 7.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ronan_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Changeling_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zelda_DuBois_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 435,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Hera_Argeia_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 133,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Phineas_Horton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Tanya_Sealy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 156,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Marius_St._Croix_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 80,
+        "height": 4.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gateway_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Karen_Page_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kevin_Sidney_(Earth-1081)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Richard_Gilmore_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 450,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elvin_Haliday_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 198,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Hudson_Logan_(Earth-982)"
+    },
+    {
+        "strength": 2,
+        "weight": 95,
+        "height": 4.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Klara_Prast_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 298,
+        "height": 7.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Unspoken_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 230,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Luchino_Nefaria_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 221,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Roger_Aubrey_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 205,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Henry_Gyrich_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 320,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Man-Beast_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Drake_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Xarus_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 175,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Paul_Cartier_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 425,
+        "height": 8.166666666666666,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maelstrom_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elsa_Bloodstone_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 280,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Clinton_McIntyre_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 400,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thena_Thorsd%C3%B3ttir_(Earth-982)"
+    },
+    {
+        "strength": 4,
+        "weight": 315,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Dennis_Dunphy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 800,
+        "height": 4.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zabu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Thomas_Fireheart_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Heather_McNeil_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/DeMarr_Davis_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 157,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Angela_del_Toro_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Victor_Strange_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 67,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Bereet_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Richard_Deacon_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 155,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mister_X_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jack_Hammer_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 142,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Inez_Temple_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Candra_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Yuri_Topolov_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Gustav_Brandt_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Neal_Shaara_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Abigail_Wright_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 109,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kimura_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gunther_Bain_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Louise_Grant_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 238,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joseph_Chapman_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 239,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathaniel_Essex_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/May_Reilly_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ebenezer_Laughton_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Hippolyta_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 355,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Howlett_(Earth-2107)"
+    },
+    {
+        "strength": 2,
+        "weight": 105,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Irma_Cuckoo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 285,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lemar_Hoskins_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/George_Stacy_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 245,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Makkari_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ivan_Kragoff_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1421,
+        "height": 15.083333333333334,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Awesome_Android_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 510,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alkhema_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jasper_Sitwell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 105,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sophie_Cuckoo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 165,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Parker_(Richard_Parker)_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Peter_Petruski_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 455,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Martinex_T%27Naga_(Earth-691)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shen_Xorn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 114,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mary_Fitzpatrick_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Victor_Creed_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Cleo_Nefertiti_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ulysses_Bloodstone_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Grayson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 395,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Luther_Manning_(Earth-7484)"
+    },
+    {
+        "strength": 7,
+        "weight": 165,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dargo_Ktor_(Earth-8710)"
+    },
+    {
+        "strength": 4,
+        "weight": 222,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Blanche_Sitznski_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 128,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Charlotte_Witter_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 386,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Michael_Baer_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 5.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anastasia_Kravinoff_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 10,
+        "height": 1.1666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Niels_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 100,
+        "height": 5.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tath_Ki_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 185,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anton_Miguel_Rodriquez_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 400,
+        "height": 292.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Wilbur_Day_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kirika_Yashida_(Earth-295)"
+    },
+    {
+        "strength": 5,
+        "weight": 420,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vali_Halfling_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 117,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ororo_Munroe_(Earth-1610)"
+    },
+    {
+        "strength": 6,
+        "weight": 178,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Zarda_(Earth-31916)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Esteban_Coraz%C3%B3n_de_Ablo_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 321,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Johann_Fennhoff_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 255,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mikhail_Ursus_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 144,
+        "height": 4.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Pip_Gofern_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 3000,
+        "height": 10.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Vidar_Odinson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 154,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Paul_Norbert_Ebersol_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/John_Greycrow_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 50000,
+        "height": 50.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Set_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 560,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Phoebus_Apollo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 550,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mitchell_Tanner_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shevaun_Haldane_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 210,
+        "height": 4.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arthur_Molekevic_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 500,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Wilson_Fisk_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sebastian_Druid_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Marvin_Flumm_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Angelo_Espinosa_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 230,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/George_Washington_Bridge_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ashley_Kafka_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 165,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Andreas_von_Strucker_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathaniel_Essex_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Orson_Randall_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kevin_Masterson_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Gabriel_Lan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 112,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sybil_Dvorak_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Red_Shift_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Psycho-Man_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 540,
+        "height": 7.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Antonio_Rodriguez_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 5.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ananym_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mariko_Yashida_(Earth-2109)"
+    },
+    {
+        "strength": 2,
+        "weight": 126,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Juston_Seyfert_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ben_Urich_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ahmet_Abdol_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 195,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Sharra_Neramani_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 205,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Steel_Serpent_(Davos)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Arthur_Pendragon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lila_Cheney_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 320,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Elihas_Starr_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jason_Macendale_Jr._(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 131,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Melody_Jacobs_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 450,
+        "height": 7.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Bernard_Hoyster_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 98,
+        "height": 5.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Rebecca_Barnes_(Heroes_Reborn)_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 250,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Brian_Braddock_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 215,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Kevin_Marlow_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 183,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Jonah_Jameson_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Simon_Garth_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rita_DeMara_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 600,
+        "height": 7.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Fury_(Earth-238)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kenshiro_Cochrane_(Earth-928)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Carolyn_Trainer_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 173,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Suvik_Senyaka_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Blackout_(Lilin)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 129,
+        "height": 5.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Amelia_Voght_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 135,
+        "height": 5.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/James_Marks_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lance_Hunter_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alexei_Kravinoff_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 105,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Esme_Cuckoo_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 135,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jazinda_Kl%27rt-Spawn_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 555,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Charlie-27_(Earth-691)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Deacon_Frost_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Madcap_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 302,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Angelina_Brancale_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 334,
+        "height": 6.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Old_Lace_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ajax_(Francis)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 110,
+        "height": 4.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Melati_Kusuma_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 240,
+        "height": 9.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Alpha_(Mutant)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 151,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Roland_Burroughs_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 750,
+        "height": 10.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Grom_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 270,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jerome_Beechman_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 150,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Marshall_Stone_III_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 145,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Wilhelm_Lohmer_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 258,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anti-Cap_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 260,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Prism_(Robbie)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kurt_Wagner_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Roger_Brokeridge_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 250,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Raza_Longknife_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Leyu_Yoshida_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Everett_Thomas_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lorina_Dodson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 198,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mark_Todd_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 143,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Petra_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 98,
+        "height": 5.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Kiden_Nixon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 134,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Faiza_Hussain_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/John_Falsworth_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathan_Garrett_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Franklin_Nelson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michiko_Musashi_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 10000,
+        "height": 18.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shaper_of_Worlds_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 195,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Silvio_Manfredi_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 105,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Silhouette_Chord_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 450,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mendel_Stromm_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 154,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gregory_Nettles_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 105,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Phoebe_Cuckoo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Randall_Spector_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Klaus_Voorhees_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Trevor_Fitzroy_(Earth-1191)"
+    },
+    {
+        "strength": 2,
+        "weight": 132,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elizabeth_Twoyoungmen_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 240,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zarda_Shelton_(Earth-712)"
+    },
+    {
+        "strength": 2,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathaniel_Richards_(Scarlet_Centurion)_(Earth-6311)"
+    },
+    {
+        "strength": 2,
+        "weight": 134,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Valerie_Cooper_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Walter_Newell_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 550,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mark_Raxton_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 295,
+        "height": 6.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ethan_Edwards_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 137,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Lucia_Callasantos_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 197,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joseph_Green_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 145,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Santini_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Erik_Killmonger_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 500,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Quicksand_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 134,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Katherine_Waynesboro_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Khn%27nr_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 162,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Aman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bethany_Cabe_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 214,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Fabian_Cortez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 90,
+        "height": 5.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jennifer_Stavros_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Matthew_Hawk_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Steven_Harmon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Willis_Stryker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jacob_Gavin,_Jr._(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 99,
+        "height": 5.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Native_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Erik_Lehnsherr_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 119,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alison_Blaire_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Elektra_Natchios_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Franklin_Richards_(Earth-6311)"
+    },
+    {
+        "strength": 2,
+        "weight": 136,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Aleksandra_Nikolaevna_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cameron_Hodge_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Miguel_Santos_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Debra_Whitman_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vladimir_Kravinoff_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 150,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Daniel_Rand_(Earth-1610)"
+    },
+    {
+        "strength": 6,
+        "weight": 128000,
+        "height": 50.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Utgard-Loki_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 5,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Katherine_Pryde_(Earth-811)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wong_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 650,
+        "height": 7.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/N%27Kantu_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dan_Kane_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 1425,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Volstagg_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 119,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Nina_Price_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 900,
+        "height": 9.333333333333334,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Cain_Marko_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Marc_Spector_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 196,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Curtis_Conners_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Karlin_Malus_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 198,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Martin_Preston_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Richard_Fisk_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sally_Blevins_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 350,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Gazer_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 100,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arthur_Centino_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bride_of_Nine_Spiders_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Freak_(Vagrant)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lillian_Crawley_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Terrance_Sorenson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Scott_Wright_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 194,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Davida_DeVito_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 117,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Candace_Southern_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Nicholas_Gleason_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 187,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/D%27Ken_Neramani_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 101,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dead_Girl_(Moonbeam)_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 9320,
+        "height": 12.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Olinka_Barankova_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 200,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Garthan_Saal_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 127,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Claire_Voyant_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 915,
+        "height": 7.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maximus_Jensen_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Fen_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Christine_Cord_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Monica_Rappaccini_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Mesmero_(Vincent)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 130,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alana_Jobson_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 209,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thomas_Halloway_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 125,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cerise_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Russell_Collins_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jean_DeWolff_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bonita_Juarez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Romulus_Augustulus_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tilda_Johnson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 171,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Topher_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 375,
+        "height": 6.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Sidney_Green_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Griffin_Gogol_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eric_Payne_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 215,
+        "height": 4.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Kondrati_Topolov_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thog_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_Twoyoungmen_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 170,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gideon_Mace_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lois_London_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 270,
+        "height": 6.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Michael_Marko_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 120,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Warren_Worthington_III_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 325,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Venus_(Siren)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Overdrive_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 222,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vargas_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Moon_Boy_(Earth-78411)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Fiona_Knoblach_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Vincent_Stewart_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 222,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Roderick_Campbell_(Earth-811)"
+    },
+    {
+        "strength": 4,
+        "weight": 187,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Steele_(American_Soldier)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gregor_Shapanka_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Arthur_Maddicks_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 244,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Christopher_Bradley_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Steven_Levins_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Norton_Fester_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michele_Gonzales_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ariel_(Coconut_Grove)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 131,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shard_Bishop_(Earth-1191)"
+    },
+    {
+        "strength": 3,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Heike_Zemo_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/John_Kowalski_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Henry_McCoy_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 134,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Robin_Borne_(Earth-9500)"
+    },
+    {
+        "strength": 2,
+        "weight": 133,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kavita_Rao_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Eliphas_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Dorma_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dreamqueen_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 420,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Artemis_(Olympian)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Woo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 253,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ravonna_Renslayer_(Earth-6311)"
+    },
+    {
+        "strength": 6,
+        "weight": 220,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Captain_(Nextwave)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sequoia_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 111,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Suzi_Endo_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 160,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Jankovicz_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 260,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wyatt_Wingfoot_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 152,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Davis_Cameron_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Robert_Farrell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 137,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Suzanne_Chan_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 166,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Roderick_Campbell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Calypso_Ezili_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Milos_Masaryk_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nikolai_Krylenko_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 510,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Mimir_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 193,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Samuel_Smithers_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 98,
+        "height": 6.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dinah_Soar_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 159,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Moses_Magnum_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 166,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Steven_Lang_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 7.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Carlos_LaMuerto_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Duc_No_Tranh_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 975,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ravenous_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 207,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Korvus_Rook%27shir_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 147,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zak-Del_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Shingen_Harada_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jason_Strongbow_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 195,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jackson_Arvad_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kyle_Richmond_(Earth-712)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Donyell_Taylor_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 177,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Temugin_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 191,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Seamus_Mellencamp_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 161,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Elliot_Boggs_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 185,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Centurious_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 365,
+        "height": 7.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Harald_Jaekelsson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 97,
+        "height": 4.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Samuel_Par%C3%A9_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 126,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sondra_Brandenberg_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 187,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_Morbius_(Earth-1610)"
+    },
+    {
+        "strength": 1,
+        "weight": 330,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Harry_Leland_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Watkins_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 156,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ralph_Roberts_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Frank_Drake_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 62,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Fever_Pitch_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 425,
+        "height": 7.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Manphibian_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 287,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Buck_Chisholm_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Magnus_Lehnsherr_(Earth-27)"
+    },
+    {
+        "strength": 2,
+        "weight": 68,
+        "height": 3.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Seraph_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 500,
+        "height": 4.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Punisher_(Cyborg)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/James_Natale_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 1,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Quasi-Motivational_Destruct_Organism_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 235,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Karl_Morgenthau_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Isaac_Christians_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 2010,
+        "height": 8.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kevin_Tremain_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Watkins_III_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 291,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cleavon_Twain_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Chester_Phillips_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 456,
+        "height": 7.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Rhino_(Kraven)_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 200,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tony_Stark_2.0_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 1100,
+        "height": 7.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jackie_Lukus_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 350,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Maggott_(Japheth)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Masque_(Morlock)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 215,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Edgar_Plunder_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thursday_Rubinstein_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 645,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hephaestus_Aetnaeus_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 410,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Buford_Hollis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 147,
+        "height": 5.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Carlton_LaFroyge_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Brian_Cruz_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anthony_Stark_(Earth-5012)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Remy_LeBeau_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 573,
+        "height": 7.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Russian_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 545,
+        "height": 18.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Quincy_McIver_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eugene_Patilio_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 320,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kro_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/William_Taurens_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Judas_Traveller_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vincent_Stegron_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 136,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Victoria_Murdock_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tommy_(Morlock)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lynn_Michaels_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 230,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Flint_Marko_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 224,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Z%27Reg_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 1000,
+        "height": 20.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bi-Beast_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 140,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sharon_Smith_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 235,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maximillian_Zaran_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 732,
+        "height": 11.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Orka_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Paul-Philip_Ravage_(Earth-928)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Red_Raven_(Liberty_Legion)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jess%C3%A1n_Hoan_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 205,
+        "height": 6.416666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Julia_Koenig_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 125,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Tania_Belinskaya_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Barton_Hamilton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Colin_Hume_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 198,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Clay_Quartermain_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Milla_Donovan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Linda_Carter_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 410,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Persephone_(Olympian)_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 152,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Wernher_von_Blitzschlag_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Joss_Shappe_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 1410000,
+        "height": 800.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Atlas_(Titan)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 285,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Artur_Zarrko_(Earth-6297)"
+    },
+    {
+        "strength": 5,
+        "weight": 180,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Reed_Richards_(Counter-Earth)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Edith_Sawyer_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 205,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bruno_Horgan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Plague_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 260,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Douglas_Scott_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Samuel_Barone_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 198,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jack_Winters_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 2,
+        "height": 2.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Monkey_Joe_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 180,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Myron_MacLain_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rogue_(Anna_Marie)_(Earth-295)"
+    },
+    {
+        "strength": 4,
+        "weight": 215,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Janus_Tepes_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 400,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kelda_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 285,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/David_Rand_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tike_Alicar_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 135,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Carmella_Unuscione_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 155,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elysius_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 72,
+        "height": 4.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Carter_Ghazikhanian_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Daniel_Leighton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Vanessa_Fisk_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 224,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Carl_King_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Spymaster_(Ted_Calloway)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shalla-Bal_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 500,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mikhail_Rasputin_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 31,
+        "height": 2.4166666666666665,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Hit-Monkey_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 156,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Fred_Davis_Jr._(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Edward_Whelan_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 500,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Eric_Savin_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 675,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Wong-Chu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lancaster_Sneed_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 700,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Piotr_Rasputin_(Earth-295)"
+    },
+    {
+        "strength": 4,
+        "weight": 1000,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Praxagora_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/John_Howlett,_Jr._(Earth-4011)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Rachel_van_Helsing_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Humanoid_Experimental_Robot_B-Type_Integrated_Electronics_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 341,
+        "height": 7.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ord_(Breakworld)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Benjamin_Parker_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 144,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Wilson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Leonard_McKenzie_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 173,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_van_Patrick_(Michael)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 207,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Roscoe_Simons_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Plan_Chu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 109,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Helen_Takahama_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Robert_Kelly_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joseph_Robertson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 270,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Robert_Baxter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Burglar_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 450,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Desak_Sterixian_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kwaku_Anansi_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bloodscream_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Frederick_Duncan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Abdul_Qamar_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Doug_Taggert_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 182,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vincent_Gonzales_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 405,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arkady_Rossovich_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 118,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Norah_Winters_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 90,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Margaret_Murdock_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Enid_Richards_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sir_Percy_of_Scandia_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Matthew_Gilden_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 260,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Maxam_(Earth-93112)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Modred_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Marie-Ange_Colbert_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 75,
+        "height": 3.6666666666666665,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Lavinia_LeBlanc_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 146,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jack_Jameson_(Earth-982)"
+    },
+    {
+        "strength": 3,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Opul_Lun_Sat-Yr-Nin_(Earth-794)"
+    },
+    {
+        "strength": 4,
+        "weight": 615,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Paibok_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 105,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Harley_Davis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kenji_Oyama_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Andrea_von_Strucker_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Pandemonia_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 157,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Ralston_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 177,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jackson_Norriss_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 325,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Yu-Huang_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 224,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lucas_Cross_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Andromeda_Attumasen_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 140,
+        "height": 4.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Roger_Bochs_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Davan_Shakari_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 420,
+        "height": 16.166666666666668,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Llyra_Morris_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 145,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nekra_Sinclair_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kim_Il_Sung_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 680,
+        "height": 8.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ard-Con_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Christian_Cord_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 84,
+        "height": 5.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Aged_Genghis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jillian_Woods_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Curtis_Doyle_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 145,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Namora_(Earth-2189)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Malcolm_Colcord_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Malcolm_McBride_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 225,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Noah_Black_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Thaddeus_Ross_(Earth-1610)"
+    },
+    {
+        "strength": 7,
+        "weight": 655,
+        "height": 7.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Leir_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 282,
+        "height": 7.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Katerina_van_Horn_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Talltrees_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 275,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Eshu_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rina_Patel_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sally_Avril_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 99,
+        "height": 5.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wicked_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 460,
+        "height": 6.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Zhib-Ran_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 162,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Perry_Webb_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Pietro_Maximoff_(Earth-295)"
+    },
+    {
+        "strength": 6,
+        "weight": 220000,
+        "height": 60.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tri-Sentinel_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 8000,
+        "height": 40.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Garm_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 117,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rumiko_Fujikawa_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 240,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Captain_America_(Earth-1298)"
+    },
+    {
+        "strength": 4,
+        "weight": 116,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Fahnbullah_Eddy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 157,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jeremy_Stevens_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 175,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Samuel_Saxon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Joshua_Ayers_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Peter_Quinn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hamilton_Slade_(Rider)_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 1500,
+        "height": 7.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/S%27ym_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 104,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Fritz_von_Meyer_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 3572,
+        "height": 10.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Doomsday_Man_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 192,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Erg_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 340,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kenneth_Hale_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 140,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tara_Richards_(Earth-6311)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Bourne_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dallas_Riordan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mordred_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 187,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/George_Smith_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 133,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Maria_Vasquez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 169,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Garabed_Bashur_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 400,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Minion_(Earth-8410)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/David_Lowell_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ruriko_Tsumura_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Leper_Queen_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Johnny_Dee_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Melina_Vostokoff_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jack_Dio_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Pele_(Oceanic_Goddess)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Muramasa_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ethan_Warren_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 300,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Emrys_Killebrew_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 105,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Blaquesmith_(Earth-4935)"
+    },
+    {
+        "strength": 4,
+        "weight": 565,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Basil_Sandhurst_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_O%27Brien_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Edward_Lansky_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 255,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Alexander_Gentry_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Daniel_Berkhart_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Deathwatch_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 203,
+        "height": 6.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Marissa_Darrow_(Earth-9201)"
+    },
+    {
+        "strength": 4,
+        "weight": 423,
+        "height": 6.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Theodore_Winchester_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 1100,
+        "height": 11.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Xemnu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Stewart_Cadwall_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 350,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Izanagi-No-Mikoto_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Francis_Klum_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 30000,
+        "height": 20.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/TESS-One_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sergei_Kravinoff_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Damon_Ryder_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/David_Angar_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Joseph_Manfredi_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Bram_Velsing_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 192,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Edward_Lavell_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 6.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Maxwell_Markham_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 410,
+        "height": 6.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Horus_(Deity)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jonathan_Powers_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 143,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Janice_Yanizeski_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 185,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jonathan_Raven_(Earth-691)"
+    },
+    {
+        "strength": 3,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Colin_McKay_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Simon_Hall_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 410,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lloyd_Bloch_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 170,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Bruce_Dickson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Aaron_Nicholson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Mike_Columbus_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 2000,
+        "height": 12.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/S.H.I.V.A._(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 9.083333333333334,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Arize_(Mojoverse)"
+    },
+    {
+        "strength": 3,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Brenda_Drago_(Earth-982)"
+    },
+    {
+        "strength": 7,
+        "weight": 180000,
+        "height": 8.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Gallowglass_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 215,
+        "height": 6.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Century_(Alien)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dennis_Sykes_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gary_Gilbert_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 230,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mondo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Peter_van_Zante_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 160,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nakia_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 2040,
+        "height": 9.083333333333334,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Maht_Pacle_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Topaz_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 270,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nox_(Nyx)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 136,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Minn-Erva_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shiro_Yoshida_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Daniel_Lyons_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 184,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Benjamin_Tibbets_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Donald_Callahan_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/James_Madrox_(Cortex)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 142,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Betty_Swanson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 430,
+        "height": 9.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ch%27od_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lester_Verde_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Maria_de_Guadalupe_Santiago_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 169,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Larry_Ekler_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 308,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Hathor-Sekhmet_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 657,
+        "height": 6.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Talos_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 133,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Susan_Scarbo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Korath-Thak_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 182,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Matsu%27o_Tsurayaba_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Pyro_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 235,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frank_Bohannan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 173,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kodiak_Noatak_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 178,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Paul_Provenzano_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 111,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Eileen_Harsaw_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Olivier_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 119,
+        "height": 5.416666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Roberto_Velasquez_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 225,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Achmed_Korba_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 447,
+        "height": 8.166666666666666,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rubanna_Quormo_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Bartholomew_Gallows_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 3500,
+        "height": 8.416666666666666,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sleipnir_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Oracle_(Sybil)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Silver_Sable_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ashake_(Egyptian)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jean_DeWolff_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 165,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wundarr_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 186,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Han,_Chang,_Lin,_Sun,_and_Ho_Tao-Yu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 329,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Crule_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Desmond_Pitt_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 1000,
+        "height": 8.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Interloper_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 200000,
+        "height": 30.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/It_the_Living_Colossus_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Krang_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 330,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Frank_Jr._(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Marian_Pouncy_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 125,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jonathan_Clay_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Drake_Shannon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 158,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anne_Marie_Cortez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 154,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ringo_Kid_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lionel_Jeffries_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 178,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Arcturus_Rann_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 40000,
+        "height": 15.333333333333334,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Uroc_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Zoe_Culloden_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Heinz_Kruger_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Rhona_Burchill_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thakorr_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 158,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Dexter_Bennett_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Jim_Morita_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 175,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Eliot_Franklin_(Clown)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 3,
+        "height": 3.5833333333333335,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Doctor_Sun_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Duvid_Fortunov_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 155,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Thomas_Gideon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Haroun_ibn_Sallah_al-Rashid_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Robert_Markham_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 245,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maha_Yogi_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 195,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kevin_Cole_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 450,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ulysses_Lugman_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 180,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Anna_May_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 900,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joseph_Timms_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 795,
+        "height": 10.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Typhon_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 600,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Torgo_(Mekkan)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Robin_Braxton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/David_Lieberman_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 118,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nikolaus_Geist_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 380,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sylene_Lokisd%C3%B3ttir_(Earth-982)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ian_McNee_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 132,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Screwball_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Orlando_Furio_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ajak_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Carl_Denti_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Feron_(Excalibur)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 116,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gaia_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 122,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Delilah_Dearborn_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Guy_Smith_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mountjoy_(Earth-1191)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Denise_Baranger_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 465,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hecate_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 500,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/M-11_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lani_Ubanu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 350,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jeff_Wilde_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Stuart_Clarke_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 950,
+        "height": 8.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Kelly_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Siena_Blaze_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hector_Rendoza_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 113,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Blindspot_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 172,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jack_Frost_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Spencer_Smythe_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 207,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Neal_Richmond_(Earth-712)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Deborah_Fields_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 15.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Omega_(Android)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 129,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Danielle_Forte_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Xandu_(Sorcerer)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 350,
+        "height": 8.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Hunter_in_Darkness_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 188,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/A._G._Bell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Petunia_Grimm_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Richard_Jones_(Phantom_Reporter)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jean_Grey_(Earth-9575)"
+    },
+    {
+        "strength": 3,
+        "weight": 260,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hammerhead_(Joseph)_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 173,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_van_Patrick_(Clone)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 271,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frank_Oliver_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jesse_Black_Crow_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Renee_Deladier_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 230,
+        "height": 6.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Tiboro_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Nicholas_Scratch_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Charles_Chandler_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Trey_Rollins_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 165,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Charles_Little_Sky_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zuzha_Yu_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 84,
+        "height": 5.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Enmity_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 128,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vixen_(British_Crimelord)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 154,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Christopher_Cassera_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/White_Dragon_(Chinatown)_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 1000,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Proudstar_(Earth-1100)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kevin_Trench_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Bernadette_Rosenthal_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Vincent_Patilio_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 110,
+        "height": 5.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Sasha_Martin_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 189,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Trenton_Craft_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alana_Jobson_(Sara_Ehret)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Janis_Jones_(Earth-9200)"
+    },
+    {
+        "strength": 3,
+        "weight": 158,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zodiac_(Dark_Reign)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Curtis_Carr_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kinji_Obatu_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 245,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Drew_Daniels_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Beautiful_Dreamer_(Morlock)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sk%27ym%27x_(Earth-712)"
+    },
+    {
+        "strength": 2,
+        "weight": 330,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zachary_Smith_Jr._(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gordon_Thomas_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 660,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Perun_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Howard_Mitchell_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Aaron_Chord_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Illyana_Rasputina_(Earth-4210)"
+    },
+    {
+        "strength": 2,
+        "weight": 158,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sheoke_Sanada_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 158,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jean-Paul_Duchamp_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 350,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mojo_Adams_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Autonomously_Decisive_Automated_Mechanism_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Barry_Bauman_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Shir_Ydrn_Talonis_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 2123,
+        "height": 13.083333333333334,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Inheritor_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thomas_Jones_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1050,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Aragorn_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joseph_Cartelli_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 280,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Byrrah_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 480,
+        "height": 7.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hemingway_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 177,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/William_Robert_Reilly_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Andrew_Graves_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 16000,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mordecai_Midas_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/M%27Nai_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 774,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Roughouse_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Adrian_Corbo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1,
+        "height": 16.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Big_Mother_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 23,
+        "height": 2.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Atleza_Langunn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cassandra_Richards_(Earth-6311)"
+    },
+    {
+        "strength": 3,
+        "weight": 229,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Louis_Sadler,_Jr._(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Elaine_Coll_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Warren_Traveler_(Earth-58163)"
+    },
+    {
+        "strength": 2,
+        "weight": 193,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sinclair_Abbott_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 129,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Celia_Ricadonna_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zephyrus_Jones_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 290,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bercilak_de_Hautdesert_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jody_Putt_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Philip_Sheldon_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 101,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Number_Nine_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jaine_Cutter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bird-Brain_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Andr%C3%A9_Gerard_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Leopold_Stryke_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 300,
+        "height": 6.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Melvin_Potter_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 135,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kala_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Simon_Maddicks_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Seth_Voelker_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 1050,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Missing_Link_(Lincoln)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 165,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sergei_Krylov_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Leila_Davis_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Basil_Elks_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/James_Jaspers_(Earth-238)"
+    },
+    {
+        "strength": 2,
+        "weight": 290,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jared_Corbo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Damon_Dran_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 450,
+        "height": 8.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Psyklop_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 36000,
+        "height": 300.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gog_(Tsiln)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 114,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Tanya_Trask_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 159,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sarah_Ryall_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Darian_Elliott_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 235,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Markus_Ettlinger_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 96,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ce%27Athauna_Asira_Davin_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 105,
+        "height": 5.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Alexander_Woolcot_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Steven_Hudak_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 400,
+        "height": 8.583333333333334,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/White_Tiger_(Evolved_Tiger)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 195,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ganymede_(Spinsterhood)_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 189,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Boris_(Latverian)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 77,
+        "height": 2.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Deuce_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 1320,
+        "height": 12.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lyle_Dekker_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 240,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Marco_Delgado_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Martin_Blank_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 265,
+        "height": 6.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Woodgod_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 127,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gloria_Mu%C3%B1oz_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 119,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Priscilla_Lyons_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 800,
+        "height": 8.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rintrah_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Stellaris_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 495,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elton_Morrow_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 135,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elizabeth_Barstow_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 1225,
+        "height": 8.166666666666666,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Electro_(Robot)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 450,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Meranno_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 133,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Leiko_Wu_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 55,
+        "height": 4.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tim_Harrison_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Katherine_Pryde_(Earth-295)"
+    },
+    {
+        "strength": 1,
+        "weight": 1,
+        "height": 2.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tippy-Toe_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Xira_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 205,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Syndicate_(Luke_and_Matthew)_(Earth-1610)"
+    },
+    {
+        "strength": 3,
+        "weight": 245,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bishop_(Earth-2107)"
+    },
+    {
+        "strength": 2,
+        "weight": 105,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mary_Mitchell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Blaine_Colt_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 200,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Josef_Huber_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 137,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Millicent_Collins_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Chili_Storm_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 652,
+        "height": 6.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Fat_Cobra_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 173,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_van_Patrick_(Van)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 145,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anthony_Davis_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Carl_Burbank_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Captain_Barracuda_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 157,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ereshkigal_(Deviant)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ambient-Energy_Dampening_Actualization_Module_Unit_Zero_(Earth-4935)"
+    },
+    {
+        "strength": 3,
+        "weight": 161,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lupa_(Savage_Land_Mutate)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 260,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Skullbuster_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Silas_King_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Infant_Terrible_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dakota_North_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Venkat_Katregadda_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 157,
+        "height": 5.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Frederick_Foswell_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 98,
+        "height": 5.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Moira_Brandon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Arnold_Lundberg_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 128,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Andrea_Roarke_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 118,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dania_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 343,
+        "height": 4.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Googam_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 516,
+        "height": 7.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Otto_Kronsteig_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 625,
+        "height": 6.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Tezcatlipoca_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 144,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Invader-1_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lunatik_(Mercenary)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 199,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shola_Inkose_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Piper_Dali_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 3600000000000,
+        "height": 15840.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Apocalypse_Beast_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Benjamin_Parker_(Earth-6078)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jonathan_Storm_(Earth-721)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Percy_%26_Barton_Grimes_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Lumpkin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Brian_DeWolff_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 278,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Llyron_McKenzie_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sunset_Bain_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Victoria_Star_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Domini_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Louis_Dexter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mortimer_Everett_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zachary_Williams_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kurt_Gerhardt_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shen_Kuei_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 915,
+        "height": 7.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Qnax_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Yandroth_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dark-Crawler_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Thomas_Lightner_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sprite_(Eternal)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 326,
+        "height": 6.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Litterbug_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 135,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Aldo_Ferro_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ulysses_Archer_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jacob_Nash_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 129,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alyssa_Moy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Electric_Eve_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alysande_Stuart_(Earth-9809)"
+    },
+    {
+        "strength": 6,
+        "weight": 905,
+        "height": 7.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eochaid_Ollathir_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 590,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cairbre_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Erica_Sondheim_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 169,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Carlos_Cabrera_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 257,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bran_Bardic_(Earth-70518)"
+    },
+    {
+        "strength": 6,
+        "weight": 285,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cephalus_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1700,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Toothgnasher_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Elijah_Stern_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Elfqueen_(Linnea)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Manta_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zoltan_Drago_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 183,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Titan_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 415,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tyrak_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Annalee_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 568,
+        "height": 8.083333333333334,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frank_Skorina_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tana_Nile_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 139,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Giuletta_Nefaria_(Masque)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kamal_el_Alaoui_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 160,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cody_Fleischer_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Raniero_Drago_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 163,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Veronica_Dultry_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 800,
+        "height": 8.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Blood_Brothers_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Prowler_(The_Cat)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 265,
+        "height": 6.416666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Korrek_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Adam_II_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 220,
+        "height": 6.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eisenhower_Canty_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 197,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Elizabeth_Rawson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Gloria_Grant_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Conrad_Josten_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Alexander_Ellis_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jack_Danner_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kateri_Deseronto_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gravemoss_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 325,
+        "height": 7.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ghoul_(Killer)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sinjin_Quarrel_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 990,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Reptyl_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 218,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ardina_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 480,
+        "height": 50.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Intelligentsia_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jacob_Oh_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 250,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Buford_Wilson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 5400,
+        "height": 15.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Belathauzer_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arthur_Blackwood_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 171,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Katu_Kath_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 127,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Woodstock_Schumaker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/John_Lopez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Amelia_Weatherly_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 131,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Rachel_Argosy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 219,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Manuel_Eloganto_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 231,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Paine_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Healer_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 250,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Philip_Javert_(Earth-921)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Arthur_Dearborn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Turk_Barrett_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Brendon_Doyle_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Marcus_Andrews_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 139,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Scaleface_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 60,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Straw_Man_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Aleksey_Lebedev_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Prester_John_(Johann)_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 385,
+        "height": 6.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Death_Metal_(Earth-8410)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Carl_Burgess_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alice_Nugent_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 153,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Beatta_Dubiel_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 165,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alton_Vibereaux_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 142,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elizabeth_Bondi_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Leonard_Tippit_(Multiverse)"
+    },
+    {
+        "strength": 6,
+        "weight": 257,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bran_Braddock_(Earth-2122)"
+    },
+    {
+        "strength": 4,
+        "weight": 160,
+        "height": 4.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Eitri_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 2500,
+        "height": 14.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Horde_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 132,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mari_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 132,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Charlemagne_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 199,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Richard_Palance_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 205,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Oyakata_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Fabian_Marechal-Julbin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Carson_Knowles_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 125,
+        "height": 5.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Brainchild_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Raoul_Bushman_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 829,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Archibald_Dyker_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 680,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Neutron_(Imperial_Guard)_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 185,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Quincy_Harker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Antoine_Delsoin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Molly_Fitzgerald_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 205,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Marcus_Kang_XXIII_(Earth-6311)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Johnny_Wakely_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Doris_Evans_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 126,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Marianne_Rodgers_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lily_Cromwell_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 5.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Albert_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Betty_Dean_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 129,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Marie_Laveau_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Hunter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 98,
+        "height": 5.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Mary_Zero_(Mary)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 142,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Leeann_Foreman_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jack_Magniconte_(Earth-148611)"
+    },
+    {
+        "strength": 2,
+        "weight": 90,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kristine_Watson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1400000,
+        "height": 100.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Chiantang_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vincente_Fortunato_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zhered-Na_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 524,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hrinmeer_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 345,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Gorgilla_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Percival_Pinkerton_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Henry_Hellrung_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Earl_Everett_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 165,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Jack_Mead_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lee_Guardineer_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Philip_Wing_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/William_Allen_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 97,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Chance_(Fallen_Angels)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Allen_Marc_Yuric_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thomas_Corsi_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Myles_Alfred_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 290,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Vril-Rokk_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 159,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Willie_Walkaway_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 776,
+        "height": 9.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Imus_Champion_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 179,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/William_Carmody_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 450,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Craig_Saunders_Jr._(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mortigan_Goth_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Roscoe_Sweeney_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Slaymaster_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Patricia_Starr_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jonathan_Bryant_(Digitek)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 198,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wyre_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 195,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jack_the_Ripper_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 280,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/William_Young_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Gregory_Herd_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Araki_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/John_McIver_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Piet_Voorhees_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 400,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Yuriko_Oyama_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jonathan_Juniper_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 128,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shang-Chi_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 351,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kyknos_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Mana_Yanowa_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ronald_English_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Phillip_Sterling_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Fang_(Imperial_Guard)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 173,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/John_Zander_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 75,
+        "height": 2.1666666666666665,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/B%27nee_and_C%27cll_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Mentor_(Imperial_Guard)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Francisco_Milan_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 265,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Turac_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 1,
+        "height": 1.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Sikorsky_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 245,
+        "height": 7.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mark_Hallett_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 300,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kirigi_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 194,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sean_Watanabe_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Kenneth_Crichton_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 810,
+        "height": 6.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Elektro_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 732,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ahpuch_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 620,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dionysus_Acratophorus_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Andro_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 126,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Angel_Dust_(Christina)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dirtnap_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 153,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Neil_Shelton_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 300,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Milos_Abyss_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alison_Blaire_(Earth-295)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Witness_(WWII)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 5.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Zhao_Yen_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Aireo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 252,
+        "height": 6.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Julius_Mullarkey_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Reynard_Slinker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 139,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Cole_Wittman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thelius_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mendendez_Flores_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Astra_(Imperial_Guard)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Calvin_Carr_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Burtram_Worthington_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 285,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Paul_Destine_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Eric_Kleinstock_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 119,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Irene_Merryweather_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anthony_Davis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frank_Farnum_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Molyb_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 235,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Victor_Conrad_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Charles_Weiderman_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 150,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Pixie_(First_Line)_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 280,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Meryet_Karim_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 4000,
+        "height": 25.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gormuu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 603,
+        "height": 6.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Arthur_Nagan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alan_Fagan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gianna_Esperanza_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rick_Mason_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 475,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Samantha_Parrington_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 213,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Condor_(Nova_Foe)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Aamshed_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Vera_Cantor_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Gary_Wilton,_Jr._(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 136,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Semiramis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 176,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Don_Hertz_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Brent_Jackson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 115,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Night_Raven_(Vigilante)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 265,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Rieg_Davan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sapphire_Styx_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Shatter_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 250,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Waring_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 300,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/A%27Sai_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Randolph_Robertson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1300,
+        "height": 5.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Brightwind_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 280,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jason_Roland_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Navid_Hashim_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nick_Lewis,_Sr._(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 400,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Owayodata_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 575,
+        "height": 6.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Quetzalcoatl_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 150,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jordan_Boone_(Earth-928)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Black_Axe_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Roy_Chambers_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jack_Castle_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 220,
+        "height": 7.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Rex_Randolph_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Marlene_Alraune_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 410,
+        "height": 4.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bonebreaker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jalome_Beacher_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jonas_Harrow_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Achebe_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 169,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Pierre_Fresson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Buchanan_Mitty_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Tagak_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Luis_Alvarez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_Rossi_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 134,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jacob_Eichorn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 252,
+        "height": 6.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Giraud_(Earth-691)"
+    },
+    {
+        "strength": 2,
+        "weight": 243,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Edward_March_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 230,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Russ_Broxtel_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 139,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jacob_Lashinski_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Magique_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 169,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Harold_Kane_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jeff_Hagees_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zemu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Richard_Janus_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jason_Ionello_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 165,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Paul_Hark_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 250,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dynamic_Man_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 285,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nimrod_(Vampire)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/William_Scott_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 132,
+        "height": 5.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bambina_Arbogast_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 674,
+        "height": 20.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Imdugud_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 158,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Fera_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 1490,
+        "height": 9.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Hadad_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 200,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jason_Cragg_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 176,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wallace_Jackson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Peter_Noble_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Andrea_von_Strucker_(Clone)_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 2000,
+        "height": 10.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Unum_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Miles_Warren_(Clone)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ree-Zee_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 142,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Robert_Hellsgaard_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 20,
+        "height": 2.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kerberos_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 280,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Melvin_Potter_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 235,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Barbarus_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Desmond_Drew_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 125,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Delilah_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 151,
+        "height": 5.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Brian_Dunlap_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 6.416666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Model_X3Z_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cathy_Webster_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1200,
+        "height": 9.083333333333334,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Isaac_Javitz_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Samantha_Dunbar_(Heroes_Reborn)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 189,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Parnell_Jacobs_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ferdinand_Lopez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Manslaughter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathan_Dolly_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nightside_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 129,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maguire_Beck_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 115,
+        "height": 5.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Cecilia_Cardinale_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jesse_Aaronson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Blackie_Gaxton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 173,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Donald_Birch_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Caretaker_(Blood)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Edward_Buckman_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zarek_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mzungu_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Postman_(David)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/N%27Kano_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Piper_(Morlock)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dane_Whitman_(Earth-374)"
+    },
+    {
+        "strength": 3,
+        "weight": 290,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Marduk_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 181,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Michael_Stockton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 156,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cyrus_Black_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 205,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/John_Tensen_(Earth-148611)"
+    },
+    {
+        "strength": 2,
+        "weight": 173,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sol_Brodstroke_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dennis_Burton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 80,
+        "height": 4.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Evans,_Jr._(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 222,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jim_Gardley_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 27766,
+        "height": 833.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Klaatu_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 147,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/KalAOL_(Earth-3131)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ananastasia_Rinaldi_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Charles_Grey_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Stacy_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 152,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Black_Fox_(Thief)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bradley_Kroon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 235,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lupo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Magnus_(Sorcerer)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 123,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Michael_Silk_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 20000,
+        "height": 50.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tomazooma_(Robot)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 338,
+        "height": 7.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rafael_Carago_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Victor_Ludwig_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Naomi_Kale_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 245,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jonathan_Darque_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thomas_Stuart_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 129,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cybelle_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jack_Truman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gulliver_Jones_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Kyllian_Boddicker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 148,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Rumor_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ken_Ellis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Garrison_Klum_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 280,
+        "height": 6.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Thoth_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ronald_Hilliard_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1675,
+        "height": 12.666666666666666,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ch%27Vayre_(Earth-4935)"
+    },
+    {
+        "strength": 4,
+        "weight": 1225,
+        "height": 7.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Extirpia_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Inanna_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 45,
+        "height": 1.9166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sassafras_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sven_Kleinstock_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 101,
+        "height": 5.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Suwan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jackson_Day_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Douglas_Birely_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Glitternight_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 290,
+        "height": 6.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gaza_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 151,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Radha_Dastoor_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Hussar_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 153,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Leash_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1150,
+        "height": 10.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nebulon_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Brock_Jones_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 505,
+        "height": 7.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mahkizmo_(Earth-74101)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ape_(Morlock)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 257,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Donald_Clendenon_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Arlette_Truffaut_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 360,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hubert_Carpenter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Isaiah_Curwen_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 800,
+        "height": 10.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Edward_Cross_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 169,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Carlo_Strange_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 137,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Trung_Tuan_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 400,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Android_Man_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 700,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Prime_Mover_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/De%27Lila_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Scintilla_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 1200,
+        "height": 6.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Randau_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 62,
+        "height": 3.1666666666666665,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Isabella_Carmela_Magdalena_Gnucci_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 132,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Regina_Morgan_(Earth-982)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.416666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Jackson_Weele_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 270,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Virako_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jacob_Conover_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Hastings_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Heather_Glenn_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 425,
+        "height": 7.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Berserker_(Primitive)_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 350,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gitche_Manitou_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 189,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thomas_Samuels_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 235,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sal_Kennedy_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 145,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jean-Pierre_Beaubier_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 195,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Blackwulf_(Lucian)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Keith_Remsen_(Earth-148611)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nguyen_Ngoc_Coy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 144,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Clytemnestra_Erwin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 129,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tuk_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Angela_Cairn_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 300,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Daniel_Rose_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Harlan_Kleinstock_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ben_Urich_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 110,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Whiz_Kid_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 181,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arthur_Bigelow_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kathleen_Dare_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 3572,
+        "height": 10.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kerwin_Korman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Xakku_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 122,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Sandra_Verdugo_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 923,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Titannus_(Earth-5012)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Elton_Healey_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 197,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Greg_Salinger_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ghaur_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 142,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Harold_Harold_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 168,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/August_Hopper_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 235,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Pretty_Boy_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 220,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anthony_Power_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 35,
+        "height": 3.1666666666666665,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Elsie_Dee_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 395,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Sonny_Baredo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 163,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tar_Baby_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Joseph_Hogan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 320,
+        "height": 4.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kurrgo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 153,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Maris_Morlak_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 110,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Rutherford_Princeton_III_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 516,
+        "height": 6.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Monstra_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 425,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Saint_Elmo_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 205,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zuri_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Heather_McDaniel_(Earth-3470)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Orson_Kasloff_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Nadia_Dornova_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 700,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Flexo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 285,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Chronok_(Earth-6025)"
+    },
+    {
+        "strength": 6,
+        "weight": 300,
+        "height": 7.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Frank_Bigelow_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Joost_van_Straaten_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Kurt_Barton_(Earth-4040)"
+    },
+    {
+        "strength": 4,
+        "weight": 142,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ravonna_Renslayer_(Earth-93091)"
+    },
+    {
+        "strength": 4,
+        "weight": 26000,
+        "height": 38.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Uncegila_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gaunt_(Earth-29283)"
+    },
+    {
+        "strength": 3,
+        "weight": 240,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lagaro_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 4.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Freki_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 163,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Garko_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 141,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Valeria_Toomes_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 122,
+        "height": 4.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/King_Cadaver_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 4.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hank_Kipple_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Electron_(Imperial_Guard)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Desmond_Charne_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Alain_Racine_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 320,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vessel_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Shazana_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Piranha_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 151,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Scarlet_Fasinera_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sandy_Vincent_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 145,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mechamage_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Wayne_Markley_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nina_Tsiolkovsky_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Piper_(Savage_Land_Mutate)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 245,
+        "height": 5.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tamara_Rahn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Zorba_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 1000000,
+        "height": 84.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Slorioth_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 360,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Giacomo_Fortunato_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/MK-9_(Earth-71778)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Keniuchio_Harada_(Earth-295)"
+    },
+    {
+        "strength": 2,
+        "weight": 179,
+        "height": 5.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Pavel_Plotnick_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/John_Ryker_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 750,
+        "height": 7.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bodb_Derg_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ramrod_(Cyborg)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 222,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Victor_Slaughter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 181,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Merzah_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Allan_Lewis_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 4.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Geri_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 12.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dam-Ayido_Wede_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 139,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Martin_Simon_Burns_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Narda_Ravanna_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Stephen_Beckley_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 425,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Flying_Tiger_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 119,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Patricia_Tilby_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 660,
+        "height": 6.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mogul_of_the_Mystic_Mountain_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Douglas_Carmody_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Roland_Rayburn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Pascal_Horta_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 115,
+        "height": 5.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Suzi_Endo_(Earth-9528)"
+    },
+    {
+        "strength": 2,
+        "weight": 107,
+        "height": 5.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Karl_Kort_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 24000,
+        "height": 30.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Colossus_(Vegan)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Deborah_Bertrand_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 80,
+        "height": 4.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Hubert_Fusser_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Max_Parrish_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lawrence_Young_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 182,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tigon_Liger_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 183,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tom_Regal_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 82,
+        "height": 4.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Neosaurus_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 121,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Fabian_Stankowicz_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Hedy_Wolfe_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jill_Stacy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Paul_Stacy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/William_Lincoln_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Carik_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Stacy_Dolan_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 467,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Knorda_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 185,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kearson_DeWitt_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Shagreen_(Earth-5311)"
+    },
+    {
+        "strength": 2,
+        "weight": 182,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Derek_Khanata_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Edwin_Cord_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Sedna_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Clive_Reston_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 230,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Suma-Ket_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Astrid_Mordo_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Solomon_Prey_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 257,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Spencer_Keen_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Brainstorm_(Jimmy)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Laslo_Pevely_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alisher_Sham_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 133,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ladyfair_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joaquin_Pennysworth_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 347,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Roberta_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Monako_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zara_of_the_Jungle_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 20,
+        "height": 3.4166666666666665,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hugin_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 278,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zaniac_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Hero_of_the_Day_(Earth-8386)"
+    },
+    {
+        "strength": 2,
+        "weight": 237,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Boss_Morgan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 8,
+        "height": 1.3333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cr%27reee_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 450,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Setanta_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 52,
+        "height": 2.5833333333333335,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Biri_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 970,
+        "height": 7.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Fireflyte_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/William_Roberts_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 280,
+        "height": 6.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mickey_Tork_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 390,
+        "height": 6.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Buck_Cashman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 154,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Tako_Shamara_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 420,
+        "height": 12.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dromedan_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Norman_Harrison_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 400,
+        "height": 12.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Randolph_James_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/William_Turner_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Necrom_(Earth-148)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Seward_Trainer_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Reed_Richards_(Earth-944)"
+    },
+    {
+        "strength": 5,
+        "weight": 325,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Edward_Cobert_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 244,
+        "height": 6.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Malcolm_Murphy_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 185,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Llan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lawrence_Cranston_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 532,
+        "height": 10.333333333333334,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lurking_Unknown_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 173,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Pierre_Truffaut_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 292,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Geatar_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Burt_Kenyon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Andre_Rostov_(Agamemnon)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 250,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kulla_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 163,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Frank_Smith_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 195,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arides_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 450,
+        "height": 7.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Monstro_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Arthur_Stacy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Arc_(Imperial_Guard)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/M-Nell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jim_Sharp_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 145,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Leslie_Anne_Shappe_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 140,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Nathan_Lubensky_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Raymond_Sikorski_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 145,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jennifer_Swensen_(Earth-148611)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Kyle_Gibney_(Earth-295)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sn%27Tlo_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 225,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Phaeder_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 125,
+        "height": 4.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Pico_Halfghanaghan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dafydd_ap_Iowerth_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Chip_Martin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Keith_Kraft_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nagala_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 211,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Harrow_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 293,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Manfred_Haller_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Vuk_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 227,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Muzzafar_Lambert_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Rhodes_(Earth-55921)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ricky_Gibson_(Earth-1610)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Agron_(Earth-76216)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Commander_Kraken_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Earthquake_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Edith_Harker_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 390,
+        "height": 6.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Urthona_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Harrington_Byrd_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 252,
+        "height": 6.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Charles_Moss_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mary_Brown_(Karisma)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Blackthorn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 45,
+        "height": 3.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Fader_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 5.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Meltdown_(Russian)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 212,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Carl_Blake_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nicholas_Grossman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 234,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Aggamon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 3.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dwarf_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Anton_Hellgate_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 1200,
+        "height": 6.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Nathaniel_Bumpo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 156,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sonya_Tolsky_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 90,
+        "height": 4.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Benjamin_Beckley_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jon_Kasiya_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathan_Lemon_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 395,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Roco-Bai_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ixar_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1020,
+        "height": 10.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Preak_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Master_Zhao_(Earth-928)"
+    },
+    {
+        "strength": 2,
+        "weight": 181,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Stewart_Ward_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 990,
+        "height": 15.333333333333334,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Oberon_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 447,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Morwen_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Verminus_Rex_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 403,
+        "height": 6.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Daniel_Axum_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.583333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Linda_Littletrees_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Leonard_Gade_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 20,
+        "height": 3.4166666666666665,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Munin_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Crystar_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1700,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Toothgrinder_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 6389,
+        "height": 13.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Grendell_(Dark_Elf)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 119,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Martin_Oksner_Burns_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 4.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Papa_Shorty_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Todd_Fields_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 40,
+        "height": 2.4166666666666665,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ina_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 317,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mortimer_Norris_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 510,
+        "height": 7.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Predator_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 155,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Harvey_Schlemerman_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Druig_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Equilibrius_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kevin_O%27Brien_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Hobgoblin_(Imperial_Guard)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Grannz_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 96000,
+        "height": 30.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tempus_(Immortus_Servant)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Blank_(Clyde)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 183,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Manuel_Vicente_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robbie_Rodriguez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Gabriel_(Devil-Hunter)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Redford_Raven_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Madame_Macabre_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 975,
+        "height": 8.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Caldwell_Rozza_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gregory_Gideon_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 532,
+        "height": 7.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Death_Wreck_(Minion)_(Earth-8410)"
+    },
+    {
+        "strength": 3,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Doe_(Earth-8908)"
+    },
+    {
+        "strength": 3,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Wildrun_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 6.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ricardo_Jones_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 137,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Delphos_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 780,
+        "height": 7.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Yeti_(Inhuman)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 390,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ernest_St._Ives_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 267,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Jonathan_Tremont_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Oswald_Silkworth_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 16000,
+        "height": 25.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Chtylok_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mikado_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Advisor_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Elianne_Turac_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 195,
+        "height": 5.083333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Michael_Hart_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 220,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nick_Katzenberg_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Samuel_Silke,_Jr._(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 243,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jaromel_(Earth-69901)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Abraham_Zimmer_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 825,
+        "height": 7.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Nuadhu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 6000,
+        "height": 19.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zxaxz_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Stephen_Loss_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 868,
+        "height": 7.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Durok_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Tito_Mendez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 241,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Selma_Blotte_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 128,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Evelyn_Necker_(Earth-8410)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Darklore_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Christopher_Daniels_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 42000,
+        "height": 27.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mechano_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Morley_Erwin_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 240,
+        "height": 9.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Daniel_Jermain_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 220,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kimora_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Juan-Carlos_Sanchez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dale_Sturm_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Foster_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Robert_Strong_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tigerman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 400,
+        "height": 4.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zar_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 260,
+        "height": 2.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Puppy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jacques_Dernier_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 133,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Grace_%26_Mary_Mercy_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Duncan_Vess_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 175,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Alex_Wildman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Andrea_von_Strucker_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Andreas_von_Strucker_(Earth-1610)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Susan_Storm_(Doppelganger)_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 133,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Eric_Cameron_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ross_G._Everbest_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 1590,
+        "height": 8.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Golem_(Statue)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 155,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nocturne_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 74,
+        "height": 3.4166666666666665,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Faceless_One_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 3125,
+        "height": 15.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dark_Rider_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 251,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Aaron_English_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 475,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mister_Jip_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jeremy_Swimming-Bear_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gerald_Stone_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 192,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hatap_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Charles_Stanton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Carl_Zante_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 755,
+        "height": 7.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Digger_(Vegas_Thirteen)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 187,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hate-Monger_(Psycho-Man%27s_Creation)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gerald_Marsh_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 297,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Antonio_Rojo_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Clifton_Shallot_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 200,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Arisen_Tyrk_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 5.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Hardball_(Imperial_Guard)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 245,
+        "height": 6.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Taj_Nital_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dakor_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 135,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Joy_Mercado_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 130,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Martha_Gomes_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Catherine_D%27Antan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Conundrum_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Yith_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 100,
+        "height": 5.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Rebecca_Blake_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 15,
+        "height": 1.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Baby_Karen_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 4750,
+        "height": 7.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Black_Brigade_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 188,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shigeru_Ezaki_(Clone)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Neil_Donaldson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 94,
+        "height": 4.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nyko_Halfghanaghan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mikal_Drakonmegas_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 127,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Aranda_Charboneau_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sandu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Buford_Lange_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 40000,
+        "height": 164.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Droom_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alfredo_Morelli_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 250,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Scully_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Taboo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Victor_Jay_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1100,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Strider_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 185,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Thomas_Thunderhead_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Marcus_Hazzard_(Earth-148611)"
+    },
+    {
+        "strength": 4,
+        "weight": 3400,
+        "height": 12.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cauldron_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 350,
+        "height": 8.166666666666666,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Varen_David_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Generic_Super-Hero_(Earth-84041)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alfonso_Lopez_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 89,
+        "height": 4.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Manticore_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 455,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Deimne_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 188,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Barnabus_Mullen_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/John_Wilson_(Golden_Age)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 178,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Pink_Lady_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ramades_(Earth-6311)"
+    },
+    {
+        "strength": 2,
+        "weight": 164,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Harrison_Stavrou_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Zachary_Moonhunter_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Misty_Collins_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 142,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/John_Ladue_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Flavius_Scollio_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1876,
+        "height": 12.166666666666666,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Harlan_Ryker_(Earth-7484)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Cache_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Edward_Forsyth_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Michael_English_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lucas_Brand_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Barbara_Robb_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 217,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Abner_Jonas_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gorr_(New_Men)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Talisman_(Australian)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jerold_Morgan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Moondark_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 155,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Khaos_(Earth-9339)"
+    },
+    {
+        "strength": 4,
+        "weight": 205,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Richard_Jones_(Earth-9309)"
+    },
+    {
+        "strength": 4,
+        "weight": 2400,
+        "height": 12.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gargantus_(Alien_Robot)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Brian_Muldoon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 250,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ivan_Kronov_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Bruce_Bravelle_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 157,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Elias_Weams_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 195,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/David_Breyer_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 211,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/O.Z._Chase_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 2500,
+        "height": 15.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tutinax_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 191,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Horatio_Walters_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 595,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Achelous_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 230,
+        "height": 6.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kirov_Petrovna_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 220,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Blow-Hard_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Rupert_Kemp_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 310,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Yukotujakzurjimozoata_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 30000,
+        "height": 20.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tim_Boo_Ba_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 176,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lance_Temple_(Outlaw_Kid)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mosha_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Felix_Alvarez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Isidoro_Scarlotti_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Priscilla_Ironwood_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 2000,
+        "height": 20.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Whistle_Pig_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 78,
+        "height": 4.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/R%27Kin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 96,
+        "height": 5.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sister_Nil_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 143,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zota_of_Pergamum_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 510,
+        "height": 6.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Shango_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 900,
+        "height": 7.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Full_Acclimation_Combat_And_Defence_Explo-skeleton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 182,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Murch_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Meredith_McCall_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mike_Farrell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 115,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Wilhelmina_Lumpkin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alfie_O%27Meagan_(Earth-8908)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/James_Owl_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 142,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Suspiria_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 300,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Marvex_the_Super-Robot_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 224,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Azaziah_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1400,
+        "height": 10.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Doombringer_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 195,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jason_Beere_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 146,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Virago_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 130,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/K%27rll_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 177,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Henry_Akai_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Monark_(Earth-7643)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Benjamin_Ruff_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 195,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Doyle_Denton_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vampire_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 149,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Terry_Vance_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 173,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Pro-Rata_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 5210,
+        "height": 12.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Droog_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 540,
+        "height": 7.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Tiamat_(Champion)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 325,
+        "height": 9.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Solon_Stabilizer_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 225,
+        "height": 6.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Khufor_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 276,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/American_Samurai_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mort_Graves_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.916666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Geldoff_(Earth-1610)"
+    },
+    {
+        "strength": 5,
+        "weight": 300,
+        "height": 6.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Mowfus_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 185,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Draconis_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 45,
+        "height": 3.6666666666666665,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Papa_Hagg_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 95,
+        "height": 5.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Adri_Nital_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 167,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jerald_(Earth-7511)"
+    },
+    {
+        "strength": 1,
+        "weight": 109,
+        "height": 4.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Nathaniel_Omen_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Albert_Potter_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 120,
+        "height": 5.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Necrodamus_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 131,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/F.R._Crozier_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Denton_Phelps_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 179,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Simon_Meke_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Drom_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Pearla_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ral_Dorn_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 192,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sumner_Beckwith_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 181,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Liso_Trago_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 167,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Paxton_Page_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Justice_Peace_(Earth-869371)"
+    },
+    {
+        "strength": 4,
+        "weight": 2000,
+        "height": 15.416666666666666,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Rorgg_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/William_McLaughlin_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 120,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tamika_Bowden_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Animus_(Hate-Monger)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 165,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Richard_Raleigh_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Morris_Sloan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Kathy_Malper_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 230,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Skinner_(Lilin)_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 353,
+        "height": 6.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Bonham_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 143,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cassandra_Locke_(Earth-700)"
+    },
+    {
+        "strength": 2,
+        "weight": 215,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Wilhelm_van_Vile_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Rabble_Rouser_(Weinberg)_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 923,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Titannus_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 150,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dontrell_Hamilton_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1225,
+        "height": 7.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Eradica_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.416666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Salo_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 285,
+        "height": 6.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Abd-el-Hazred_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 208,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Death_Tiger_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 156,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tazza_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 430,
+        "height": 6.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Haokah_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Sagbata_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Richard_Rory_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 137,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Lawrence_Zaxton_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1000,
+        "height": 5.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Elendil_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 154,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Elias_Schleigal_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Kathryn_Cushing_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Victor_von_Doom_(Clone)_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 16000,
+        "height": 25.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Rakkhal_(Earth-6966)"
+    },
+    {
+        "strength": 1,
+        "weight": 160,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Henry_Mortonson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1200,
+        "height": 5.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Valinor_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ariel_Tremmore_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tapping_Tommy_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 398,
+        "height": 7.416666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Benjamin_Donovan_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 245,
+        "height": 5.25,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Edward_Ferbel_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 42000,
+        "height": 65.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Monstro_the_Mighty_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Texas_Kid_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 11,
+        "height": 0.9166666666666666,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Otto_von_Schmittsder_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 8,
+        "height": 290.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Colossus_(Super_Computer)_(Earth-60672)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Shredder_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Samuel_Smith_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 2,
+        "height": 15.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ddraig_Goch_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Donovan_Gorman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Trojak_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 7500,
+        "height": 20.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zombie_Master_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 120,
+        "height": 5.666666666666667,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Sky-Walker_(Starron)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 378,
+        "height": 6.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jaard_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gray_Garrison_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 1640,
+        "height": 7.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Dirty_Wolff_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Noah_DuBois_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 375,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Osinga_Rplss_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 132,
+        "height": 5.75,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Marcy_Pearson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Paddy_O%27Hanlon_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Barry_Windom_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Peter_Brand_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Sundance_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 700,
+        "height": 8.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Eye_Killers_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 165,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Lunatik_(Tyrk_Fragment)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dagny_Forrester_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dredmund_Cromwell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 125,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Apache_Kid_(Rosa)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 195,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kevin_Leonardo_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Lawrence_Chesney_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 4000,
+        "height": 18.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Necromon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 149,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jonathan_Logan_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gary_Buser_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/John_Robert_Keane_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 184,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jomo_Kimanye_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 4000,
+        "height": 25.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Grottu_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 290,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Occulus_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gregori_Larionov_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Trader_(Morlock)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Patrick_Carney_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 30000,
+        "height": 25.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thermal_Man_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/David_Christopher_Bank_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 90,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Mairi_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 65,
+        "height": 4.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hope_Hibbert_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kerwin_Broderick_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 250,
+        "height": 6.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Micah_Synn_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Sven_Gollison_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 16000,
+        "height": 28.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jakar_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 80,
+        "height": 4.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Diabolique_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 136,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/S%27Bak_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.333333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Megan_Daemon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 224,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Reginald_Mantz_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Joseph_Smith_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 142,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Philadelphia_Filly_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.833333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Purple_Hayes_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 250,
+        "height": 5.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Waldo_(Computer)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Steven_Rogers_(Impersonator)_(Earth-928)"
+    },
+    {
+        "strength": 4,
+        "weight": 130,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ultima_Wordman_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 191,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Larry_Scott_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1504,
+        "height": 12.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Cru_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 139,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lynx_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 158,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Rama_Kaliph_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 159,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Theodore_Scott_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Leslie_Lenrow_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 181,
+        "height": 6.083333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Black_Brother_(Joshua)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 260,
+        "height": 6.333333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Brell_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 290,
+        "height": 6.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lord_Moses_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 230,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lord_of_Death_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 200,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Mariano_Lopez_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 225,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lawrence_Rambow_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 100,
+        "height": 7.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/River_Verys_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 118,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Glenda_Sandoval_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jim_Taylor_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 105,
+        "height": 3.1666666666666665,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Shep_Gunderson_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 759,
+        "height": 8.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Mogol_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Michel_Berman_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 121,
+        "height": 5.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Sharon_Ginsberg_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/David_Dean_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 166,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ken_Masters_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 168,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Pusher_Man_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 178,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Benjamin_Rabin_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 185,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jonathan_East_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 197,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ilaney_Brukner_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 141,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Valerie_Toomes_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 161,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Nelson_Frank_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 420,
+        "height": 10.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Diablo_(Bear)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 109,
+        "height": 5.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Josephine_Pulaski_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 1300,
+        "height": 15.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Harek_Korgon_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Phineous_Umbridge_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 106,
+        "height": 5.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kelly_Kooliq_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 7.333333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Tyler_Smithson_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 480,
+        "height": 7.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Fear_(Dark_Man)_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 198,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Night_Flyer_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 118,
+        "height": 5.416666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Hiram_Riddley_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Rich_van_Burian_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 950,
+        "height": 8.5,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Ditmal_Pirvat_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 60,
+        "height": 2.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Brynocki_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 160,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Jebediah_Fate_(Earth-616)"
+    },
+    {
+        "strength": 7,
+        "weight": 232000,
+        "height": 50.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Xanth_(Earth-81049)"
+    },
+    {
+        "strength": 2,
+        "weight": 128,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Lucy_Westenra_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 225,
+        "height": 6.083333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Iconoclast_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 240,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Thibodaux_Boudreaux_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 136,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Elspeth_Cromwell_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alden_Maas_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 140,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Staak_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 3660,
+        "height": 10.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Geometer_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 65,
+        "height": 4.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Holly-Ann_Ember_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 325,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Man-oo_(Earth-616)"
+    },
+    {
+        "strength": 6,
+        "weight": 450,
+        "height": 7.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Frank_Johnson_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 100,
+        "height": 5.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Marandi_Sjorokker_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Edward_Passim_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lucy_Crumm_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 5.333333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Walter_Collins_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 160,
+        "height": 5.5,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Khafre_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Malachi_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 300,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lee_Portman_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 62000,
+        "height": 30.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Omnivore_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Clay_Riley_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 180,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Verdelet_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 130,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Vera_Gemini_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 143,
+        "height": 5.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Provost_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 190,
+        "height": 6.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Tongah_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 150,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Threkker_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 178,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Jefferson_Archer_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 195,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Gray_Dolman_(Earth-616)"
+    },
+    {
+        "strength": 5,
+        "weight": 410,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Priapus_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.833333333333333,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Artemus_Pithins_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 1225,
+        "height": 7.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Extermina_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 312000,
+        "height": 30.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Devil%27s_Heart_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 85,
+        "height": 3.1666666666666665,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gnome_(Scientist)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 132,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Aria_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 210,
+        "height": 6.25,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Tribune_(Tane)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Dorian_Murdstone_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 80,
+        "height": 5.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ulysses_Abboud_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 5061,
+        "height": 25.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Orrgo_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 210,
+        "height": 6.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Henry_Carter_(Earth-5464)"
+    },
+    {
+        "strength": 2,
+        "weight": 74,
+        "height": 4.583333333333333,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Jimmy_Everett_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Muro_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Luther_Robinson_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 166,
+        "height": 6.0,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Philo_Zogolowski_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Klaus_Kruger_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 175,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hunk_Hondo_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 150,
+        "height": 5.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ernest_Popchik_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 255,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Zacharaiah_Seavey_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 5.916666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Vincent_Martinelli_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 155,
+        "height": 2.5833333333333335,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Nimo_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 215,
+        "height": 6.166666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Hate-Monger_(National_Force)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 124,
+        "height": 5.166666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ana_Shwartz_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ambrose_Meek_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 110,
+        "height": 6.083333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Kl%27rt_(Earth-20604)"
+    },
+    {
+        "strength": 4,
+        "weight": 154,
+        "height": 5.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Varney_(Mortimer)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 121,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Dolly_Donahue_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 145,
+        "height": 5.75,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Ira_Gross_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 190,
+        "height": 5.916666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alexander_Bont_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 149,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Alistaire_Armstrong_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 340,
+        "height": 5.583333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Ape_(Old_West)_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 285,
+        "height": 6.416666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Armorer_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 98,
+        "height": 3.5,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Big_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 175,
+        "height": 5.916666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Comet_Pierce_(Earth-40800)"
+    },
+    {
+        "strength": 2,
+        "weight": 170,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Commuter_(Ron)_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 158,
+        "height": 5.833333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Darick_Gallhager_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 190,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Doctor_Weird_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 140,
+        "height": 5.5,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Duane_Freeman_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 160,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Edward_Brecker_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 125,
+        "height": 5.666666666666667,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Elyse_Nelson_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 152,
+        "height": 5.75,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Father_Darklyte_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.0,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Gavin_Grant_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 401,
+        "height": 6.666666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Iann-23_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 87,
+        "height": 4.666666666666667,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Ilse_Pterigil_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 220,
+        "height": 6.0,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Jack_Hazzard_(Earth-616)"
+    },
+    {
+        "strength": 2,
+        "weight": 180,
+        "height": 6.0,
+        "alignment": "Neutral",
+        "URL": "http://marvel.wikia.com/Jason_Jerome_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 154,
+        "height": 5.583333333333333,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Joseph_Calhoun_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 200,
+        "height": 6.25,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Joshua_Farkas_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 160,
+        "height": 5.75,
+        "alignment": "NA",
+        "URL": "http://marvel.wikia.com/Lord_Ruthven_(Earth-616)"
+    },
+    {
+        "strength": 3,
+        "weight": 135,
+        "height": 5.833333333333333,
+        "alignment": "Bad",
+        "URL": "http://marvel.wikia.com/Lotus_Newmark_(Earth-616)"
+    },
+    {
+        "strength": 1,
+        "weight": 130,
+        "height": 5.166666666666667,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lucas_Jackson_(Earth-616)"
+    },
+    {
+        "strength": 4,
+        "weight": 110,
+        "height": 5.25,
+        "alignment": "Good",
+        "URL": "http://marvel.wikia.com/Lynne_Harris_(Earth-616)"
+    }
+]

--- a/stories/data-graphics/elements/Line01.svelte
+++ b/stories/data-graphics/elements/Line01.svelte
@@ -58,7 +58,7 @@ const labels = Array.from({ length: K }).map((_, i) => `Group-${i}`);
   grid-template-columns: repeat(4, 200px);
   justify-items: start;
   align-items: start;
-  grid-column-gap: var(--space-2x);
+  grid-column-gap: var(--space-base);
   grid-row-gap: var(--space-4x);
   margin-top: var(--space-4x);
   font-family: var(--main-mono-font);

--- a/stories/data-graphics/elements/Line01.svelte
+++ b/stories/data-graphics/elements/Line01.svelte
@@ -1,0 +1,136 @@
+<script>
+import { onMount } from 'svelte';
+import { spring } from 'svelte/motion';
+import { derived } from 'svelte/store';
+import { format } from 'd3-format';
+import { fly } from 'svelte/transition';
+import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
+import Line from '../../../src/components/data-graphics/elements/Line.svelte';
+import Point from '../../../src/components/data-graphics/elements/Point.svelte';
+
+import MarginText from '../../../src/components/data-graphics/guides/MarginText.svelte';
+import LeftAxis from '../../../src/components/data-graphics/guides/LeftAxis.svelte';
+import BottomAxis from '../../../src/components/data-graphics/guides/BottomAxis.svelte';
+
+import Button from '../../../src/components/Button.svelte';
+
+const fmt = format(',.2f');
+
+function makeLine(m = 3, n = 1) {
+  let v = 50;
+  return Array.from({ length: 100 }).map((_, i) => {
+    const datapoint = { x: i + 1900, y: v };
+    v = Math.max(0, Math.min(100, v + (Math.random() - 0.5) * m * n));
+    return datapoint;
+  });
+}
+
+// let's make 25 lines.
+const K = 16;
+let lines = Array.from({ length: K })
+  .map((_, i) => spring(makeLine(5), { stiffness: 0.3, damping: 0.3 }));
+
+const lineSet = derived(lines, ($lines) => $lines);
+
+let hoverValue;
+
+function getY(data, x) {
+  const match = data.find((v) => v.x === x);
+  if (!match || !x) return undefined;
+  return match.y;
+}
+
+let mounted = false;
+
+onMount(() => {
+  mounted = true;
+});
+
+const labels = Array.from({ length: K }).map((_, i) => `Group-${i}`);
+
+</script>
+
+<style>
+
+.lines {
+  display: grid;
+  grid-template-columns: repeat(4, 200px);
+  justify-items: start;
+  align-items: start;
+  grid-column-gap: var(--space-2x);
+  grid-row-gap: var(--space-4x);
+  margin-top: var(--space-4x);
+}
+
+.offset-for-graphs {
+  padding-left: 45px;
+  padding-right: 20px;
+}
+
+h3 {
+  margin:0;
+  /* font-weight: 300; */
+  font-size: 14px;
+  text-align: center;
+
+}
+
+</style>
+
+<div class=story>
+
+  <h1 class="story__title offset-for-graphs">Lines</h1>
+
+  <div class=offset-for-graphs>
+    <Button compact level=medium on:click={() => {
+      lines.forEach((line, i) => {
+        line.set(makeLine(5));
+      });
+    }}>randomize</Button>
+  </div>
+{#if mounted}
+<div class=lines>
+  {#each $lineSet as line, i}
+  <div class=small-multiple in:fly={{ duration: 500, delay: (i) * 50, x: -5 }}>
+    <h3 class=offset-for-graphs>{labels[i]}</h3>
+    <DataGraphic
+      xDomain={[1900, 2000]}
+      yDomain={[0, 100]}
+      yType="linear"
+      xType="linear"
+      width={200}
+      height={100}
+      data={line}
+      top={20}
+      bind:hoverValue={hoverValue}
+    >
+      <LeftAxis ticks={[0, 50, 100]} showLabels={i === 0} />
+      <BottomAxis ticks={[1900, 1950, 2000]} />
+      <Line
+      lineDrawAnimation={{ duration: 1000, delay: i * 45 }}
+        data={line} 
+        xAccessor=x 
+        yAccessor=y />
+
+      <g slot='mouseover' let:value=>
+        {#if hoverValue.body}
+        <Point 
+            x={hoverValue.x} y={getY(line, Math.floor(hoverValue.x))} r={2} />
+          />
+          <Point 
+            x={hoverValue.x} 
+            y={getY(line, Math.floor(hoverValue.x))} 
+            r={1 + 10 * (getY(line, Math.floor(hoverValue.x)) / 100)} 
+            opacity={0.2}
+            />
+          <MarginText justify=left temporaryLabel={Math.floor(value.x) || ''} />
+          <MarginText justify=right temporaryLabel={value.y ? fmt(getY(line, Math.floor(hoverValue.x))) : ''} />
+        {/if}
+      </g>
+
+    </DataGraphic>
+  </div>
+  {/each}
+</div>
+{/if}
+</div>

--- a/stories/data-graphics/elements/Line01.svelte
+++ b/stories/data-graphics/elements/Line01.svelte
@@ -14,7 +14,9 @@ import BottomAxis from '../../../src/components/data-graphics/guides/BottomAxis.
 
 import Button from '../../../src/components/Button.svelte';
 
-const fmt = format(',.2f');
+const fmt = (v) => (v ? format(',.2f')(v) : '');
+const perc = format('.2p');
+const M = 6;
 
 function makeLine(m = 3, n = 1) {
   let v = 50;
@@ -25,14 +27,13 @@ function makeLine(m = 3, n = 1) {
   });
 }
 
-// let's make 25 lines.
 const K = 16;
 let lines = Array.from({ length: K })
-  .map((_, i) => spring(makeLine(5), { stiffness: 0.3, damping: 0.3 }));
+  .map((_, i) => spring(makeLine(M), { stiffness: 0.3, damping: 0.3 }));
 
 const lineSet = derived(lines, ($lines) => $lines);
 
-let hoverValue;
+let hoverValue = {};
 
 function getY(data, x) {
   const match = data.find((v) => v.x === x);
@@ -60,11 +61,25 @@ const labels = Array.from({ length: K }).map((_, i) => `Group-${i}`);
   grid-column-gap: var(--space-2x);
   grid-row-gap: var(--space-4x);
   margin-top: var(--space-4x);
+  font-family: var(--main-mono-font);
+
+}
+
+.small-multiple__header {
+  display: grid;
+  grid-template-columns: max-content auto;
+  grid-column-gap: var(--space-2x);
+}
+
+.small-multiple__metric {
+  font-size: 14px;
+  font-weight: 300;
+  justify-self: end;
 }
 
 .offset-for-graphs {
-  padding-left: 45px;
-  padding-right: 20px;
+  padding-left: 48px;
+  margin-right: 15px;
 }
 
 h3 {
@@ -72,7 +87,6 @@ h3 {
   /* font-weight: 300; */
   font-size: 14px;
   text-align: center;
-
 }
 
 </style>
@@ -83,8 +97,8 @@ h3 {
 
   <div class=offset-for-graphs>
     <Button compact level=medium on:click={() => {
-      lines.forEach((line, i) => {
-        line.set(makeLine(5));
+      lines.forEach((line) => {
+        line.set(makeLine(M));
       });
     }}>randomize</Button>
   </div>
@@ -92,7 +106,10 @@ h3 {
 <div class=lines>
   {#each $lineSet as line, i}
   <div class=small-multiple in:fly={{ duration: 500, delay: (i) * 50, x: -5 }}>
-    <h3 class=offset-for-graphs>{labels[i]}</h3>
+    <div class="small-multiple__header offset-for-graphs">
+      <h3>{labels[i]}</h3>
+      <div class='small-multiple__metric'>{fmt(getY(line, Math.floor(hoverValue.x ? hoverValue.x : line[line.length - 1].x)))}</div>
+    </div>
     <DataGraphic
       xDomain={[1900, 2000]}
       yDomain={[0, 100]}
@@ -123,8 +140,8 @@ h3 {
             r={1 + 10 * (getY(line, Math.floor(hoverValue.x)) / 100)} 
             opacity={0.2}
             />
-          <MarginText justify=left temporaryLabel={Math.floor(value.x) || ''} />
-          <MarginText justify=right temporaryLabel={value.y ? fmt(getY(line, Math.floor(hoverValue.x))) : ''} />
+          <MarginText fontSize=11.5 justify=left temporaryLabel={Math.floor(value.x) || ''} />
+          <MarginText fontSize=11.5 justify=right temporaryLabel={value.y ? perc(getY(line, Math.floor(hoverValue.x)) / line[0].y - 1) : ''} />
         {/if}
       </g>
 

--- a/stories/data-graphics/elements/Line02.svelte
+++ b/stories/data-graphics/elements/Line02.svelte
@@ -1,0 +1,102 @@
+<script>
+import { cubicOut as easing } from 'svelte/easing';
+
+import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
+import Line from '../../../src/components/data-graphics/elements/Line.svelte';
+import Point from '../../../src/components/data-graphics/elements/Point.svelte';
+import LeftAxis from '../../../src/components/data-graphics/guides/LeftAxis.svelte';
+import BottomAxis from '../../../src/components/data-graphics/guides/BottomAxis.svelte';
+import MarginText from '../../../src/components/data-graphics/guides/MarginText.svelte';
+
+
+import Springable from '../../../src/components/data-graphics/motion/Springable.svelte';
+import Tweenable from '../../../src/components/data-graphics/motion/Tweenable.svelte';
+
+function createData(n = 30) {
+  let y = 50;
+  return Array.from({ length: n }).map((_, i) => {
+    let r = (Math.random() - 0.5) * 20;
+    y = Math.max(0, Math.min(100, y + r));
+
+    let year = Math.floor(i / 12);
+    let month = 3;// (i % 12) + 1;
+    let day = i + 1;
+
+    return { y, x: new Date(`${1990}-${month}-${day}`) };
+  });
+}
+
+// taken from d3 source https://github.com/d3/d3-array/blob/master/src/ascending.js
+/* eslint-disable */
+
+function c(a, b) {
+  return a < b ? -1 : a > b ? 1 : a >= b ? 0 : NaN;
+}
+
+function b(a, x, lo = 0, hi = a.length) {
+  while (lo < hi) {
+    let mid = lo + hi >>> 1;
+    if (c(+a[mid].x, x) < 0) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/* eslint-enable */
+
+let data = createData();
+
+function g(d, v) {
+  if (v < d[0].x) return d[0];
+  const index = b(d, v);
+  if (index >= d.length) return d[d.length - 1];
+  const prior = index - 1;
+  let midpoint = 0;
+  let px;
+  let ix;
+  if (d[prior]) {
+    px = +d[prior].x;
+    ix = +d[index].x;
+    midpoint = (ix - px) / 2;
+  }
+  if (v < (d[index].x - midpoint)) return d[prior];
+  return d[index];
+}
+
+</script>
+
+<div class=story>
+  <DataGraphic
+    xDomain={[data[0].x, data[data.length - 1].x]}
+    yDomain={[0, 100]}
+    xType='time'
+    yType='linear'
+    width={500}
+    height={250}
+  >
+    <LeftAxis />
+    
+    <BottomAxis />
+
+    <Line
+      data={data}
+      lineDrawAnimation={{ duration: 1000 }}
+     />
+
+    <g slot='mouseover' let:value={value}>
+      {#if value.x}
+        <Tweenable params={{ duration: 200, easing }} value={g(data, value.x).y} let:tweenValue>
+            <!-- a bug in svelte prevents us from using MarginText w/ slot props if in another slot prop context.
+            For now, we'll use temporaryLabel, but obviously this isn't ideal. -->
+            <MarginText fontSize=13 justify=right temporaryLabel={Math.round(tweenValue)} />
+        </Tweenable>
+        
+        <Springable
+            value={{ x: g(data, value.x).x, y: g(data, value.x).y }} 
+            let:springValue={spr} >
+              <Point x={spr.x} y={spr.y} r={2.5} />
+        </Springable>
+      {/if}
+    </g>
+  </DataGraphic>
+</div>

--- a/stories/data-graphics/elements/Line02.svelte
+++ b/stories/data-graphics/elements/Line02.svelte
@@ -1,28 +1,29 @@
 <script>
 import { cubicOut as easing } from 'svelte/easing';
 
+import { schemeTableau10 as cm } from 'd3-scale-chromatic';
 import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
 import Line from '../../../src/components/data-graphics/elements/Line.svelte';
 import Point from '../../../src/components/data-graphics/elements/Point.svelte';
 import LeftAxis from '../../../src/components/data-graphics/guides/LeftAxis.svelte';
 import BottomAxis from '../../../src/components/data-graphics/guides/BottomAxis.svelte';
 import MarginText from '../../../src/components/data-graphics/guides/MarginText.svelte';
-
+import Marker from '../../../src/components/data-graphics/guides/Marker.svelte';
 
 import Springable from '../../../src/components/data-graphics/motion/Springable.svelte';
 import Tweenable from '../../../src/components/data-graphics/motion/Tweenable.svelte';
 
-function createData(n = 30) {
-  let y = 50;
-  return Array.from({ length: n }).map((_, i) => {
-    let r = (Math.random() - 0.5) * 20;
+function createData(n = 155) {
+  let y = 20 + Math.random() * 0.6 * 100;
+  let d = new Date('1990-03-01');
+  return Array.from({ length: n }).map(() => {
+    let x = new Date(+d);
+    d.setDate(d.getDate() + 1);
+    // d.setHours(d.getHours() + 1);
+    let r = (Math.random() - 0.5) * 10;
     y = Math.max(0, Math.min(100, y + r));
 
-    let year = Math.floor(i / 12);
-    let month = 3;// (i % 12) + 1;
-    let day = i + 1;
-
-    return { y, x: new Date(`${1990}-${month}-${day}`) };
+    return { y, x };
   });
 }
 
@@ -44,12 +45,14 @@ function b(a, x, lo = 0, hi = a.length) {
 
 /* eslint-enable */
 
-let data = createData();
+const N = 5;
+
+let data = Array.from({ length: N }).fill(null).map(() => createData());
 
 function g(d, v) {
-  if (v < d[0].x) return d[0];
+  if (v < d[0].x) return { ...d[0], index: 0 };
   const index = b(d, v);
-  if (index >= d.length) return d[d.length - 1];
+  if (index >= d.length) return { ...d[d.length - 1], index: d.length - 1 };
   const prior = index - 1;
   let midpoint = 0;
   let px;
@@ -59,44 +62,137 @@ function g(d, v) {
     ix = +d[index].x;
     midpoint = (ix - px) / 2;
   }
-  if (v < (d[index].x - midpoint)) return d[prior];
-  return d[index];
+  if (v < (d[index].x - midpoint)) return { ...d[prior], index: prior };
+  return { ...d[index], index };
+}
+
+function gg(d, v) {
+  return d.map((di) => g(di, v));
+}
+
+function getValue(d, v) {
+  return d.map((di) => g(di, v.x).y);
+}
+
+function getXY(d, v) {
+  return d.map((di) => ({ x: g(di, v.x).x, y: g(di, v.x).y }));
 }
 
 </script>
 
+<style>
+.data-graphic-container {
+  font-family: var(--main-mono-font);
+}
+</style>
+
 <div class=story>
+  <h1 class=story__title>Multiple lines, custom hover</h1>
+  <div class=data-graphic-container>
   <DataGraphic
-    xDomain={[data[0].x, data[data.length - 1].x]}
+    xDomain={[data[0][0].x, data[0][data[0].length - 1].x]}
     yDomain={[0, 100]}
     xType='time'
     yType='linear'
-    width={500}
-    height={250}
+    width={700}
+    height={350}
+    right={120}
   >
     <LeftAxis />
     
     <BottomAxis />
 
+    {#each data as line, i}
     <Line
-      data={data}
+      data={line}
+      color={cm[i]}
       lineDrawAnimation={{ duration: 1000 }}
      />
+    {/each}
 
-    <g slot='mouseover' let:value={value}>
+    <g slot='mouseover' let:value={value} let:top let:right let:bottom let:width let:xScale let:yScale>
+
       {#if value.x}
-        <Tweenable params={{ duration: 200, easing }} value={g(data, value.x).y} let:tweenValue>
-            <!-- a bug in svelte prevents us from using MarginText w/ slot props if in another slot prop context.
-            For now, we'll use temporaryLabel, but obviously this isn't ideal. -->
-            <MarginText fontSize=13 justify=right temporaryLabel={Math.round(tweenValue)} />
-        </Tweenable>
-        
-        <Springable
-            value={{ x: g(data, value.x).x, y: g(data, value.x).y }} 
-            let:springValue={spr} >
-              <Point x={spr.x} y={spr.y} r={2.5} />
-        </Springable>
+        {#each getValue(data, value) as v, i}
+        <Tweenable params={{ duration: 100 }} value={v} let:tweenValue>
+          <text 
+            x={right} 
+            text-anchor=end
+            y={top + 12 * (i + 1)}
+            font-size=12
+          >
+            <tspan>
+                {Math.round(tweenValue)}
+            </tspan> <tspan font-size=20 dx=2 dy=2 fill={cm[i]}>•</tspan> 
+          </text>
+          <text 
+            x={right + 2 } 
+            text-anchor=start
+            y={top + 12 * (i + 1)}
+            font-size=11
+            fill={cm[i]}
+            >
+            {['WI', 'FL', 'TX', 'CA', 'NY'][i]}
+          </text>
+      </Tweenable>
+
+        {/each}
       {/if}
+
+      {#if value.x}
+      <Springable value={g(data[0], value.x)} let:springValue>
+          <Marker 
+            location={springValue.x} 
+            lineColor=var(--cool-gray-300)
+            lineThickness=2
+            dasharray='3,2'
+          />
+          <text          
+            text-anchor=middle
+            font-size=12
+            fill=var(--cool-gray-400)
+            font-weight=bold
+            text-transform=uppercase
+            x={xScale(springValue.x)} 
+            y={top - 8}>day {Math.round(springValue.index)}</text>
+      </Springable>
+
+      <Springable
+          value={getXY(data, value)} 
+          let:springValue={spr} >
+            {#each spr as {x,y}, i}
+              <Point fill={cm[i]} x={x} y={y} r={3} />
+              <!-- <text 
+                x={xScale(x)} 
+                text-anchor=end
+                y={yScale(y)}
+                font-size=12
+              >
+ 
+              </text>
+              <text 
+                x={xScale(x) + 2} 
+                text-anchor=start
+                y={yScale(y)}
+                font-size=16
+                font-weight=900
+                stroke=white
+                style="font-family: var(--brand-font)"
+
+                >
+                <tspan fill={cm[i]}>{['WI', 'FL', 'TX', 'CA', 'NY'][i]}</tspan>
+                <tspan dx=4 fill='var(--cool-gray-600)'>
+                    {Math.round(y)}
+                </tspan>
+              </text> -->
+
+            {/each}
+            <!-- draw a marker line -->
+      </Springable>
+
+
+    {/if}
     </g>
   </DataGraphic>
+  </div>
 </div>

--- a/stories/data-graphics/elements/Point01.svelte
+++ b/stories/data-graphics/elements/Point01.svelte
@@ -1,0 +1,147 @@
+<script>
+import { fly, fade } from 'svelte/transition';
+
+import Button from '../../../src/components/Button.svelte';
+import ButtonGroup from '../../../src/components/ButtonGroup.svelte';
+
+
+import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
+import GraphicBody from '../../../src/components/data-graphics/GraphicBody.svelte';
+import Point from '../../../src/components/data-graphics/elements/Point.svelte';
+
+import LeftAxis from '../../../src/components/data-graphics/guides/LeftAxis.svelte';
+import BottomAxis from '../../../src/components/data-graphics/guides/BottomAxis.svelte';
+import marvel from '../data/marvel-strength-weight.json';
+// import genericPointData from '../data/four-class.json';
+
+let alignmentColors = {
+  Good: 'blue',
+  Bad: 'red',
+  Neutral: 'black',
+};
+
+// let colors = {
+//   a: 'var(--pantone-red-600)',
+//   b: 'var(--digital-blue-500)',
+//   c: 'var(--cool-gray-700)',
+// };
+
+// const makeScatter = (n = N) => Array.from({ length: n })
+//   .map(() => ({ x: slowRandom() * 10, y: slowRandom() * 2 + 5 }));
+
+// function jitter(data, ...dimensions) {
+//   return data.map((d) => {
+//     let di = { ...d };
+//     dimensions.forEach((dim) => {
+//       di[dim] += (Math.random() - 0.5) * 0.5;
+//     });
+//     return di;
+//   });
+// }
+
+let which = ['Good', 'Bad', 'Neutral'];
+
+function toggle(value) {
+  if (which.includes(value)) which = [...which].filter((w) => w !== value);
+  else which = [...which, value];
+}
+
+</script>
+
+<style>
+
+h3 {
+  margin:0;
+  margin-left: 45px;
+  margin-right: 35px;
+  width: 600px;
+}
+
+.offset {
+  padding-left: 45px;
+}
+
+.data-graphic {
+  font-family: var(--main-mono-font);
+}
+
+.story-body-controls {
+  margin: var(--space-2x);
+}
+
+.story-body-controls label {
+  font-size: var(--text-02);
+  text-transform: uppercase;
+  padding-bottom: var(--space-1h);
+  padding-left: var(--space-base);
+  color: var(--cool-gray-500);
+}
+</style>
+
+<div class=story>
+  <h1 class="story__title offset">Points</h1>
+  <div class=dg>
+    <h3>Height vs. Weight of Marvel Characters: an investigation</h3>
+    <div class="story-body-controls offset">
+      <label>Alignment</label>
+      <ButtonGroup>
+        {#each ['Good', 'Bad', 'Neutral'] as alignment, i}
+          <Button 
+          level=medium
+          toggled={which.includes(alignment) }
+          on:click={() => { toggle(alignment); }}
+          compact>{alignment}</Button>
+        {/each}
+        </ButtonGroup>
+      </div>
+
+      <div class=data-graphic>
+        <DataGraphic
+          xDomain={[0, 1000]}
+          yDomain={[0, 1000000]}
+          xType=log
+          yType=log
+          width={600}
+          height={350}
+          top={10}
+          leftBorder={true}
+          rightBorder={true}
+          topBorder={true}
+          bottomBorder={true}
+          borderThickness={2}
+        >
+        <LeftAxis />
+        <BottomAxis lineStyle=long />
+        <GraphicBody>
+          <g in:fly={{ duration: 200, y: 5 }}>
+
+            <!-- {#each genericPointData as {x, y, color}, i (x + y + color)}
+              {#if which.includes(color)}
+              <g>
+                <Point 
+                  r={3} x={x} y={y} 
+                  fillOpacity={0.2} 
+                  fill={colors[color]}
+                  stroke={colors[color]} strokeWidth={2} strokeOpacity={0.4} />
+                </g>
+              {/if}
+            {/each} -->
+          {#each marvel as {strength, weight, height, alignment, URL}, i (URL)}
+            {#if which.includes(alignment)}
+            <g>
+              <Point 
+                r={1 + strength / 2} x={height} y={weight} 
+                fillOpacity={0.3} 
+                fill={alignmentColors[alignment]}
+                opacity={0.6}
+                stroke={alignmentColors[alignment]} strokeWidth=1 strokeOpacity={0.6} />
+              </g>
+            {/if}
+          {/each}
+        </g>
+      </GraphicBody>
+
+      </DataGraphic>
+    </div>
+  </div>
+</div>

--- a/stories/data-graphics/elements/lines.stories.js
+++ b/stories/data-graphics/elements/lines.stories.js
@@ -1,0 +1,9 @@
+import { storiesOf } from '@storybook/svelte';
+import Line01 from './Line01.svelte';
+import '../../../public/static/global.css';
+import '../../glean-design-stories.css';
+
+storiesOf('Data Graphics|Elements', module)
+  .add('Lines', () => ({
+    Component: Line01,
+  }));

--- a/stories/data-graphics/elements/points.stories.js
+++ b/stories/data-graphics/elements/points.stories.js
@@ -1,13 +1,9 @@
 import { storiesOf } from '@storybook/svelte';
-import Line01 from './Line01.svelte';
-import Line02 from './Line02.svelte';
+import Point01 from './Point01.svelte';
 import '../../../public/static/global.css';
 import '../../glean-design-stories.css';
 
 storiesOf('Data Graphics|Elements', module)
-  .add('Lines 01', () => ({
-    Component: Line01,
-  }))
-  .add('Lines 02', () => ({
-    Component: Line02,
+  .add('Points', () => ({
+    Component: Point01,
   }));


### PR DESCRIPTION
Fixes #77 by re-implementing the build id view using dates.

- [x] create story for how `DataGraphic` handles time scales
- [x] refactor the client data transformation to use dates
- [x] refactor mouseovers, reference, hover points, etc. to use variable-width dates
- [x] clean up `ProbeExplorer.svelte` / make code more legible