### PR TITLE
Allow bucket to be passed as an argument for import_aggs.

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -54,6 +54,14 @@ Firefox:
 
 where `CHANNEL` is one of `nightly`, `beta`, or `release`.
 
+You can also import data from a custom bucket using the bucket argument.
+Remember to set the project accordingly:
+
+```bash
+export GOOGLE_CLOUD_PROJECT=<PROJECT>
+./manage.py import_aggs release --bucket <BUCKET>
+```
+
 You will need to have viewer permissions in the non-prod GCP project to pull
 down data. Reach out to someone on the #glam Slack channel if you need the
 proper authorization.

--- a/glam/api/management/commands/import_aggs.py
+++ b/glam/api/management/commands/import_aggs.py
@@ -27,14 +27,19 @@ class Command(BaseCommand):
         parser.add_argument(
             "channel", choices=constants.CHANNEL_IDS.keys(),
         )
+        parser.add_argument(
+            "--bucket",
+            help="The bucket location for the exported aggregates",
+            default=GCS_BUCKET,
+        )
 
-    def handle(self, *args, **options):
+    def handle(self, bucket, *args, **options):
 
         channel = options["channel"]
 
         self.gcs_client = storage.Client()
 
-        blobs = self.gcs_client.list_blobs(GCS_BUCKET)
+        blobs = self.gcs_client.list_blobs(bucket)
         blobs = list(
             filter(
                 lambda b: b.name.startswith(f"glam-extract-firefox-{channel}"), blobs


### PR DESCRIPTION
This will help us test new data locally before merging changes in the ETL. I would place data in a project and bucket called `glam-desktop-dev`. So we can pull in data like this:

```
export GOOGLE_CLOUD_PROJECT=glam-desktop-dev
./manage.py import_aggs release --bucket glam-desktop-dev
```