### PR TITLE
tweaks to summary table

### DIFF
--- a/src/components/explore/ComparisonSummary.svelte
+++ b/src/components/explore/ComparisonSummary.svelte
@@ -1,5 +1,4 @@
 <script>
-import { format } from 'd3-format';
 import Tweenable from 'udgl/data-graphics/motion/Tweenable.svelte';
 
 

--- a/src/components/explore/ComparisonSummary.svelte
+++ b/src/components/explore/ComparisonSummary.svelte
@@ -2,7 +2,6 @@
 import { format } from 'd3-format';
 import Tweenable from 'udgl/data-graphics/motion/Tweenable.svelte';
 
-let pFmt = format('.0%');
 
 export let hovered = false;
 export let colorMap = () => 'black';
@@ -20,6 +19,8 @@ export let showDiff = true;
 import Help from 'udgl/icons/Help.svelte';
 
 import { tooltip as tooltipAction } from 'udgl/utils/tooltip';
+import { formatPercentDecimal } from '../../utils/formatters';
+
 
 function percentChange(l, r) {
   return (r - l) / l;
@@ -79,6 +80,7 @@ tbody tr:last-child td {
 }
 
 th {
+  font-family: var(--main-text-font);
   line-height: 1;
   font-weight: normal;
   text-transform: uppercase;
@@ -123,7 +125,7 @@ td, th {
 }
 
 .value-change {
-  min-width: 54px; 
+  min-width: calc(var(--space-6x) + var(--space-base)); 
   width: max-content;
 }
 </style>
@@ -169,13 +171,13 @@ td, th {
 
               {#if showLeft}
               <td  class:hidden={!hovered} class=value-left>
-                  {leftValue ? valueFormatter(leftValue) : ' '}
+                  {leftValue !== undefined ? valueFormatter(leftValue) : ' '}
               </td>
               {/if}
 
               {#if showRight}
               <td class=value-right>
-                  {#if rightValue}
+                  {#if rightValue !== undefined}
                   <Tweenable value={rightValue} let:tweenValue>{valueFormatter(tweenValue)}</Tweenable>
                 {:else}
                     {' '}
@@ -185,7 +187,7 @@ td, th {
 
               {#if showDiff}
               <td class:hidden={!hovered} class=value-change>
-                {percentageChange ? pFmt(percentageChange) : ' '}
+                {percentageChange !== undefined ? formatPercentDecimal(percentageChange) : ' '}
               </td>
               {/if}
 

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -46,6 +46,7 @@ export let yScaleType;
 export let yDomain;
 export let densityMetricType;
 export let yTickFormatter = format(',d');
+export let summaryNumberFormatter = yTickFormatter;
 export let comparisonKeyFormatter = (v) => v;
 export let summaryLabel = 'perc.';
 
@@ -263,7 +264,7 @@ $: if (hoverValue.x) {
     binLabel={summaryLabel}
     keySet={activeBins}
     colorMap={binColorMap}
-    valueFormatter={yTickFormatter}
+    valueFormatter={summaryNumberFormatter}
     keyFormatter={comparisonKeyFormatter}
     dataVolume={data.length}
     showLeft={data.length > 1}

--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -9,7 +9,7 @@ import TimeHorizonControl from '../controls/TimeHorizonControl.svelte';
 import ProportionMetricTypeControl from '../controls/ProportionMetricTypeControl.svelte';
 import ProbeKeySelector from '../controls/ProbeKeySelector.svelte';
 
-import { formatPercent, formatCount } from '../../utils/formatters';
+import { formatPercent, formatCount, formatPercentDecimal } from '../../utils/formatters';
 
 import { overTimeTitle, proportionsOverTimeDescription } from '../../utils/constants';
 
@@ -144,6 +144,7 @@ h2 {
               aggregationLevel={aggregationLevel}
               pointMetricType={metricType}
               yTickFormatter={metricType === 'proportions' ? formatPercent : formatCount}
+              summaryNumberFormatter={metricType === 'proportions' ? formatPercentDecimal : formatCount}
               yScaleType={'linear'}
               yDomain={[0, Math.max(...data.map((d) => Object.values(d[metricType])).flat())]}
             >

--- a/src/components/explore/QuantileExplorerView.svelte
+++ b/src/components/explore/QuantileExplorerView.svelte
@@ -148,7 +148,7 @@ function xyheat(d, x = 'label', y = 'bin', heat = 'value') {
               aggregationLevel={aggregationLevel}
 
               binColorMap={percentileLineColorMap}
-              pointMetricType={'percentiles'}
+              pointMetricType={'transformedPercentiles'}
               overTimePointMetricType={probeType === 'histogram' ? 'transformedPercentiles' : 'percentiles'}
               densityMetricType={'histogram'}
               comparisonKeyFormatter={(perc) => `${perc}%`}


### PR DESCRIPTION
Closes #345

 - use `transformedPercentiles` for Fx probes in the summary table instead of `percentiles`
- use two-pt decimal percentages in tables where appropriate