### PR TITLE
Add optional bucket to import_glean_aggs

### DIFF
--- a/glam/api/management/commands/import_glean_aggs.py
+++ b/glam/api/management/commands/import_glean_aggs.py
@@ -41,7 +41,13 @@ class Command(BaseCommand):
         self.gcs_client = storage.Client()
 
         blobs = self.gcs_client.list_blobs(bucket)
-        blobs = list(filter(lambda b: b.name.startswith(csv_prefix), blobs))
+        blobs = list(
+            filter(
+                lambda b: b.name.startswith(csv_prefix)
+                and not b.name.endswith("counts.csv"),
+                blobs,
+            )
+        )
 
         for blob in blobs:
             # Create temp table for data.

--- a/glam/api/management/commands/import_glean_aggs.py
+++ b/glam/api/management/commands/import_glean_aggs.py
@@ -8,9 +8,7 @@ from google.cloud import storage
 
 
 GCS_BUCKET = "glam-dev-bespoke-nonprod-dataops-mozgcp-net"
-PRODUCT_MODEL_MAP = {
-    "fenix": "api.FenixAggregation",
-}
+PRODUCT_MODEL_MAP = {"fenix": "api.FenixAggregation"}
 
 
 def log(message):
@@ -27,17 +25,22 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "product", help="The Glean product we are importing data for.",
+            "product", help="The Glean product we are importing data for."
+        )
+        parser.add_argument(
+            "--bucket",
+            help="The bucket location for the exported aggregates",
+            default=GCS_BUCKET,
         )
 
-    def handle(self, product, *args, **options):
+    def handle(self, product, bucket, *args, **options):
 
         csv_prefix = f"glam-extract-{product}"
         model = apps.get_model(PRODUCT_MODEL_MAP[product])
 
         self.gcs_client = storage.Client()
 
-        blobs = self.gcs_client.list_blobs(GCS_BUCKET)
+        blobs = self.gcs_client.list_blobs(bucket)
         blobs = list(filter(lambda b: b.name.startswith(csv_prefix), blobs))
 
         for blob in blobs:


### PR DESCRIPTION
This adds an argument to the glean import so it can read from the `glam-fenix-dev` project instead of the nonprod project.

However, it looks like there are some issues with the import. https://github.com/mozilla/bigquery-etl/pull/870 probably needs a closer look.

```bash
root@84b5a9382da2:/app# ./manage.py import_glean_aggs fenix --bucket glam-fenix-dev
04/04/20 00:07:12 - Creating temp table for import: tmp_import_glam_extract_fenix.
04/04/20 00:07:12 - Copying GCS file glam-extract-fenix-000000000000.csv to local file /tmp/tmp7j3uymi8.
04/04/20 00:07:16 -   Importing file into temp table.
Traceback (most recent call last):
  File "./manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/venv/lib/python3.8/site-packages/django/core/management/base.py", line 328, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/venv/lib/python3.8/site-packages/django/core/management/base.py", line 369, in execute
    output = self.handle(*args, **options)
  File "/app/glam/api/management/commands/import_glean_aggs.py", line 64, in handle
    self.import_file(tmp_table, model, fp)
  File "/app/glam/api/management/commands/import_glean_aggs.py", line 88, in import_file
    cursor.copy_expert(sql, tmp_file)
  File "/venv/lib/python3.8/site-packages/django/db/backends/postgresql/base.py", line 322, in copy_expert
    return self.cursor.copy_expert(sql, file, *args)
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for integer: "total_users"
CONTEXT:  COPY tmp_import_glam_extract_fenix, line 1, column total_users: "total_users"
```

@robhudson r?