### PR TITLE
various improvements to DataGraphic.svelte

### DIFF
--- a/src/app/patterns/elements/FirefoxReleaseVersionMarkers.svelte
+++ b/src/app/patterns/elements/FirefoxReleaseVersionMarkers.svelte
@@ -17,7 +17,7 @@ firefoxVersionMarkers.subscribe((m) => { markers = m; });
 <g class='firefox-release-version-markers'>
   {#if markers && markers.length}
     {#each markers
-      .filter((d) => d.date !== undefined && d.date >= xScale.domain()[0] && d.date <= xScale.domain()[1]) as {label, date}, i (date)}
+      .filter((d) => d.date !== undefined && d.date >= $xScale.domain()[0] && d.date <= $xScale.domain()[1]) as {label, date}, i (date)}
       <Marker location={date}>
         {#if labels}
           {label}

--- a/src/app/patterns/explorer/CompareOverTimeGraph.svelte
+++ b/src/app/patterns/explorer/CompareOverTimeGraph.svelte
@@ -21,10 +21,6 @@ import FirefoxReleaseVersionMarkers from '../elements/FirefoxReleaseVersionMarke
 
 import { buildIDComparisonGraph } from '../utils/constants';
 
-import {
-  firstOfMonth, buildIDToMonth,
-} from '../utils/build-id-utils';
-
 export let data;
 export let markers;
 export let metricKeys;
@@ -236,6 +232,11 @@ $: if (referenceTextElement && referenceBackgroundElement) {
  }}
 >
 
+<!-- for the additional-plot-elements slot in ProbeExplorer.svelte -->
+<g slot=body-background>
+  <slot></slot>
+</g>
+
 {#if hovered.datum && xScale && topPlot && bodyHeight}
  {#if aggregationLevel === 'build_id'}
     <BuildIDRollover 
@@ -261,23 +262,14 @@ $: if (referenceTextElement && referenceBackgroundElement) {
   {/if}
 
   <!-- this is the reference rect -->
-  {#if aggregationLevel === 'build_id'}
     <rect
       bind:this={referenceBackgroundElement}
       x={$refLabelSpring} 
       y={topPlot} 
       width={referenceWidth} 
       height={bodyHeight}
-      fill="var(--cool-gray-100)" />
-    {:else}
-    <rect
-      bind:this={referenceBackgroundElement}
-      x={$refLabelSpring} 
-      y={topPlot} 
-      width={referenceWidth} 
-      height={bodyHeight}
-      fill="var(--cool-gray-100)" />
-    {/if}
+      fill="var(--cool-gray-100)"
+    />
   
  <LeftAxis tickFormatter={yTickFormatter} tickCount=6 />
  

--- a/src/app/patterns/explorer/CompareOverTimeGraph.svelte
+++ b/src/app/patterns/explorer/CompareOverTimeGraph.svelte
@@ -133,11 +133,11 @@ function determinePlacementOfBackgroundFill(datum) {
 }
 
 
-$: if (xDomain && xScale && rightPlot) {
+$: if (xScale && rightPlot) {
   [referenceWidth, refLabelPlacement] = determinePlacementOfBackgroundFill(reference);
 }
 
-$: if (xDomain && hovered.datum && xScale) {
+$: if (hovered.datum && xScale) {
   [hoverWidth, hoverLabelPlacement] = determinePlacementOfBackgroundFill(hovered.datum);
 }
 

--- a/src/app/patterns/explorer/ProbeExplorer.svelte
+++ b/src/app/patterns/explorer/ProbeExplorer.svelte
@@ -167,7 +167,9 @@ h4 {
         aggregationLevel={aggregationLevel}
         hoverActive={hoverActive}
         insufficientData={insufficientData}
-    />
+    >
+      <slot name=additional-plot-elements></slot>
+    </CompareOverTimeGraph>
   </div>
 
   <DistributionComparison 

--- a/src/app/patterns/explorer/ProbeExplorer.svelte
+++ b/src/app/patterns/explorer/ProbeExplorer.svelte
@@ -69,7 +69,9 @@ function setDomain(str) {
   }
 }
 
-$: if (aggregationLevel === 'build_id') setDomain(timeHorizon);
+$: if (aggregationLevel === 'build_id') {
+  setDomain(timeHorizon);
+}
 
 export let hovered = !hoverActive ? { x: data[0].label, datum: data[0] } : {};
 export let reference = data[data.length - 1];

--- a/src/app/patterns/explorer/QuantileExplorerView.svelte
+++ b/src/app/patterns/explorer/QuantileExplorerView.svelte
@@ -2,11 +2,15 @@
 import { setContext, getContext, createEventDispatcher } from 'svelte';
 import { tweened } from 'svelte/motion';
 import { cubicOut as easing } from 'svelte/easing';
+import { interpolateBlues as colorMap } from 'd3-scale-chromatic';
 
 import ProbeExplorer from './ProbeExplorer.svelte';
 import PercentileSelectionControl from '../controls/PercentileSelectionControl.svelte';
 import TimeHorizonControl from '../controls/TimeHorizonControl.svelte';
 import AggregationTypeSelector from '../controls/AggregationTypeSelector.svelte';
+
+import Heatmap from '../../../components/data-graphics/elements/Heatmap.svelte';
+
 import { percentileLineColorMap } from '../../../components/data-graphics/utils/color-maps';
 
 import { formatCount, formatValue } from '../utils/formatters';
@@ -49,6 +53,22 @@ const movingAudienceSize = tweened(0, { duration: 500, easing });
 const refMedian = tweened(0, { duration: 500, easing });
 $: if (reference) movingAudienceSize.set(reference.audienceSize);
 $: if (reference) refMedian.set(reference.percentiles[50]);
+
+
+// for heatmap
+function xyheat(d, x = 'label', y = 'bin', heat = 'value') {
+  return d.map((di) => {
+    const label = di[x];
+    // this needs to return an array of values
+    return di.histogram.map((dii) => {
+      let out = {};
+      out[x] = label;
+      out[y] = dii[y];
+      out[heat] = dii[heat];
+      return out;
+    });
+  }).flat();
+}
 
 </script>
 
@@ -132,6 +152,20 @@ $: if (reference) refMedian.set(reference.percentiles[50]);
                 probeType === 'histogram' ? data[0].histogram.map((d) => d.bin)
                 : [0, Math.max(...data.map((d) => d.percentiles[95]))]}
             >
+
+                <!-- <g slot='additional-plot-elements'>
+                  <Heatmap 
+                    data={xyheat(data)}
+                    xAccessor=label
+                    yAccessor=bin
+                    heatAccessor=value
+                    transition={{ duration: 100, easing }}
+                    colorMap={colorMap}
+                    scaleType=log
+                    heatRange={[0.075, 0.50]}
+                    opacity={1}
+                  />
+                </g> -->
 
                 <!-- summary bignums -->
                 <div class='probe-body-overview__numbers' slot='summary'>

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -250,9 +250,12 @@ let onMouseleave = (e) => { rollover.onMouseleave(e); };
 
 export let dataGraphicMounted = false;
 
-export let hoverValue = {
+const emptyValue = () => ({
   x: undefined, y: undefined, px: undefined, py: undefined,
-};
+});
+
+export let hoverValue = emptyValue();
+
 
 onMount(() => {
   dataGraphicMounted = true;
@@ -287,6 +290,9 @@ $: if (dataGraphicMounted) {
     on:mousemove={onMousemove}
     on:mouseleave={onMouseleave}
     on:click
+    on:mousedown
+    on:mouseup
+    on:mousemove
   >
   <rect 
     x={$leftPlot} y={$topPlot} width={$bodyWidth} height={$bodyHeight}
@@ -301,10 +307,28 @@ $: if (dataGraphicMounted) {
         height={$bodyHeight}
       />
     </clipPath>
+
+    {#if dataGraphicMounted}
+      <g id='graphic-body-content-{key}' style="clip-path: url(#graphic-body-{key})">
+        <slot name='body-background' 
+          xScale={xScale} 
+          yScale={yScale}
+          left={$leftPlot}
+          right={$rightPlot}
+          top={$topPlot}
+          bottom={$bottomPlot}
+          width={$graphicWidth}
+          height={$graphicHeight}
+        ></slot>
+      </g>
+    {/if}
+
     {#if dataGraphicMounted}
       <slot></slot>
     {/if}
     <use clip-path="url(#graphic-body-{key})" xlink:href="#graphic-body-content={key}" fill="transparent" />
+
+
 
     <!-- pass the rollover value into the scale -->
     {#if dataGraphicMounted}

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -167,11 +167,16 @@ function createYPointScale(values) {
 
 // /////////////////////////////////////////////////////////////////////////
 
-export let yScale = createYPointScale(yDomain);
-export let xScale = createXPointScale(xDomain);
+export let xScaleStore = writable(createXPointScale(xDomain));
+export let yScaleStore = writable(createYPointScale(yDomain));
 
-setContext('xScale', xScale);
-setContext('yScale', yScale);
+export let xScale = $xScaleStore;
+export let yScale = $yScaleStore;
+$: xScale = $xScaleStore;
+$: yScale = $yScaleStore;
+
+setContext('xScale', xScaleStore);
+setContext('yScale', yScaleStore);
 
 const internalRolloverStore = writable({
   x: undefined, y: undefined, px: undefined, py: undefined,

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -323,7 +323,7 @@ $: if (dataGraphicMounted) {
     </clipPath>
 
     {#if dataGraphicMounted}
-      <g id='graphic-body-content-{key}' style="clip-path: url(#graphic-body-{key})">
+      <g id='graphic-body-background-{key}' style="clip-path: url(#graphic-body-{key})">
         <slot name='body-background' 
           xScale={xScale} 
           yScale={yScale}
@@ -352,9 +352,9 @@ $: if (dataGraphicMounted) {
     </g>
   {/if}
 
-    {#if dataGraphicMounted}
-    <g>
-      <slot name=body 
+  {#if dataGraphicMounted}
+    <g id='graphic-body-{key}' style="clip-path: url(#graphic-body-{key})">
+      <slot name='body' 
         xScale={xScale} 
         yScale={yScale}
         left={$leftPlot}

--- a/src/components/data-graphics/DataGraphic.svelte
+++ b/src/components/data-graphics/DataGraphic.svelte
@@ -323,12 +323,12 @@ $: if (dataGraphicMounted) {
       </g>
     {/if}
 
+    <!-- generalized slot at body level -->
     {#if dataGraphicMounted}
       <slot></slot>
     {/if}
+
     <use clip-path="url(#graphic-body-{key})" xlink:href="#graphic-body-content={key}" fill="transparent" />
-
-
 
     <!-- pass the rollover value into the scale -->
     {#if dataGraphicMounted}
@@ -351,5 +351,20 @@ $: if (dataGraphicMounted) {
         <line x1={x1} x2={x2} y1={y1} y2={y2} stroke={color} stroke-width={thickness} opacity={opacity} />
       {/if}
     {/each}
+
+
+    <!-- Annotation layer – for additional points, comments, etc. that must sit above everything else -->
+    {#if dataGraphicMounted}
+      <slot name='annotation' 
+        xScale={xScale} 
+        yScale={yScale}
+        left={$leftPlot}
+        right={$rightPlot}
+        top={$topPlot}
+        bottom={$bottomPlot}
+        width={$graphicWidth}
+        height={$graphicHeight}
+      ></slot>
+    {/if}
   </svg>
 </div>

--- a/src/components/data-graphics/elements/BoxPlot.svelte
+++ b/src/components/data-graphics/elements/BoxPlot.svelte
@@ -1,11 +1,12 @@
 <script>
 import { getContext } from 'svelte';
+import { writable } from 'svelte/store';
 import { fly } from 'svelte/transition';
 
 const defaults = getContext('defaults');
 
-export let xScale = getContext('xScale');
-export let yScale = getContext('yScale');
+export let xScale = getContext('xScale') || writable((v) => v);
+export let yScale = getContext('yScale') || writable((v) => v);
 
 export let flyValues = defaults.flyParams;
 export let lowest;
@@ -19,21 +20,21 @@ export let opacity = 1;
 
 <g in:fly={flyValues} class="small-multiple quantiles" opacity={opacity}>
   <line 
-    x1={xScale(x)}
-    x2={xScale(x)}
-    y1={yScale(lowest)}
-    y2={yScale(highest)}
+    x1={$xScale(x)}
+    x2={$xScale(x)}
+    y1={$yScale(lowest)}
+    y2={$yScale(highest)}
     stroke=black />
   <rect
-    x={xScale(x) - 5}
-    y={yScale(higher)}
+    x={$xScale(x) - 5}
+    y={$yScale(higher)}
     width={10}
     height={yScale(lower) - yScale(higher)}
     fill=var(--blue-slate-500)
   />
   <line  
-    x1={xScale(x) - 5}
-    x2={xScale(x) + 5}
+    x1={$xScale(x) - 5}
+    x2={$xScale(x) + 5}
     y1={yScale(middle)}
     y2={yScale(middle)}
     stroke=white

--- a/src/components/data-graphics/elements/Heatmap.svelte
+++ b/src/components/data-graphics/elements/Heatmap.svelte
@@ -1,4 +1,5 @@
 <script>
+import { writable } from 'svelte/store';
 import { getContext, onMount } from 'svelte';
 import { fade } from 'svelte/transition';
 import { easeOut } from 'svelte/easing';
@@ -11,8 +12,8 @@ export let xAccessor = 'x';
 export let yAccessor = 'y';
 export let heatAccessor = 'heat';
 export let scaleType = 'log';
-export let xScale = getContext('xScale');
-export let yScale = getContext('yScale');
+export let xScale = getContext('xScale') || writable((v) => v);
+export let yScale = getContext('yScale') || writable((v) => v);
 export let heatRange = [0.1, 0.9];
 export let transition = { duration: 200, easing: easeOut };
 export let hidden = false;
@@ -38,14 +39,14 @@ let canvas;
 
 let byColor = data.map((d) => ({
   [heatAccessor]: d[heatAccessor] === 0.0 ? 'transparent' : interpolateRdPu(scale(d[heatAccessor])),
-  [xAccessor]: xScale(d[xAccessor]),
-  [yAccessor]: yScale(d[yAccessor]) - yScale.step() / 2,
+  [xAccessor]: $xScale(d[xAccessor]),
+  [yAccessor]: $yScale(d[yAccessor]) - $yScale.step() / 2,
 }));
   // try to not change the fillStyle and strokeStyle too much.
   // the canvas state machine can be VERY slow otherwise.
 const colors = new Set(byColor.map((b) => b[heatAccessor]));
-let w = xScale.step();
-let h = yScale.step();
+let w = $xScale.step();
+let h = $yScale.step();
 
 const colorCombos = Array.from(colors).reduce((acc, c) => {
   acc[c] = byColor.filter((bc) => bc[heatAccessor] === c);

--- a/src/components/data-graphics/elements/Heatmap.svelte
+++ b/src/components/data-graphics/elements/Heatmap.svelte
@@ -14,9 +14,11 @@ export let heatAccessor = 'heat';
 export let scaleType = 'log';
 export let xScale = getContext('xScale') || writable((v) => v);
 export let yScale = getContext('yScale') || writable((v) => v);
-export let heatRange = [0.1, 0.9];
+export let heatRange = [0.3, 0.8];
+export let opacity = 1;
 export let transition = { duration: 200, easing: easeOut };
 export let hidden = false;
+export let colorMap = interpolateRdPu;
 
 let graphicWidth;
 let graphicHeight;
@@ -57,7 +59,7 @@ let widths = getLengths(data, $xScale, xAccessor);
 let heights = getLengths(data, $yScale, yAccessor);
 
 let byColor = data.map((d, i) => ({
-  [heatAccessor]: d[heatAccessor] === 0.0 ? 'transparent' : interpolateRdPu(scale(d[heatAccessor])),
+  [heatAccessor]: d[heatAccessor] === 0.0 ? 'transparent' : colorMap(scale(d[heatAccessor])),
   [xAccessor]: $xScale(d[xAccessor]),
   [yAccessor]: $yScale(d[yAccessor]) - $yScale.step() / 2,
   width: widths[d[xAccessor]],
@@ -99,7 +101,7 @@ $: if ((!hidden) && canvas) renderCanvas();
 </script>
 
 {#if !hidden}
-  <g transition:fade={transition}>
+  <g transition:fade={transition} {opacity}>
     <foreignObject width={graphicWidth} height={graphicHeight}>
       <canvas bind:this={canvas} width={graphicWidth} height={graphicHeight}  />
     </foreignObject>

--- a/src/components/data-graphics/elements/Heatmap.svelte
+++ b/src/components/data-graphics/elements/Heatmap.svelte
@@ -2,7 +2,7 @@
 import { writable } from 'svelte/store';
 import { getContext, onMount } from 'svelte';
 import { fade } from 'svelte/transition';
-import { easeOut } from 'svelte/easing';
+import { cubicOut as easing } from 'svelte/easing';
 import { interpolateRdPu } from 'd3-scale-chromatic';
 import { scaleLog, scaleLinear } from 'd3-scale';
 
@@ -16,7 +16,7 @@ export let xScale = getContext('xScale') || writable((v) => v);
 export let yScale = getContext('yScale') || writable((v) => v);
 export let heatRange = [0.3, 0.8];
 export let opacity = 1;
-export let transition = { duration: 200, easing: easeOut };
+export let transition = { duration: 200, easing };
 export let hidden = false;
 export let colorMap = interpolateRdPu;
 

--- a/src/components/data-graphics/elements/Line.svelte
+++ b/src/components/data-graphics/elements/Line.svelte
@@ -19,13 +19,14 @@ export let lineDrawAnimation = { duration: 0 };
 export let curve = 'curveMonotoneX';
 export let area = false;
 const curveFunction = SHAPE[curve];
-
-const lineGenerator = SHAPE.line()
+let lineGenerator;
+let areaGenerator;
+$: lineGenerator = SHAPE.line()
   .x((d) => (useXScale ? $xScale(d[xAccessor]) : d[xAccessor]))
   .y((d) => (useYScale ? $yScale(d[yAccessor]) : d[yAccessor]))
   .curve(curveFunction);
 
-const areaGenerator = SHAPE.area()
+$: areaGenerator = SHAPE.area()
   .x((d) => $xScale(d[xAccessor]))
   .y1((d) => $yScale(d[yAccessor]))
   .y0($yScale.range()[0])

--- a/src/components/data-graphics/elements/Line.svelte
+++ b/src/components/data-graphics/elements/Line.svelte
@@ -1,11 +1,12 @@
 <script>
 import { getContext } from 'svelte';
+import { writable } from 'svelte/store';
 import { draw, fade } from 'svelte/transition';
 import * as SHAPE from 'd3-shape';
 
 
-export let xScale = getContext('xScale');
-export let yScale = getContext('yScale');
+export let xScale = getContext('xScale') || writable((v) => v);
+export let yScale = getContext('yScale') || writable((v) => v);
 export let xAccessor = 'x';
 export let yAccessor = 'y';
 export let useXScale = true;
@@ -20,14 +21,14 @@ export let area = false;
 const curveFunction = SHAPE[curve];
 
 const lineGenerator = SHAPE.line()
-  .x((d) => (useXScale ? xScale(d[xAccessor]) : d[xAccessor]))
-  .y((d) => (useYScale ? yScale(d[yAccessor]) : d[yAccessor]))
+  .x((d) => (useXScale ? $xScale(d[xAccessor]) : d[xAccessor]))
+  .y((d) => (useYScale ? $yScale(d[yAccessor]) : d[yAccessor]))
   .curve(curveFunction);
 
 const areaGenerator = SHAPE.area()
-  .x((d) => xScale(d[xAccessor]))
-  .y1((d) => yScale(d[yAccessor]))
-  .y0(yScale.range()[0])
+  .x((d) => $xScale(d[xAccessor]))
+  .y1((d) => $yScale(d[yAccessor]))
+  .y0($yScale.range()[0])
   .curve(curveFunction);
 
 </script>

--- a/src/components/data-graphics/elements/LineBand.svelte
+++ b/src/components/data-graphics/elements/LineBand.svelte
@@ -1,0 +1,35 @@
+<script>
+import { getContext } from 'svelte';
+import { fade } from 'svelte/transition';
+import * as SHAPE from 'd3-shape';
+
+export let xScale = getContext('xScale');
+export let yScale = getContext('yScale');
+export let useXScale = true;
+export let useYScale = true;
+export let data;
+export let xAccessor = 'x';
+export let yMinAccessor = 'low';
+export let yMaxAccessor = 'high';
+export let color = 'var(--cool-gray-200)';
+export let curve = 'curveMonotoneX';
+export let mixBlendMode = 'multiply';
+
+const curveFunction = SHAPE[curve];
+
+
+const areaGenerator = SHAPE.area()
+  .x((d) => (useXScale ? xScale(d[xAccessor]) : d[xAccessor]))
+  .y((d) => (useYScale ? yScale(d[yMinAccessor]) : d[yMinAccessor]))
+  .y1((d) => (useYScale ? yScale(d[yMaxAccessor]) : d[yMaxAccessor]))
+  .curve(curveFunction);
+
+</script>
+
+<g class=line-band>
+  <path 
+    d={areaGenerator(data)} 
+    fill={color} 
+    in:fade
+    style="mix-blend-mode: {mixBlendMode};" />
+</g>

--- a/src/components/data-graphics/elements/LineBand.svelte
+++ b/src/components/data-graphics/elements/LineBand.svelte
@@ -18,8 +18,8 @@ export let mixBlendMode = 'multiply';
 
 const curveFunction = SHAPE[curve];
 
-
-const areaGenerator = SHAPE.area()
+let areaGenerator;
+$: areaGenerator = SHAPE.area()
   .x((d) => (useXScale ? $xScale(d[xAccessor]) : d[xAccessor]))
   .y((d) => (useYScale ? $yScale(d[yMinAccessor]) : d[yMinAccessor]))
   .y1((d) => (useYScale ? $yScale(d[yMaxAccessor]) : d[yMaxAccessor]))

--- a/src/components/data-graphics/elements/LineBand.svelte
+++ b/src/components/data-graphics/elements/LineBand.svelte
@@ -1,10 +1,11 @@
 <script>
 import { getContext } from 'svelte';
+import { writable } from 'svelte/store';
 import { fade } from 'svelte/transition';
 import * as SHAPE from 'd3-shape';
 
-export let xScale = getContext('xScale');
-export let yScale = getContext('yScale');
+export let xScale = getContext('xScale') || writable((v) => v);
+export let yScale = getContext('yScale') || writable((v) => v);
 export let useXScale = true;
 export let useYScale = true;
 export let data;
@@ -19,9 +20,9 @@ const curveFunction = SHAPE[curve];
 
 
 const areaGenerator = SHAPE.area()
-  .x((d) => (useXScale ? xScale(d[xAccessor]) : d[xAccessor]))
-  .y((d) => (useYScale ? yScale(d[yMinAccessor]) : d[yMinAccessor]))
-  .y1((d) => (useYScale ? yScale(d[yMaxAccessor]) : d[yMaxAccessor]))
+  .x((d) => (useXScale ? $xScale(d[xAccessor]) : d[xAccessor]))
+  .y((d) => (useYScale ? $yScale(d[yMinAccessor]) : d[yMinAccessor]))
+  .y1((d) => (useYScale ? $yScale(d[yMaxAccessor]) : d[yMaxAccessor]))
   .curve(curveFunction);
 
 </script>

--- a/src/components/data-graphics/elements/Point.svelte
+++ b/src/components/data-graphics/elements/Point.svelte
@@ -1,5 +1,6 @@
 <script>
 import { getContext } from 'svelte';
+import { writable } from 'svelte/store';
 
 export let x;
 export let y;
@@ -11,13 +12,13 @@ export let strokeWidth = 0;
 export let strokeOpacity = 1;
 export let fill = 'blue';
 
-const xScale = getContext('xScale');
-const yScale = getContext('yScale');
+const xScale = getContext('xScale') || writable((v) => v);
+const yScale = getContext('yScale') || writable((v) => v);
 </script>
 
 <circle 
-  cx={xScale(x)}
-  cy={yScale(y)}
+  cx={$xScale(x)}
+  cy={$yScale(y)}
   r={r}
   fill={fill}
   opacity={opacity}

--- a/src/components/data-graphics/elements/VerticalErrorBar.svelte
+++ b/src/components/data-graphics/elements/VerticalErrorBar.svelte
@@ -11,16 +11,16 @@ const xScale = getContext('xScale');
 const yScale = getContext('yScale');
 
 export let bandWidth = 10;
-if (xScale.type === 'scalePoint') bandWidth = xScale.step();
-else if (previousX && nextX) bandWidth = xScale(nextX) - xScale(previousX);
+if ($xScale.type === 'scalePoint') bandWidth = $xScale.step();
+else if (previousX && nextX) bandWidth = $xScale(nextX) - $xScale(previousX);
 // is this clunky? sort of is?
 
 </script>
 
 {#if minY && maxY && x}
 <g class='error-bar vertical-error-bar'>
-  <line x1={xScale(x)} x2={xScale(x)} y1={yScale(minY)} y2={yScale(maxY)} stroke={color} />
-  <line x1={xScale(x) - bandWidth / 2} x2={xScale(x) - bandWidth / 2} y1={yScale(minY)} y2={yScale(minY)} stroke={color} />
-  <line x1={xScale(x) - bandWidth / 2} x2={xScale(x) - bandWidth / 2} y1={yScale(maxY)} y2={yScale(maxY)} stroke={color} />
+  <line x1={$xScale(x)} x2={$xScale(x)} y1={$yScale(minY)} y2={$yScale(maxY)} stroke={color} />
+  <line x1={$xScale(x) - bandWidth / 2} x2={$xScale(x) - bandWidth / 2} y1={$yScale(minY)} y2={$yScale(minY)} stroke={color} />
+  <line x1={$xScale(x) - bandWidth / 2} x2={$xScale(x) - bandWidth / 2} y1={$yScale(maxY)} y2={$yScale(maxY)} stroke={color} />
 </g>
 {/if}

--- a/src/components/data-graphics/elements/VerticalErrorBar.svelte
+++ b/src/components/data-graphics/elements/VerticalErrorBar.svelte
@@ -1,0 +1,26 @@
+<script>
+import { getContext } from 'svelte';
+
+export let minY;
+export let maxY;
+export let x;
+export let previousX;
+export let nextX;
+export let color = 'var(--cool-gray-700)';
+const xScale = getContext('xScale');
+const yScale = getContext('yScale');
+
+export let bandWidth = 10;
+if (xScale.type === 'scalePoint') bandWidth = xScale.step();
+else if (previousX && nextX) bandWidth = xScale(nextX) - xScale(previousX);
+// is this clunky? sort of is?
+
+</script>
+
+{#if minY && maxY && x}
+<g class='error-bar vertical-error-bar'>
+  <line x1={xScale(x)} x2={xScale(x)} y1={yScale(minY)} y2={yScale(maxY)} stroke={color} />
+  <line x1={xScale(x) - bandWidth / 2} x2={xScale(x) - bandWidth / 2} y1={yScale(minY)} y2={yScale(minY)} stroke={color} />
+  <line x1={xScale(x) - bandWidth / 2} x2={xScale(x) - bandWidth / 2} y1={yScale(maxY)} y2={yScale(maxY)} stroke={color} />
+</g>
+{/if}

--- a/src/components/data-graphics/elements/Violin.svelte
+++ b/src/components/data-graphics/elements/Violin.svelte
@@ -21,7 +21,7 @@ export let showTop = true;
 export let showBottom = true;
 export let areaColor = 'var(--digital-blue-600)';
 export let lineColor = 'var(--digital-blue-600)';
-export let densityRange = [0, placementScale.step() * 0.5 * 0.75];
+export let densityRange = [0, $placementScale.step() * 0.5 * 0.75];
 
 const getValues = (data) => data.map((obj) => obj[densityAccessor]);
 
@@ -39,8 +39,8 @@ const smallBarMultipleScale = (obj, range = [0, 20]) => {
   ]).range(range);
 };
 
-let valueScaleType = valueScale.type;
-let valueScaleAdjustment = valueScaleType === 'scalePoint' ? valueScale.step() / 2 : 0;
+let valueScaleType = $valueScale.type;
+let valueScaleAdjustment = valueScaleType === 'scalePoint' ? $valueScale.step() / 2 : 0;
 
 let histogramScale = smallBarMultipleScale(plotDensities, densityRange);
 $: histogramScale = smallBarMultipleScale(plotDensities, densityRange);
@@ -55,12 +55,12 @@ let [histogramArea, inverseHistogramArea] = [1, -1].map((direction) => area()
   [topDensity]((d) => direction * histogramScale(d.value))
   [baseDensity](() => histogramScale(0))
   .curve(curve)
-  [binLocation]((d) => valueScale(d.bin) + valueScaleAdjustment));
+  [binLocation]((d) => $valueScale(d.bin) + valueScaleAdjustment));
 
 let histogramLine = histogramArea[derivedLine]()
-  [binLocation]((d) => valueScale(d.bin) + valueScaleAdjustment);
+  [binLocation]((d) => $valueScale(d.bin) + valueScaleAdjustment);
 let inverseHistogramLine = inverseHistogramArea[derivedLine]()
-  [binLocation]((d) => valueScale(d.bin) + valueScaleAdjustment);
+  [binLocation]((d) => $valueScale(d.bin) + valueScaleAdjustment);
 
 onMount(() => {
   mounted = true;
@@ -69,8 +69,8 @@ onMount(() => {
 let translate;
 let translateX;
 let translateY;
-$: translateX = orientation === 'vertical' ? (placementScale(placement) || rawPlacement) : 0;
-$: translateY = orientation === 'vertical' ? 0 : (placementScale(placement) || rawPlacement);
+$: translateX = orientation === 'vertical' ? ($placementScale(placement) || rawPlacement) : 0;
+$: translateY = orientation === 'vertical' ? 0 : ($placementScale(placement) || rawPlacement);
 $: translate = `translate(${translateX}, ${translateY})`;
 
 

--- a/src/components/data-graphics/guides/BottomAxis.svelte
+++ b/src/components/data-graphics/guides/BottomAxis.svelte
@@ -4,29 +4,6 @@ import { fade } from 'svelte/transition';
 
 import SimpleAxis from './SimpleAxis.svelte';
 
-// const defaults = getContext('defaults');
-// const margins = getContext('margins');
-
-// export let fadeValues = defaults.fadeParams;
-
-// export let height = getContext('bodyHeight');
-// export let bottomPlot = getContext('bottomPlot');
-// export let fontSize = defaults.axisTickFontSize;
-// export let xScale = getContext('xScale');
-// export let ticks = xScale.ticks !== undefined ? xScale.ticks() : xScale.domain();
-
-// let _ticks;
-// if (Array.isArray(ticks)) {
-//   _ticks = ticks;
-// } else if (typeof ticks === 'function') {
-//   // if you pass in a function, the function operates
-//   // on the xScale accordingly and returns whatever it needs
-//   // to be an array
-//   _ticks = ticks(xScale);
-// }
-
-// export let tickFormatter = (t) => t;
-// export let every = 1;
 </script>
 
 <SimpleAxis 
@@ -34,23 +11,3 @@ import SimpleAxis from './SimpleAxis.svelte';
   side='bottom'
   mainScaleName='xScale'
 />
-
-<!-- <g in:fade={fadeValues} class=bottom-axis>
-  {#each _ticks as tick, i (tick)}
-    {#if i % every === 0}
-      <line
-        x1={xScale(tick)}
-        x2={xScale(tick)}
-        y1={$bottomPlot}
-        y2={$bottomPlot + margins.buffer}
-        stroke="var(--cool-gray-200)"
-        stroke-width=2
-      />
-      <text 
-        font-size={fontSize} 
-        text-anchor='middle'
-        y={margins.top + $height + fontSize + margins.buffer}
-        x={xScale(tick)}>{tickFormatter(tick)}</text>
-      {/if}
-  {/each}
-</g> -->

--- a/src/components/data-graphics/guides/Marker.svelte
+++ b/src/components/data-graphics/guides/Marker.svelte
@@ -44,7 +44,7 @@ let locationCoord;
 let textEndCoord;
 $: lineEndCoord = $endLocation + ($distance / 2) * $scaling;
 $: lineStartCoord = $rootLocation;
-$: locationCoord = scale(location);
+$: locationCoord = $scale(location);
 $: textEndCoord = $endLocation + (-pixelDirection) * margins.buffer + ($distance / 2) * $scaling;
 
 let x1 = 0;

--- a/src/components/data-graphics/guides/SimpleAxis.svelte
+++ b/src/components/data-graphics/guides/SimpleAxis.svelte
@@ -59,12 +59,12 @@ function symLogTicks(topVal) {
 
 
 function getDefaultTicks() {
-  if (mainScale.type === 'numeric' || mainScale.type === 'linear' || mainScale.type === 'time') {
-    return mainScale.ticks(tickCount);
-  } if (mainScale.type === 'log') {
-    return symLogTicks(mainScale.domain()[1]);
+  if ($mainScale.type === 'numeric' || $mainScale.type === 'linear' || $mainScale.type === 'time') {
+    return $mainScale.ticks(tickCount);
+  } if ($mainScale.type === 'log') {
+    return symLogTicks($mainScale.domain()[1]);
   }
-  return mainScale.domain().reduce((acc, v, i, source) => {
+  return $mainScale.domain().reduce((acc, v, i, source) => {
     // let's filter to get the right number of ticks.
     const every = Math.floor(source.length / tickCount);
     if (i % every === 0) {
@@ -85,7 +85,7 @@ if (Array.isArray(ticks)) {
   // if you pass in a function, the function operates
   // on the xScale accordingly and returns whatever it needs
   // to be an array
-  TICKS = ticks(mainScale);
+  TICKS = ticks($mainScale);
 }
 
 export let tickDirection = side === 'right' || side === 'bottom' ? 1 : -1;
@@ -94,7 +94,7 @@ export let fadeValues = defaults.fadeParams;
 export let tickFontSize = defaults.axisTickFontSize;
 
 export let lineStyle = (side === 'left' || side === 'right') ? 'long' : 'short';
-export let tickFormatter = mainScale.type === 'time' ? mainScale.tickFormat(tickCount) : (t) => t;
+export let tickFormatter = $mainScale.type === 'time' ? $mainScale.tickFormat(tickCount) : (t) => t;
 
 export let showTicks = true;
 export let showBorder = false;
@@ -119,8 +119,8 @@ $: tickEnd = lineStyle === 'long' ? $obverseDimension : $bodyDimension;
           {...{
             [`${mainDim}1`]: $bodyDimension + tickDirection * margins.buffer,
             [`${mainDim}2`]: tickEnd,
-            [`${secondaryDim}1`]: mainScale(tick),
-            [`${secondaryDim}2`]: mainScale(tick),
+            [`${secondaryDim}1`]: $mainScale(tick),
+            [`${secondaryDim}2`]: $mainScale(tick),
           }}
           stroke='var(--line-gray-01)'
           stroke-width=1
@@ -129,8 +129,8 @@ $: tickEnd = lineStyle === 'long' ? $obverseDimension : $bodyDimension;
       {#if showBorder}
         <line 
           {...{
-            [`${secondaryDim}1`]: mainScale.range()[0],
-            [`${secondaryDim}2`]: mainScale.range()[1],
+            [`${secondaryDim}1`]: $mainScale.range()[0],
+            [`${secondaryDim}2`]: $mainScale.range()[1],
             [`${mainDim}1`]: $bodyDimension,
             [`${mainDim}2`]: $bodyDimension,
           }}           
@@ -148,7 +148,7 @@ $: tickEnd = lineStyle === 'long' ? $obverseDimension : $bodyDimension;
         <text 
           {...{
             [`${mainDim}`]: $bodyDimension + tickDirection * margins.buffer + tickDirection * fontSizeCorrector,
-            [`${secondaryDim}`]: mainScale(tick),
+            [`${secondaryDim}`]: $mainScale(tick),
             dy: secondaryDim === 'y' ? '.35em' : undefined,
           }}
           text-anchor={textAnchor}

--- a/src/components/data-graphics/guides/SimpleAxis.svelte
+++ b/src/components/data-graphics/guides/SimpleAxis.svelte
@@ -58,13 +58,13 @@ function symLogTicks(topVal) {
 }
 
 
-function getDefaultTicks() {
-  if ($mainScale.type === 'numeric' || $mainScale.type === 'linear' || $mainScale.type === 'time') {
-    return $mainScale.ticks(tickCount);
-  } if ($mainScale.type === 'log') {
+function getDefaultTicks(sc) {
+  if (sc.type === 'numeric' || sc.type === 'linear' || sc.type === 'time') {
+    return sc.ticks(tickCount);
+  } if (sc.type === 'log') {
     return symLogTicks($mainScale.domain()[1]);
   }
-  return $mainScale.domain().reduce((acc, v, i, source) => {
+  return sc.domain().reduce((acc, v, i, source) => {
     // let's filter to get the right number of ticks.
     const every = Math.floor(source.length / tickCount);
     if (i % every === 0) {
@@ -74,18 +74,19 @@ function getDefaultTicks() {
   }, []);
 }
 
-export let ticks = getDefaultTicks();
-
+export let ticks;
 // we will need to internally calculate TICKS depending on the passed value
 // of ticks.
 let TICKS;
-if (Array.isArray(ticks)) {
+$: if (Array.isArray(ticks)) {
   TICKS = ticks;
 } else if (typeof ticks === 'function') {
   // if you pass in a function, the function operates
   // on the xScale accordingly and returns whatever it needs
   // to be an array
   TICKS = ticks($mainScale);
+} else {
+  TICKS = getDefaultTicks($mainScale);
 }
 
 export let tickDirection = side === 'right' || side === 'bottom' ? 1 : -1;

--- a/src/components/data-graphics/rollovers/BuildIDRollover.svelte
+++ b/src/components/data-graphics/rollovers/BuildIDRollover.svelte
@@ -38,7 +38,7 @@ $: if (x && mounted) {
 
 <text
 bind:this={rollover}
-x={Math.min(Math.max(xScale(x), leftCorrection), rightCorrection)} 
+x={Math.min(Math.max($xScale(x), leftCorrection), rightCorrection)} 
 y={topPlot - margins.buffer - 12}
 text-anchor='middle'
 font-family="var(--main-mono-font)"

--- a/stories/data-graphics/elements/Heatmap.svelte
+++ b/stories/data-graphics/elements/Heatmap.svelte
@@ -8,10 +8,6 @@ import LeftAxis from '../../../src/components/data-graphics/guides/LeftAxis.svel
 import BottomAxis from '../../../src/components/data-graphics/guides/BottomAxis.svelte';
 import GraphicBody from '../../../src/components/data-graphics/GraphicBody.svelte';
 
-import {
-  firstOfMonth, buildIDToMonth,
-} from '../../../src/app/patterns/utils/build-id-utils';
-
 import GCMS from '../../../tests/data/gc_ms_build_id.json';
 
 import {
@@ -19,6 +15,11 @@ import {
 } from '../../../src/app/utils/probe-utils';
 
 let gcms = byKeyAndAggregation(GCMS.response)[undefined]['summed-histogram'];
+
+// get extents.
+
+let dates = gcms.map((d) => d.label);
+let xDomain = [new Date(Math.min(...dates)), new Date(Math.max(...dates))];
 
 function xyheat(d, x = 'label', y = 'bin', heat = 'value') {
   return d.map((di) => {
@@ -49,8 +50,9 @@ let active = true;
 <input type=checkbox bind:checked={active} /> Active
 
 <DataGraphic
-  xDomain={gcms.map((d) => d.label)}
+  {xDomain}
   yDomain={gcms[0].histogram.map((d) => d.bin)}
+  xType=time
   left={40}
   right={40}
   bottom={40}
@@ -70,7 +72,7 @@ let active = true;
   </GraphicBody>
 
   <LeftAxis tickCount=6 />
-  <BottomAxis ticks={firstOfMonth} tickFormatter={buildIDToMonth}  />
+  <BottomAxis />
   {#if mounted}
     <Line 
       xAccessor="label"

--- a/stories/data-graphics/elements/Heatmap.svelte
+++ b/stories/data-graphics/elements/Heatmap.svelte
@@ -1,6 +1,7 @@
 <script>
 import { onMount } from 'svelte';
 import { cubicOut as easing } from 'svelte/easing';
+import { interpolateBlues } from 'd3-scale-chromatic';
 import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
 import Heatmap from '../../../src/components/data-graphics/elements/Heatmap.svelte';
 import Line from '../../../src/components/data-graphics/elements/Line.svelte';
@@ -62,11 +63,15 @@ let active = true;
     {#if mounted}
       <Heatmap 
         data={heat}
-        xAccessor={'label'}
-        yAccessor={'bin'}
-        heatAccessor={'value'}
+        xAccessor=label
+        yAccessor=bin
+        heatAccessor=value
         transition={{ duration: 100, easing }}
         hidden={!active}
+        colorMap={interpolateBlues}
+        scaleType=log
+        heatRange={[0.1, 0.45]}
+        opacity={1}
       />
       {/if}
   </GraphicBody>

--- a/stories/data-graphics/elements/Line02.svelte
+++ b/stories/data-graphics/elements/Line02.svelte
@@ -7,13 +7,12 @@ import Line from '../../../src/components/data-graphics/elements/Line.svelte';
 import Point from '../../../src/components/data-graphics/elements/Point.svelte';
 import LeftAxis from '../../../src/components/data-graphics/guides/LeftAxis.svelte';
 import BottomAxis from '../../../src/components/data-graphics/guides/BottomAxis.svelte';
-import MarginText from '../../../src/components/data-graphics/guides/MarginText.svelte';
 import Marker from '../../../src/components/data-graphics/guides/Marker.svelte';
 
 import Springable from '../../../src/components/data-graphics/motion/Springable.svelte';
 import Tweenable from '../../../src/components/data-graphics/motion/Tweenable.svelte';
 
-import { get1D } from '../../../src/components/data-graphics/utils/window-functions';
+import { window1D } from '../../../src/components/data-graphics/utils/window-functions';
 
 function createData(n = 155) {
   let y = 20 + Math.random() * 0.6 * 100;
@@ -35,7 +34,7 @@ let data = Array.from({ length: N }).fill(null).map(() => createData());
 
 const xDomain = [data[0][0].x, data[0][data[0].length - 1].x];
 
-const get = (d, value) => get1D({
+const get = (d, value) => window1D({
   value, data: d, key: 'x', domain: xDomain,
 });
 

--- a/stories/data-graphics/elements/Line03.svelte
+++ b/stories/data-graphics/elements/Line03.svelte
@@ -79,6 +79,14 @@ const get = (d, value) => {
   return 0;
 };
 
+const getWindowVals = (d, value) => {
+  const w = window1D({
+    value, data: d, key: 'date', domain: xDomain,
+  });
+  if (w.current) return w;
+  return { next: {}, current: {}, previous: {} };
+};
+
 
 const graphs = [
   {
@@ -255,7 +263,9 @@ h2 {
               </g>
               <g in:fade={{ duration: 1000, delay: 300 }}>
                 <VerticalErrorBar 
-                  x={spr.date} minY={spr[`${key}Low`]} maxY={spr[`${key}High`]}
+                  x={spr.date} 
+                  minY={spr[`${key}Low`]} 
+                  maxY={spr[`${key}High`]}
                 />
               </g>
               {#if hoverValue.x}

--- a/stories/data-graphics/elements/Line03.svelte
+++ b/stories/data-graphics/elements/Line03.svelte
@@ -1,0 +1,173 @@
+<script>
+import { format } from 'd3-format';
+import { timeFormat } from 'd3-time-format';
+
+import { fly } from 'svelte/transition';
+import DataGraphic from '../../../src/components/data-graphics/DataGraphic.svelte';
+import Line from '../../../src/components/data-graphics/elements/Line.svelte';
+import Point from '../../../src/components/data-graphics/elements/Point.svelte';
+import LeftAxis from '../../../src/components/data-graphics/guides/LeftAxis.svelte';
+import BottomAxis from '../../../src/components/data-graphics/guides/BottomAxis.svelte';
+import Springable from '../../../src/components/data-graphics/motion/Springable.svelte';
+
+import { window1D } from '../../../src/components/data-graphics/utils/window-functions';
+
+let dtfmt = timeFormat('%b %d, %Y');
+
+let dates = (n = 365) => {
+  let dt = new Date('2017-06-01');
+  return Array.from({ length: n }).fill(null).map((_, i) => {
+    let dt2 = new Date(dt);
+    dt.setDate(dt.getDate() + 1);
+    return dt2;
+  });
+};
+
+let M = (Math.random() * 10);
+let dau = 1000000 * M;
+let wau = dau * 2;
+let mau = dau * 3.5;
+let usage = 2.5;
+let r01 = 0.8;
+let r02 = 0.7;
+
+const metricData = dates().map((date) => {
+  dau += (Math.random() - 0.45) * 100000 * M;
+  wau += (Math.random() - 0.45) * 50000 * M;
+  mau += (Math.random() - 0.45) * 50000 * M;
+  const r = Math.random();
+  if (r < 0.005) {
+    r01 += (Math.random() - 0.6) * 0.1;
+  }
+  return {
+    date,
+    dau,
+    wau,
+    mau,
+    usage: usage + (Math.random() - 0.5) * 0.1,
+    retention01: r01 + (Math.random() - 0.5) * 0.05,
+    retention02: r02 + (Math.random() - 0.5) * 0.05,
+  };
+});
+
+
+let xDomain = [
+  new Date(Math.min(...metricData.map((d) => d.date))),
+  new Date(Math.max(...metricData.map((d) => d.date)))];
+let auMax = Math.max(
+  ...metricData.map((d) => d.dau),
+  ...metricData.map((d) => d.wau),
+  ...metricData.map((d) => d.mau),
+) * 1.1;
+
+
+const get = (d, value) => {
+  const w = window1D({
+    value, data: d, key: 'date', domain: xDomain,
+  });
+  if (w.current) return w.current;
+  return 0;
+};
+
+
+const graphs = [
+  {
+    name: 'DAU', key: 'dau', type: 'count', yMax: auMax, yFormat: (v) => format('~s')(v),
+  },
+  {
+    name: 'WAU', key: 'wau', type: 'count', yMax: auMax, yFormat: (v) => format('~s')(v),
+  },
+  {
+    name: 'MAU', key: 'mau', type: 'count', yMax: auMax, yFormat: (v) => format('~s')(v),
+  },
+  {
+    name: 'Usage', key: 'usage', type: 'rate', yMax: 7, yFormat: format(',d'),
+  },
+  {
+    name: 'Retention ', key: 'retention01', type: 'percentage', yMax: 1, yFormat: format('.0%'),
+  },
+  {
+    name: 'Retention (1 wk. new)', key: 'retention02', type: 'percentage', yMax: 1, yFormat: format('.0%'),
+  },
+];
+
+let hoverValue = {};
+let hoverPt;
+$: hoverPt = get(metricData, hoverValue.x ? hoverValue.x : metricData[metricData.length - 1].date);
+
+</script>
+
+<style>
+.multiples {
+  display: grid;
+  grid-template-columns: auto auto auto;
+  grid-column-gap: var(--space-4x);
+  grid-row-gap: var(--space-8x);
+  justify-content: start;
+}
+
+.dg-header {
+  display: grid;
+  grid-template-columns: auto auto;
+  padding-left: 36px;
+  padding-right: 12px;
+}
+
+h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.dg-header div {
+  justify-self: end;
+  
+}
+
+</style>
+
+<div class=story>
+  <h1 class=story__title>Usage Metrics</h1>
+  <div class=multiples>
+    {#each graphs as {name, type, key, yMax, yFormat}, i}
+      <div>
+        <div class=dg-header>
+            <h2>{name}</h2>
+            <div>
+              {yFormat(get(metricData, hoverValue.x ? hoverValue.x : metricData[metricData.length - 1].date, key)[key])}
+          </div>
+        </div>
+        
+        <DataGraphic
+          width={300}
+          height={200}
+          top={20}
+          left={36}
+          right={12}
+          xDomain={xDomain}
+          yDomain={[0, yMax]}
+          xType=time
+          yType=linear
+          bind:hoverValue={hoverValue}
+        >
+
+          <LeftAxis  tickFormatter={yFormat} />
+          <BottomAxis />
+
+          <Line lineDrawAnimation={{ duration: 1200 }} data={metricData} xAccessor=date yAccessor={key} />
+
+          <Springable
+            params={{ stiffness: 0.4, damping: 0.9 }}
+            value={hoverPt} 
+            let:springValue={spr} >
+              <g in:fly={{ duration: 1000, y: 200 }}>
+                <Point x={spr.date} y={spr[key]} r={3} />
+              </g>
+              {#if hoverValue.x}
+                <text x={36} y={12} font-size={12}>{dtfmt(spr.date)}</text>
+              {/if}
+          </Springable>
+        </DataGraphic>
+      </div>
+    {/each}
+  </div>
+</div>

--- a/stories/data-graphics/elements/lines.stories.js
+++ b/stories/data-graphics/elements/lines.stories.js
@@ -1,6 +1,7 @@
 import { storiesOf } from '@storybook/svelte';
 import Line01 from './Line01.svelte';
 import Line02 from './Line02.svelte';
+import Line03 from './Line03.svelte';
 import '../../../public/static/global.css';
 import '../../glean-design-stories.css';
 
@@ -10,4 +11,7 @@ storiesOf('Data Graphics|Elements', module)
   }))
   .add('Lines 02', () => ({
     Component: Line02,
+  }))
+  .add('Lines 03', () => ({
+    Component: Line03,
   }));


### PR DESCRIPTION
This PR culminates a number of experiments done over the holidays. More specifically:

![gud-v2-01](https://user-images.githubusercontent.com/95735/71733011-67d1cd00-2dfd-11ea-893b-d86b1a9fb053.gif)


- [x] introduces the `Line03.svelte` story, which is a mock-up of the main interaction in GUD
- [x] transforms the x and y scales in DataGraphic to be _stores_, which allows for reactive updates to the extents of a graphic
- [x] updates all elements to use the new store through the context
- [x] introduces _layers_ to DataGraphic, which allows users to use slot props to place elements semantically in one layer (bg, body, annotation, etc.). Each of these named slots provides scales, boundaries, etc.