### PR TITLE
Add postgresql password to local docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,5 @@ services:
 
   db:
     image: postgres:11
+    environment:
+      POSTGRES_PASSWORD: pass


### PR DESCRIPTION
The upstream Docker file for Postgresql changed and now requires a
password to be defined