### PR TITLE
basic search functionality from probe search service

### DIFF
--- a/src/routing/Router.svelte
+++ b/src/routing/Router.svelte
@@ -54,7 +54,7 @@
       if (probeName) {
         store.setField('probeName', probeName);
         if ($probeSet) {
-          const newProbe = $probeSet.find((p) => p.name === probeName);
+          const newProbe = $probeSet.find((p) => p.name.toLowerCase() === probeName.toLowerCase());
           productConfig[$store.product].setDefaultsForProbe(store, newProbe);
         }
       }

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -39,7 +39,7 @@ export async function getProbeData(params, token) {
             ? FETCH_ERROR_MESSAGES.code4xx
             : FETCH_ERROR_MESSAGES.code5xx;
       }
-      let error = new Error(msg);
+      const error = new Error(msg);
       error.statusCode = response.status;
       throw error;
     }


### PR DESCRIPTION
closes #172

@robhudson this is a first pass and not ready for review. There are issues with (1) casing, and (2) the data API doesn't accept all the same strings as the probe search service gives. We should work to unify these. Preferably GLAM would match much more closely what is in the probe search service, since it seems people have been tripped up by GLAM's naming convention during the interviews.

Work left on this PR:

- [ ] remove all the bits of global state we were tracking before. This seems unnecessary in hindsight since the search workflow is 100% confined to the component. This will remove some complexity and improve maintainability.
- [ ] fix the keyboard interactions
- [ ] make the search experience somewhat nicer
- [ ] figure out the solution to the name mismatch b/t the probe search service & GLAM