### PR TITLE
Remove changes made to probe key

### DIFF
--- a/glam/api/management/commands/import_probes.py
+++ b/glam/api/management/commands/import_probes.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
         name = self.get_name(probe["key"])
         expiry = latest_history.get("expiry_version")
 
-        key = probe["key"].replace("/", "::").lower()
+        key = probe["key"]
         info = {
             "name": name,
             "apiName": name,

--- a/glam/api/migrations/0004_delete_probes.py
+++ b/glam/api/migrations/0004_delete_probes.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def drop_probes(apps, schema_editor):
+    Probe = apps.get_model("api", "Probe")
+    Probe.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0003_probe'),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_probes)
+    ]


### PR DESCRIPTION
This is so we can link directly from a probe to the probe info service.

NOTE: This change requires that all probes be deleted from the table and
re-imported.