### PR TITLE
add remaining color palettes

### DIFF
--- a/public/static/global.css
+++ b/public/static/global.css
@@ -168,14 +168,14 @@
     --body-gray-02: var(--cool-gray-900);
 
     /* use digital blue as link + button color for accessibility */
-    --digital-blue-100: hsl(209, 70%, 93%);
-    --digital-blue-150: hsl(209, 71%, 86%);
-    --digital-blue-200:	hsl(209, 71%, 79%);
-    --digital-blue-250: hsl(209, 70%, 73%);
-    --digital-blue-300: hsl(209, 69%, 66%);
-    --digital-blue-350: hsl(209, 69%, 59%);
-    --digital-blue-400: hsl(209, 69%, 53%);
-    --digital-blue-450: hsl(209, 81%, 46%);
+    --digital-blue-100: hsl(209, 90%, 93%);
+    --digital-blue-150: hsl(209, 90%, 86%);
+    --digital-blue-200:	hsl(209, 90%, 79%);
+    --digital-blue-250: hsl(209, 85%, 73%);
+    --digital-blue-300: hsl(209, 85%, 66%);
+    --digital-blue-350: hsl(209, 85%, 59%);
+    --digital-blue-400: hsl(209, 85%, 53%);
+    --digital-blue-450: hsl(209, 95%, 46%);
     --digital-blue-500: hsl(209, 100%, 39%);
     --digital-blue-550: hsl(209, 100%, 36%);
     --digital-blue-600: hsl(209, 100%, 34%);

--- a/public/static/global.css
+++ b/public/static/global.css
@@ -119,97 +119,129 @@
 
   /* Basic colors: a bluish grayish color, bluer than the UX colors, grayer
     than the digital blues we use for buttons etc. */
-  --blue-slate-100: hsl(209, 75%, 87%);
-  --blue-slate-200: hsl(220, 64%, 82%);
-  --blue-slate-300: hsl(225, 48%, 77%);
-  --blue-slate-400: hsl(229, 25%, 56%);
-  --blue-slate-500: hsl(231, 18%, 36%);
-  --blue-slate-600: hsl(233, 21%, 30%);
-  --blue-slate-700: hsl(235, 25%, 23%);
-  --blue-slate-800: hsl(237, 25%, 14%);
-  --blue-slate-900: hsl(240, 25%, 9%);
+    --blue-slate-100: hsl(209, 75%, 87%);
+    --blue-slate-150: hsl(210, 53%, 80%);
+    --blue-slate-200: hsl(213, 40%, 74%);
+    --blue-slate-250: hsl(215, 31%, 68%);
+    --blue-slate-300:	hsl(218, 26%, 61%);
+    --blue-slate-350: hsl(222, 22%, 55%);
+    --blue-slate-400: hsl(223, 20%, 49%);
+    --blue-slate-450: hsl(227, 21%, 42%);
+    --blue-slate-500: hsl(231, 18%, 36%);
+    --blue-slate-550: hsl(232, 18%, 33%);
+    --blue-slate-600: hsl(233, 18%, 29%);
+    --blue-slate-650: hsl(233, 20%, 26%);
+    --blue-slate-700: hsl(232, 20%, 23%);
+    --blue-slate-750: hsl(234, 20%, 19%);
+    --blue-slate-800: hsl(236, 21%, 16%);
+    --blue-slate-850: hsl(240, 22%, 13%);
+    --blue-slate-900: hsl(240, 25%, 9%);
 
-  /* UX GRAYS – use the cool gray variables. */
-  --cool-gray-subtle: #f5fafc;
-  --cool-gray-100: #f1f6fa;
-  --cool-gray-150: #e0e9ee;
-  --cool-gray-200: #d1dbe3;
-  --cool-gray-250: #c1ced7;
-  --cool-gray-300: #b2c1cb;
-  --cool-gray-350: #a4b5c0;
-  --cool-gray-400: #96a8b4;
-  --cool-gray-450: #899ca8;
-  --cool-gray-500: #7c909d;
-  --cool-gray-550: #6f8491;
-  --cool-gray-600: #637886;
-  --cool-gray-650: #586c7a;
-  --cool-gray-700: #4d616e;
-  --cool-gray-750: #435663;
-  --cool-gray-800: #394b57;
-  --cool-gray-850: #30404b;
-  --cool-gray-900: #273640;
+    /* UX GRAYS – use the cool gray variables. */
+    --cool-gray-subtle: hsl(197, 54%, 97%);
+    --cool-gray-100: hsl(207, 47%, 96%);
+    --cool-gray-150: hsl(201, 29%, 91%);
+    --cool-gray-200: hsl(207, 24%, 85%);
+    --cool-gray-250: hsl(205, 22%, 80%);
+    --cool-gray-300: hsl(204, 19%, 75%);
+    --cool-gray-350: hsl(204, 18%, 70%);
+    --cool-gray-400: hsl(204, 17%, 65%);
+    --cool-gray-450: hsl(203, 15%, 60%);
+    --cool-gray-500: hsl(204, 14%, 55%);
+    --cool-gray-550: hsl(203, 13%, 50%);
+    --cool-gray-600: hsl(204, 15%, 46%);
+    --cool-gray-650: hsl(205, 16%, 41%);
+    --cool-gray-700: hsl(204, 18%, 37%);
+    --cool-gray-750: hsl(204, 19%, 33%);
+    --cool-gray-800: hsl(204, 21%, 28%);
+    --cool-gray-850: hsl(204, 22%, 24%);
+    --cool-gray-900: hsl(204, 24%, 20%);
 
-  /* UX gray shorthands */
-  --bg-gray-01: var(--cool-gray-100);
-  --bg-gray-02: var(--cool-gray-300);
-  --line-gray-01: var(--cool-gray-150);
-  --line-gray-02: var(--cool-gray-400);
-  --subhead-gray-01: var(--cool-gray-550);
-  --subhead-gray-02: var(--cool-gray-650); /* cooler-colored gray */
-  --body-gray-01: var(--cool-gray-800);
-  --body-gray-02: var(--cool-gray-900);
+    /* UX gray shorthands */
+    --bg-gray-01: var(--cool-gray-100);
+    --bg-gray-02: var(--cool-gray-300);
+    --line-gray-01: var(--cool-gray-150);
+    --line-gray-02: var(--cool-gray-400);
+    --subhead-gray-01: var(--cool-gray-550);
+    --subhead-gray-02: var(--cool-gray-650); /* cooler-colored gray */
+    --body-gray-01: var(--cool-gray-800);
+    --body-gray-02: var(--cool-gray-900);
 
-  /* use digital blue as link + button color for accessibility */
-  --digital-blue-100: hsl(209, 70%, 93%);
-  --digital-blue-200: hsl(209, 75%, 87%);
-  --digital-blue-300: hsl(209, 85%, 75%);
-  --digital-blue-400: hsl(209, 95%, 60%);
-  --digital-blue-500: hsl(209, 100%, 39%);
-  --digital-blue-600: hsl(209, 100%, 34%);
-  --digital-blue-700: hsl(209, 100%, 29%);
-  --digital-blue-800: hsl(209, 100%, 24%);
-  --digital-blue-900: hsl(209, 100%, 19%);
+    /* use digital blue as link + button color for accessibility */
+    --digital-blue-100: hsl(209, 70%, 93%);
+    --digital-blue-150: hsl(209, 71%, 86%);
+    --digital-blue-200:	hsl(209, 71%, 79%);
+    --digital-blue-250: hsl(209, 70%, 73%);
+    --digital-blue-300: hsl(209, 69%, 66%);
+    --digital-blue-350: hsl(209, 69%, 59%);
+    --digital-blue-400: hsl(209, 69%, 53%);
+    --digital-blue-450: hsl(209, 81%, 46%);
+    --digital-blue-500: hsl(209, 100%, 39%);
+    --digital-blue-550: hsl(209, 100%, 36%);
+    --digital-blue-600: hsl(209, 100%, 34%);
+    --digital-blue-650: hsl(209, 100%, 32%);
+    --digital-blue-700: hsl(209, 100%, 29%);
+    --digital-blue-750: hsl(209, 100%, 27%);
+    --digital-blue-800:	hsl(209, 100%, 24%);
+    --digital-blue-850: hsl(209, 100%, 22%);
+    --digital-blue-900: hsl(209, 100%, 19%);
 
-  /* use pantone red for errors */
-  --pantone-red-100: hsl(355, 100%, 95%);
-  --pantone-red-200: hsl(355, 96%, 85%);
-  --pantone-red-300: hsl(355, 91%, 75%);
-  --pantone-red-400: hsl(355, 88%, 65%);
-  --pantone-red-500: hsl(355, 84%, 45%);
-  --pantone-red-600: hsl(355, 84%, 35%);
-  --pantone-red-700: hsl(355, 90%, 23%);
-  --pantone-red-800: hsl(355, 100%, 18%);
-  --pantone-red-900: hsl(355, 100%, 14%);
+    /* use pantone red for errors */
+    --pantone-red-100: hsl(355, 100%, 95%);
+    --pantone-red-150: hsl(354, 80%, 88%);
+    --pantone-red-200: hsl(354, 76%, 82%);
+    --pantone-red-250: hsl(355, 72%, 76%);
+    --pantone-red-300: hsl(355, 71%, 70%);
+    --pantone-red-350: hsl(355, 70%, 64%);
+    --pantone-red-400: hsl(355, 70%, 57%);
+    --pantone-red-450: hsl(355, 69%, 51%);
+    --pantone-red-500: hsl(355, 84%, 45%);
+    --pantone-red-550: hsl(355, 85%, 41%);
+    --pantone-red-600: hsl(355, 85%, 37%);
+    --pantone-red-650: hsl(355, 87%, 33%);
+    --pantone-red-700: hsl(355, 88%, 29%);
+    --pantone-red-750: hsl(355, 89%, 26%);
+    --pantone-red-800: hsl(355, 91%, 22%);
+    --pantone-red-850: hsl(354, 96%, 18%);
+    --pantone-red-900: hsl(355, 100%, 14%);
 
-  /* use pond green for success states */
-  --pond-green-100: #c7fadc;
-  --pond-green-150: #b5eece;
-  --pond-green-200: #a3e3c1;
-  --pond-green-250: #92d7b4;
-  --pond-green-300: #83cba9;
-  --pond-green-350: #74c09d;
-  --pond-green-400: #66b493;
-  --pond-green-450: #59a889;
-  --pond-green-500: #4d9d7f;
-  --pond-green-550: #429175;
-  --pond-green-600: #37866c;
-  --pond-green-650: #2e7a63;
-  --pond-green-700: #256e5a;
-  --pond-green-750: #1d6352;
-  --pond-green-800: #175749;
-  --pond-green-850: #114b40;
-  --pond-green-900: #0c4037;
+    /* use pond green for success states */
+    --pond-green-100: hsl(145, 84%, 88%);
+    --pond-green-150: hsl(146, 63%, 82%);
+    --pond-green-200: hsl(148, 53%, 76%);
+    --pond-green-250: hsl(150, 46%, 71%);
+    --pond-green-300: hsl(152, 41%, 65%);
+    --pond-green-350: hsl(152, 38%, 60%);
+    --pond-green-400: hsl(155, 34%, 55%);
+    --pond-green-450: hsl(156, 31%, 50%);
+    --pond-green-500: hsl(158, 34%, 46%);
+    --pond-green-550: hsl(159, 37%, 41%);
+    --pond-green-600: hsl(160, 42%, 37%);
+    --pond-green-650: hsl(162, 45%, 33%);
+    --pond-green-700: hsl(164, 50%, 29%);
+    --pond-green-750: hsl(165, 55%, 25%);
+    --pond-green-800: hsl(167, 58%, 22%);
+    --pond-green-850: hsl(169, 63%, 18%);
+    --pond-green-900: hsl(170, 68%, 15%);
 
-  /* use bright yellows for warnings */
-  --bright-yellow-100: hsl(53, 100%, 95%);
-  --bright-yellow-200: hsl(50, 100%, 80%);
-  --bright-yellow-300: hsl(44, 100%, 73%);
-  --bright-yellow-400: hsl(40, 100%, 67%);
-  --bright-yellow-500: hsl(37, 100%, 56%);
-  --bright-yellow-600: hsl(35, 100%, 37%);
-  --bright-yellow-700: hsl(33, 100%, 25%);
-  --bright-yellow-800: hsl(27, 100%, 20%);
-  --bright-yellow-900: hsl(20, 100%, 16%);
+    /* use bright yellows for warnings */
+    --bright-yellow-100: hsl(53, 100%, 95%);
+    --bright-yellow-150: hsl(44, 100%, 90%);
+    --bright-yellow-200: hsl(41, 100%, 85%);
+    --bright-yellow-250: hsl(40, 100%, 80%);
+    --bright-yellow-300: hsl(38, 100%, 75%);
+    --bright-yellow-350: hsl(38, 100%, 71%);
+    --bright-yellow-400: hsl(38, 100%, 66%);
+    --bright-yellow-450: hsl(37, 100%, 61%);
+    --bright-yellow-500: hsl(37, 100%, 56%);
+    --bright-yellow-550: hsl(36, 82%, 51%);
+    --bright-yellow-600: hsl(35, 80%, 46%);
+    --bright-yellow-650: hsl(34, 82%, 41%);
+    --bright-yellow-700: hsl(32, 83%, 36%);
+    --bright-yellow-750: hsl(30, 85%, 31%);
+    --bright-yellow-800: hsl(28, 88%, 26%);
+    --bright-yellow-850: hsl(25, 93%, 21%);
+    --bright-yellow-900: hsl(20, 100%, 16%);
 
   /* probe type colors */
 

--- a/src/udgl/data-graphics/utils/color-maps.js
+++ b/src/udgl/data-graphics/utils/color-maps.js
@@ -2,7 +2,7 @@ import { schemeTableau10 } from 'd3-scale-chromatic';
 
 export function percentileLineColorMap(percentile) {
   const p = +percentile;
-  if (p === 5) return 'var(--digital-blue-300)';
+  if (p === 5) return 'var(--digital-blue-250)';
   if (p === 25) return 'var(--digital-blue-500)';
   if (p === 50) return 'var(--cool-gray-600)';
   if (p === 75) return 'var(--pantone-red-500)';

--- a/src/udgl/icons/GLAM.svelte
+++ b/src/udgl/icons/GLAM.svelte
@@ -13,9 +13,9 @@ let delay = 200;
 <style>
 
 svg {
-    --dark: var(--digital-blue-300);
-    --medium:var(--digital-blue-600);
-    --light:var(--digital-blue-400);
+    --dark: var(--digital-blue-250);
+    --medium: var(--digital-blue-600);
+    --light: var(--digital-blue-350);
     fill-rule: evenodd;
     clip-rule: evenodd;
     stroke-linejoin: round;
@@ -24,7 +24,7 @@ svg {
 
 </style>
 {#if mounted}
-<svg width="100%" height={size} viewBox="0 0 512 333" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" 
+<svg width="100%" height={size} viewBox="0 0 512 333" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/"
     style="min-width: {size}px;">
     <g transform="matrix(1,0,0,1,-686.333,-953.365)">
         <g  transform="matrix(-0.866025,-0.5,-0.5,0.866025,2318.33,620.811)">

--- a/stories/basics/Color01.svelte
+++ b/stories/basics/Color01.svelte
@@ -5,26 +5,11 @@ const families = [
   { color: 'digital-blue', role: 'secondary', d: 'accessible buttons / links' },
   { color: 'pantone-red', role: 'error', d: 'dialogs, button states' },
   { color: 'bright-yellow', role: 'warning / alert', d: 'warning messages, etc.' },
-];
-
-const richFamilies = [
   { color: 'cool-gray', role: 'UX Grays', d: 'bodies, lines, text' },
   { color: 'pond-green', role: 'success', d: 'success buttons, etc.' },
 ];
 
-// const tintsAndShades = (color) => [`${color}-100`, `${color}-200`, `${color}-300`,
-//   `${color}-400`, `${color}-500`, `${color}-600`, `${color}-700`,
-//   `${color}-800`, `${color}-900`];
-
 const tintsAndShades = (color) => {
-  const vals = [100, 200, 300, 400, 500, 600, 700, 800, 900];
-  return vals.map((v) => ({
-    c: `${color}-${v}`,
-    v,
-  }));
-};
-
-const tintsAndShades17 = (color) => {
   const vals = [100, 150, 200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800, 850, 900];
   return vals.map((v) => ({
     c: `${color}-${v}`,
@@ -99,48 +84,9 @@ const tintsAndShades17 = (color) => {
                         " class="color
                         {c.includes('light') ? '' : 'dark'}">
                         <div style="
-                            background-color: var(--{color}-100); 
-                            width:max-content; 
-                            padding: var(--space-1h); 
-                            color:var(--{color}-700);
-                            border-radius: var(--space-1h);
-                            font-size:12px;
-                            font-weight:900;">{v}</div>
-
-                            {#if v === 100}
-                                <div style="
-                                    color: var(--{color}-900)">{color}</div>
-                            {/if}
-                            {#if v === 900}
-                            <div style="
-                            color: var(--{color}-100)">{color}</div>
-                            {/if}
-                        </div>
-                    </div>
-                {/each}
-            </div>
-        {/each}
-
-        <!-- 17 chade color palettes -->
-
-        {#each richFamilies as {color, role, d}, i}
-            <div>
-                <div class="color role">{role}</div>
-                <div class='description'>{d}</div>
-                {#each tintsAndShades17(color) as {c, v}, j}
-                    <div>
-                        <div style="
-                            background-color: var(--{c});
-                            display:grid;
-                            grid-template-columns: var(--space-4x) max-content ;
-                            align-items: baseline;
-                            grid-column-gap: var(--space-2x);
-                        " class="color
-                        {c.includes('light') ? '' : 'dark'}">
-                        <div style="
-                            background-color: var(--{color}-100); 
-                            width:max-content; 
-                            padding: var(--space-1h); 
+                            background-color: var(--{color}-100);
+                            width:max-content;
+                            padding: var(--space-1h);
                             color:var(--{color}-700);
                             border-radius: var(--space-1h);
                             font-size:12px;


### PR DESCRIPTION
Palettes had their saturation increased by 5% for values < 500 (except cool-gray/pond-green) and were converted back to HSL for easier numerical adjustment going forward. There will be visual differences but hopefully not deal-breakers.

Left is old, right is new:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/391260/79281298-1616f500-7e78-11ea-9588-fff03f8a4fab.png">
