### PR TITLE
adds client-side response validation

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -22,6 +22,19 @@ export async function getProbeData(params, token) {
       Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({ query: params }),
-  }).then((response) => response.json());
+  }).then(async (response) => {
+    // catch 500-level error responses and surface them into
+    // the frontend.
+    if (response.status >= 500 && response.status < 600) {
+      const msg = 'Oh no! The server encountered an error.';
+      const e = new Error(msg);
+      const txt = await response.text();
+      e.moreInformation = `The GLAM server had some trouble trying to fetch ${params.probe}, so we'll
+      report the error here: 
+      ${txt.split('\n').slice(0, 2)}`;
+      throw e;
+    }
+    return response.json();
+  });
   return data;
 }

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -126,7 +126,7 @@ export const resetFilters = () => {
   store.setField('channel', getDefaultFieldValue('channel'));
   store.setField('os', getDefaultFieldValue('os'));
   store.setField('aggregationLevel', getDefaultFieldValue('aggregationLevel'));
-  store.setField('process', getDefaultFieldValue('process'))
+  store.setField('process', getDefaultFieldValue('process'));
 };
 
 export const searchResults = derived(
@@ -273,7 +273,7 @@ export function fetchDataForGLAM(params) {
       validate(
         payload,
         (p) => noResponse(p, probe.active),
-        (p) => noDuplicates(p.response, aggregationLevel),
+        (p) => noDuplicates(p, aggregationLevel),
       );
 
       const probeType = probe.type;

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -12,6 +12,7 @@ import CONFIG from '../config.json';
 
 import { byKeyAndAggregation, getProbeViewType } from '../utils/probe-utils';
 
+import { validate, noDuplicates, noResponse } from '../utils/data-validation';
 
 export function getField(fieldKey) {
   return CONFIG.fields[fieldKey];
@@ -203,7 +204,6 @@ function paramsAreValid(params) {
 
 export const datasetResponse = (level, key, data) => ({ level, key, data });
 
-
 // FIXME: let's remove this function. It's almost comically redundant.
 export function responseToData(data, probeClass = 'quantile', probeType, aggregationMethod = 'build_id') {
   return byKeyAndAggregation(data, probeClass, aggregationMethod, { probeType }, { removeZeroes: probeType === 'histogram-enumerated' });
@@ -270,11 +270,11 @@ export function fetchDataForGLAM(params) {
       const { probe } = st;
       const { aggregationLevel } = st;
 
-      if (!('response' in payload)) {
-        const er = new Error('The data for this probe is unavailable.');
-        if (!probe.active) er.moreInformation = 'This probe appears to be inactive, so it\'s possible we don\'t have data for it.';
-        throw er;
-      }
+      validate(
+        payload,
+        (p) => noResponse(p, probe.active),
+        (p) => noDuplicates(p.response, aggregationLevel),
+      );
 
       const probeType = probe.type;
       const probeKind = probe.kind;

--- a/src/utils/data-validation.js
+++ b/src/utils/data-validation.js
@@ -1,7 +1,7 @@
-export const noDuplicates = (data, aggregationMethod = 'build_id') => {
+export const noDuplicates = (payload, aggregationMethod = 'build_id') => {
   // go through ever data
   // look at data[...].metadata[aggregationMethod]. There should be no duplicates.
-  const allBuildIDs = data.map((di) => di.metadata[aggregationMethod]);
+  const allBuildIDs = payload.response.map((di) => di.metadata[aggregationMethod]);
   const uniques = new Set(allBuildIDs);
   if (allBuildIDs.length !== uniques.size) {
     throw new Error(`Duplicate ${aggregationMethod === 'build_id' ? 'Build IDs' : 'Versions'} found.`);
@@ -17,10 +17,5 @@ export const noResponse = (payload, probeIsActive) => {
 };
 
 export function validate(data, ...validators) {
-  // each validator needs a [function, error message to throw if it doesn't work].
-  // every product will have a set of needed validators. It should have a copy called store or something
-  // so it can arbitrarily compare to the store.
-  // are keys duplicate?
-  // is histogram or percentiles missing?
   validators.forEach((check) => { check(data); });
 }

--- a/src/utils/data-validation.js
+++ b/src/utils/data-validation.js
@@ -1,0 +1,26 @@
+export const noDuplicates = (data, aggregationMethod = 'build_id') => {
+  // go through ever data
+  // look at data[...].metadata[aggregationMethod]. There should be no duplicates.
+  const allBuildIDs = data.map((di) => di.metadata[aggregationMethod]);
+  const uniques = new Set(allBuildIDs);
+  if (allBuildIDs.length !== uniques.size) {
+    throw new Error(`Duplicate ${aggregationMethod === 'build_id' ? 'Build IDs' : 'Versions'} found.`);
+  }
+};
+
+export const noResponse = (payload, probeIsActive) => {
+  if (!('response' in payload)) {
+    const er = new Error('The data for this probe is unavailable.');
+    if (!probeIsActive) er.moreInformation = 'This probe appears to be inactive, so it\'s possible we don\'t have data for it.';
+    throw er;
+  }
+};
+
+export function validate(data, ...validators) {
+  // each validator needs a [function, error message to throw if it doesn't work].
+  // every product will have a set of needed validators. It should have a copy called store or something
+  // so it can arbitrarily compare to the store.
+  // are keys duplicate?
+  // is histogram or percentiles missing?
+  validators.forEach((check) => { check(data); });
+}

--- a/tests/examples/validators.js
+++ b/tests/examples/validators.js
@@ -1,0 +1,25 @@
+const noResponseExamples = {};
+noResponseExamples.hasResponse = {
+  response: {},
+};
+
+noResponseExamples.noResponse = {
+  response_NONE: {},
+};
+
+const noDuplicatesExamples = {};
+noDuplicatesExamples.noDups = {
+  response: [
+    { metadata: { build_id: 'abcd' } },
+    { metadata: { build_id: 'abcdefg' } },
+  ],
+};
+
+noDuplicatesExamples.dups = {
+  response: [
+    { metadata: { build_id: 'abcd' } },
+    { metadata: { build_id: 'abcd' } },
+  ],
+};
+
+export { noResponseExamples, noDuplicatesExamples };

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -1,0 +1,40 @@
+import { noDuplicates, noResponse, validate } from '../src/utils/data-validation';
+
+const noResponseCases = {};
+noResponseCases.hasResponse = {
+  response: {},
+};
+
+noResponseCases.noResponse = {
+  response_NONE: {},
+};
+
+const noDupsData = {};
+noDupsData.noDups = {
+  response: [
+    { metadata: { build_id: 'abcd' } },
+    { metadata: { build_id: 'abcdefg' } },
+  ],
+};
+
+noDupsData.dups = {
+  response: [
+    { metadata: { build_id: 'abcd' } },
+    { metadata: { build_id: 'abcd' } },
+  ],
+};
+
+
+describe('noResponse', () => {
+  it('passes if there is a response key', () => {
+    expect(() => noResponse(noResponseCases.hasResponse)).not.toThrow();
+    expect(() => noResponse(noResponseCases.noResponse)).toThrow();
+  });
+});
+
+describe('noDuplicates', () => {
+  it('passes or rejects depending on if there are duplicate keys (build_ids, versions)', () => {
+    expect(() => noDuplicates(noDupsData.noDups, 'build_id')).not.toThrow();
+    expect(() => noDuplicates(noDupsData.dups, 'build_id')).toThrow();
+  });
+});

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -1,40 +1,16 @@
-import { noDuplicates, noResponse, validate } from '../src/utils/data-validation';
-
-const noResponseCases = {};
-noResponseCases.hasResponse = {
-  response: {},
-};
-
-noResponseCases.noResponse = {
-  response_NONE: {},
-};
-
-const noDupsData = {};
-noDupsData.noDups = {
-  response: [
-    { metadata: { build_id: 'abcd' } },
-    { metadata: { build_id: 'abcdefg' } },
-  ],
-};
-
-noDupsData.dups = {
-  response: [
-    { metadata: { build_id: 'abcd' } },
-    { metadata: { build_id: 'abcd' } },
-  ],
-};
-
+import { noDuplicates, noResponse } from '../src/utils/data-validation';
+import { noResponseExamples, noDuplicatesExamples } from './examples/validators';
 
 describe('noResponse', () => {
   it('passes if there is a response key', () => {
-    expect(() => noResponse(noResponseCases.hasResponse)).not.toThrow();
-    expect(() => noResponse(noResponseCases.noResponse)).toThrow();
+    expect(() => noResponse(noResponseExamples.hasResponse)).not.toThrow();
+    expect(() => noResponse(noResponseExamples.noResponse)).toThrow();
   });
 });
 
 describe('noDuplicates', () => {
   it('passes or rejects depending on if there are duplicate keys (build_ids, versions)', () => {
-    expect(() => noDuplicates(noDupsData.noDups, 'build_id')).not.toThrow();
-    expect(() => noDuplicates(noDupsData.dups, 'build_id')).toThrow();
+    expect(() => noDuplicates(noDuplicatesExamples.noDups, 'build_id')).not.toThrow();
+    expect(() => noDuplicates(noDuplicatesExamples.dups, 'build_id')).toThrow();
   });
 });

--- a/tests/window-functions.test.js
+++ b/tests/window-functions.test.js
@@ -1,5 +1,5 @@
 import { scaleLinear } from 'd3-scale';
-import { firstIndexAbove, windowIndices, window1DPlacement } from '../src/udgl/data-graphics/utils/window-functions';
+import { firstIndexAbove, windowIndices, window1DPlacement } from 'udgl/data-graphics/utils/window-functions';
 
 const data01 = [
   { a: 4 },


### PR DESCRIPTION
closes #280, closes #277, closes #283

There are many classes of bugs in GLAM that ultimately boil down to something malformed in the data. We should be checking the response for various cases upfront and throwing in the data transformation step. This will thankfully bubble up in a nice, human-readable way in the frontend.

Adding validation early and in pure JS will also allow us to write comprehensive tests for anomalies and craft nice error messages for our users.

This isn't meant to be a comprehensive set of validators; it should, however, give maintainers enough of a blueprint to go in and implement new validating functions. It also gives us a rubric for where we should throw. If there is a problem with the API response, we throw early. If there is a problem with anything downstream of the API response, we can throw there instead.

This PR addresses the following:
- adds custom validators, as described above
- fixes bug in the top k build ids workflow
- adds a generalized 500 error so we can gracefully guide the user toward reporting on the GLAM channel
