### PR TITLE
Fixes the case where keyed enumerated histograms throw error when certain buckets are missing from a keyed set

### DIFF
--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -294,7 +294,7 @@ $: if (hoverValue.x) {
     />
   </div>
   <div style="display: {insufficientData ? 'none' : 'block'}">
-    <CompareClientVolumeGraph 
+    <CompareClientVolumeGraph
       data={clientCountsData}
       description={compareDescription(clientVolumeOverTimeTitle)}
       yDomain={yClientsDomain}

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -223,13 +223,9 @@ export function responseToData(
   probeType,
   aggregationMethod = 'build_id'
 ) {
-  return byKeyAndAggregation(
-    data,
-    probeClass,
-    aggregationMethod,
-    { probeType },
-    { removeZeroes: probeType === 'histogram-enumerated' }
-  );
+  return byKeyAndAggregation(data, probeClass, aggregationMethod, {
+    probeType,
+  });
 }
 
 const makeSortOrder = (latest, which = 'counts') => (a, b) => {

--- a/src/utils/probe-utils.js
+++ b/src/utils/probe-utils.js
@@ -226,26 +226,6 @@ export function byKeyAndAggregation(
         // convert label to Date here
       }
       byKey[k][aggKey].sort(sortByKey('label'));
-
-      if (postProcessArgs.removeZeroes) {
-        // go through byKey[k][aggKey] and delete counts and proportions that are always zero.
-        const keys = Object.keys(byKey[k][aggKey][0].counts);
-        const toRemove = keys
-          .map((ki) => [
-            ki,
-            byKey[k][aggKey].every((datum) => datum.counts[ki] === 0.0),
-          ])
-          .filter(([ki, tf]) => tf)
-          .map(([k]) => k);
-        byKey[k][aggKey] = byKey[k][aggKey].map((datum) =>
-          produce(datum, (draft) => {
-            toRemove.forEach((k) => {
-              delete draft.counts[k];
-              delete draft.proportions[k];
-            });
-          })
-        );
-      }
     });
   });
   return byKey;


### PR DESCRIPTION
Fixes #217. Turns out this was error caused by an old data workaround that is no longer valid.