### PR TITLE
adds process to probe details

### DIFF
--- a/src/components/regions/ProbeDetails.svelte
+++ b/src/components/regions/ProbeDetails.svelte
@@ -3,13 +3,14 @@ import { onMount } from 'svelte';
 import { fly, fade } from 'svelte/transition';
 import LineSegSpinner from 'udgl/LineSegSpinner.svelte';
 import Button from 'udgl/Button.svelte';
+import ButtonGroup from 'udgl/ButtonGroup.svelte';
 import StatusLabel from 'udgl/StatusLabel.svelte';
 import ExternalLink from 'udgl/icons/ExternalLink.svelte';
 import telemetrySearch from '../../state/telemetry-search';
 import { store, probe, dataset } from '../../state/store';
 
 import { downloadString } from '../../utils/download';
-
+import { getProcessName } from '../../config/firefox-desktop';
 
 const paneTransition = { x: 10, duration: 300 };
 const PROBE_TYPE_DOCS = {
@@ -217,14 +218,20 @@ h2 {
             {/if}
         </div>
         <div class=drawer-section>
-          {#if $probe.record_in_processes}
+          {#if $probe.record_in_processes && $probe.record_in_processes.length}
               <h2 class="detail__heading--01">Processes</h2>
               <div class="probe-description helper-text--01">
+                <ButtonGroup>
                   {#each $probe.record_in_processes as process}
                   <div class="process-list helper-text--01">
-                    {process}
+                      <Button toggled={getProcessName(process) === $store.process}
+                        on:click={() => { store.setField('process', getProcessName(process)); }}
+                        compact level=low>
+                          {getProcessName(process)}
+                      </Button>
                   </div>
                   {/each}
+                </ButtonGroup>
               </div>
           {/if}
       </div>

--- a/src/components/regions/ProbeDetails.svelte
+++ b/src/components/regions/ProbeDetails.svelte
@@ -155,6 +155,10 @@ h2 {
     color: var(--subhead-gray-01);
 }
 
+.process-list {
+  font-family: var(--main-mono-font);
+}
+
 </style>
 
 <div class="drawer right-drawer">
@@ -212,6 +216,18 @@ h2 {
                 </div>
             {/if}
         </div>
+        <div class=drawer-section>
+          {#if $probe.record_in_processes}
+              <h2 class="detail__heading--01">Processes</h2>
+              <div class="probe-description helper-text--01">
+                  {#each $probe.record_in_processes as process}
+                  <div class="process-list helper-text--01">
+                    {process}
+                  </div>
+                  {/each}
+              </div>
+          {/if}
+      </div>
         {#if $probe.bugs && $probe.bugs.length}
         <div class="drawer-section">
             <h2 class="detail__heading--01">associated bugs</h2>

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -1,0 +1,4 @@
+export function getProcessName(process) {
+  if (process === 'main') return 'parent';
+  return process;
+}


### PR DESCRIPTION
closes #372. I still would like to do the following:

- [x] make sure the menu copy for process matches the details section name
- [x] potentially highlight which process is current, or put `(selecfted)`
- [x] add the ability to click on the processes listed and havei t set what you click to the process
- [ ] return an error message that this probe isn't available for this process