### PR TITLE
add new config-js structure

### DIFF
--- a/src/components/FirefoxReleaseVersionMarkers.svelte
+++ b/src/components/FirefoxReleaseVersionMarkers.svelte
@@ -21,9 +21,9 @@ firefoxVersionMarkers.subscribe((m) => { markers = m; });
       .filter((d) => d.date !== undefined && d.date >= $xScale.domain()[0] && d.date <= $xScale.domain()[1]) as {label, date}, i (date)}
       <Marker location={date}>
         {#if labels}
-          {#if $store.channel === 'nightly'}
+          {#if $store.productDimensions.channel === 'nightly'}
             {label + 2}
-          {:else if $store.channel === 'beta'}
+          {:else if $store.productDimensions.channel === 'beta'}
             {label + 1}`
           {:else}
             {label}

--- a/src/components/regions/MainSelectors.svelte
+++ b/src/components/regions/MainSelectors.svelte
@@ -3,7 +3,7 @@ import MenuButton from 'udgl/menu/MenuButton.svelte';
 import MenuList from 'udgl/menu/MenuList.svelte';
 import MenuListItem from 'udgl/menu/MenuListItem.svelte';
 import DownCarat from 'udgl/icons/DownCarat.svelte';
-import CONFIG from '../../config.json';
+import CONFIG from '../../config/firefox-desktop';
 
 import {
   store,
@@ -41,10 +41,10 @@ const COMPACT = true;
 
 <div class='main-filters'>
   <MenuButton tooltip={'Select a Channel'} compact={COMPACT} offset={OFFSET} location='bottom' alignment='right'>
-    <div class=main-filter__label slot="label">{getFieldValueLabel('channel', $store.channel)} <div class=pull-right-edge><DownCarat size=14 /></div></div>
+    <div class=main-filter__label slot="label">{getFieldValueLabel('channel', $store.productDimensions.channel)} <div class=pull-right-edge><DownCarat size=14 /></div></div>
     <div slot="menu">
-      <MenuList on:selection={(event) => { store.setField('channel', event.detail.key); }}>
-          {#each CONFIG.fields.channel.values as {key, label}, i (key)}
+      <MenuList on:selection={(event) => { store.setDimension('channel', event.detail.key); }}>
+          {#each CONFIG.dimensions.channel.values as {key, label}, i (key)}
             <MenuListItem  key={key} value={key}><span class='story-label
               first'></span>{label}</MenuListItem>
             {/each}
@@ -52,33 +52,33 @@ const COMPACT = true;
     </div>
   </MenuButton>
   <MenuButton tooltip={'Select an OS'} compact={COMPACT} offset={OFFSET} location='bottom' alignment='right'>
-    <div class=main-filter__label slot="label">{getFieldValueLabel('os', $store.os)}<div class=pull-right-edge><DownCarat size=14 /></div></div>
+    <div class=main-filter__label slot="label">{getFieldValueLabel('os', $store.productDimensions.os)}<div class=pull-right-edge><DownCarat size=14 /></div></div>
     <div slot="menu">
-      <MenuList on:selection={(event) => { store.setField('os', event.detail.key); }}>
-        {#each CONFIG.fields.os.values as {key, label}, i (key)}
-          <MenuListItem  key={key} value={key}><span class='story-label
+      <MenuList on:selection={(event) => { store.setDimension('os', event.detail.key); }}>
+        {#each CONFIG.dimensions.os.values as {key, label}, i (key)}
+          <MenuListItem key={key} value={key}><span class='story-label
             first'></span>{label}</MenuListItem>
           {/each}
       </MenuList>
     </div>
   </MenuButton>
-  <MenuButton tooltip={'Select an Aggregation Level'} compact={COMPACT}  offset={OFFSET} location='bottom' alignment='right'>
-    <div class=main-filter__label slot="label">{getFieldValueLabel('aggregationLevel', $store.aggregationLevel)}<div class=pull-right-edge><DownCarat size=14 /></div></div>
+  <MenuButton tooltip={'Select an Aggregation Level'} compact={COMPACT} offset={OFFSET} location='bottom' alignment='right'>
+    <div class=main-filter__label slot="label">{getFieldValueLabel('aggregationLevel', $store.productDimensions.aggregationLevel)}<div class=pull-right-edge><DownCarat size=14 /></div></div>
     <div slot="menu">
-        <MenuList on:selection={(event) => { store.setField('aggregationLevel', event.detail.key); }}>
-          {#each CONFIG.fields.aggregationLevel.values as {key, label}, i (key)}
-          <MenuListItem  key={key} value={key}><span class='story-label
+        <MenuList on:selection={(event) => { store.setDimension('aggregationLevel', event.detail.key); }}>
+          {#each CONFIG.dimensions.aggregationLevel.values as {key, label}, i (key)}
+          <MenuListItem key={key} value={key}><span class='story-label
             first'></span>{label}</MenuListItem>
           {/each}
         </MenuList>
     </div>
   </MenuButton>
   {#if $store.route.view} <!-- Hide process selector on home page. -->
-    <MenuButton tooltip={'Select a Process'} compact={COMPACT}  offset={OFFSET} location='bottom' alignment='left'>
-      <div class=main-filter__label slot="label">{getFieldValueLabel('process', $store.process) || 'select a process'}<div class=pull-right-edge><DownCarat size=14 /></div></div>
+    <MenuButton tooltip={'Select a Process'} compact={COMPACT} offset={OFFSET} location='bottom' alignment='left'>
+      <div class=main-filter__label slot="label">{getFieldValueLabel('process', $store.productDimensions.process) || 'select a process'}<div class=pull-right-edge><DownCarat size=14 /></div></div>
       <div slot="menu">
-          <MenuList on:selection={(event) => { store.setField('process', event.detail.key); }}>
-            {#each CONFIG.fields.process.values as {key, label}, i (key)}
+          <MenuList on:selection={(event) => { store.setDimension('process', event.detail.key); }}>
+            {#each CONFIG.dimensions.process.values as {key, label}, i (key)}
             <MenuListItem  key={key} value={key}><span class='story-label
               first'></span>{label}</MenuListItem>
             {/each}

--- a/src/components/regions/ProbeDetails.svelte
+++ b/src/components/regions/ProbeDetails.svelte
@@ -194,10 +194,10 @@ h2 {
         </div>
         {#if $store.versions && $store.versions.length}
             <dl class="drawer-section probe-details-overview-left probe-details-overview-left--subtle">
-                <dt>{$store.channel}</dt>
+                <dt>{$store.productDimensions.channel}</dt>
                 <dd class="probe-details-overview-left--padded">
-                    {$probe.versions[$store.channel][0]}
-                    &ndash; {$probe.versions[$store.channel][1]}
+                    {$probe.versions[$store.productDimensions.channel][0]}
+                    &ndash; {$probe.versions[$store.productDimensions.channel][1]}
                 </dd>
             </dl>
         {/if}

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -1,0 +1,41 @@
+export default {
+  sampleRate: .1,
+  dimensions: {
+    os: {
+      title: 'Operating System',
+      key: 'os',
+      values: [
+        { key: 'ALL', label: 'All OSes', keyTransform: 'NULL' },
+        { key: 'Windows', label: 'Windows' },
+        { key: 'Mac', label: 'Mac' },
+        { key: 'Linux', label: 'Linux' },
+      ],
+    },
+    channel: {
+      title: 'Channel',
+      key: 'channel',
+      values: [
+        { key: 'nightly', label: 'Nightly' },
+        { key: 'beta', label: 'Beta' },
+        { key: 'release', label: 'Release' },
+      ],
+    },
+    aggregationLevel: {
+      title: 'Aggregation Level',
+      key: 'aggregationLevel',
+      values: [
+        { key: 'build_id', label: 'by build id' },
+        { key: 'version', label: 'by major version' },
+      ],
+    },
+    process: {
+      title: 'Process',
+      key: 'process',
+      values: [
+        { key: 'parent', label: 'Parent Process' },
+        { key: 'content', label: 'Content Process' },
+        { key: 'gpu', label: 'GPU Process' },
+      ],
+    },
+  }
+};

--- a/src/routing/pages/Home.svelte
+++ b/src/routing/pages/Home.svelte
@@ -12,7 +12,7 @@
   // TODO: add this to the upcoming config.js
   const NUMBER_OF_RANDOM_PROBES = 9;
 
-  $: selectedProcess = $store.process;
+  $: selectedProcess = $store.productDimensions.process;
 </script>
 
 <style>

--- a/src/routing/wrappers/Probe.svelte
+++ b/src/routing/wrappers/Probe.svelte
@@ -40,10 +40,10 @@
     <Spinner size={48} color={'var(--cool-gray-400)'} />
   </div>
 {:then data}
-  {#if isSelectedProcessValid($store.recordedInProcesses, $store.process)}
+  {#if isSelectedProcessValid($store.recordedInProcesses, $store.productDimensions.process)}
     <slot {data} probeType={$temporaryViewTypeStore} />
   {:else}
-    <DataError reason={`This probe does not record in the ${$store.process} process.`} />
+    <DataError reason={`This probe does not record in the ${$store.productDimensions.process} process.`} />
   {/if}
 {:catch err}
   <div class="graphic-body__content">

--- a/src/utils/create-store.js
+++ b/src/utils/create-store.js
@@ -38,6 +38,14 @@ export function createStore(initialStore) {
     );
   }
 
+  function setDimension(key, value) {
+    INTERNAL_STORE.update((state) =>
+      produce(state, (draft) => {
+        draft.productDimensions[key] = value;
+      })
+    );
+  }
+
   function connect(func) {
     return (...args) => dispatch(func(...args));
   }
@@ -53,6 +61,7 @@ export function createStore(initialStore) {
     subscribe: INTERNAL_STORE.subscribe,
     getState,
     setField,
+    setDimension,
     reinitialize,
   };
 }


### PR DESCRIPTION
I had something more complicated locally that also moves much of the helper methods in store.js like `getField() getFieldValues() isField()` but decided against it until for now until we're certain of the direction.