### PR TITLE
fixes #336 - send process param to random probes

### DIFF
--- a/glam/api/views.py
+++ b/glam/api/views.py
@@ -246,6 +246,7 @@ def probes(request):
 @api_view(["POST"])
 def random_probes(request):
     n = request.data.get("n", 3)
+    process = request.data.get("process", "content")
     try:
         n = int(n)
     except ValueError:
@@ -270,6 +271,7 @@ def random_probes(request):
                     probe=probe.info["name"],
                     channel="nightly",
                     os="Windows",
+                    process=process,
                     aggregationLevel="version",
                 )
             except NotFound:

--- a/glam/tests/test_api.py
+++ b/glam/tests/test_api.py
@@ -36,7 +36,7 @@ class TestRandomProbesApi:
             "version": "72",
             "os": "Windows",
             "build_id": "*",
-            "process": 0,
+            "process": constants.PROCESS_CONTENT,
             "agg_type": constants.AGGREGATION_HISTOGRAM,
             "metric": name,
             "metric_key": "",

--- a/src/routing/pages/Home.svelte
+++ b/src/routing/pages/Home.svelte
@@ -9,6 +9,9 @@
   import { store, currentQuery } from '../../state/store';
   import { getRandomProbes } from '../../state/api';
   import { getPath } from '../Router.svelte';
+
+  // TODO: add this to the upcoming config.js
+  const NUMBER_OF_RANDOM_PROBES = 9;
 </script>
 
 <style>
@@ -89,9 +92,9 @@
     <MarketingBlock />
     <div class="random-probe-view">
       <h2>Explore</h2>
-      {#await getRandomProbes()}
+      {#await getRandomProbes(NUMBER_OF_RANDOM_PROBES, $store.process)}
         <div class="probes-overview">
-          {#each Array.from({ length: 9 }).fill(null) as _, i}
+          {#each Array.from({ length: NUMBER_OF_RANDOM_PROBES }).fill(null) as _, i}
             <div class="probe-overview__probe placeholder">
               <RandomProbePlaceholder />
             </div>

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -1,13 +1,13 @@
 const dataURL = '__BASE_DOMAIN__/api/v1/data/';
 const randomProbeURL = '__BASE_DOMAIN__/api/v1/probes/random/';
 
-export async function getRandomProbes() {
+export async function getRandomProbes(numProbes, process) {
   const data = await fetch(randomProbeURL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ n: 9 }),
+    body: JSON.stringify({ n: numProbes, process }),
   }).then((response) => response.json());
   return data;
 }


### PR DESCRIPTION
This should be the right approach and I no longer get "missing data" probes on the Home view. 