### PR TITLE
fixes the issue where process=all should default to process=[parent, content, gpu]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## [unreleased](https://github.com/mozilla/glam/compare/2020.4.2...HEAD) (date TBD)
 
 - adds prototype app warning dialog ([#478](https://github.com/mozilla/glam/pull/478))
+- Fix bug where process=all should convert to process=[parent,content,gpu](<[#481](https://github.com/mozilla/glam/pull/451)>)
 
-## [2020.4.2](https://github.com/mozilla/glam/compare/2020.4.1...2020.4.2) (2020-04-30)
+## 2020.4.2
 
-- changes the violin plot implementation ([#451](https://github.com/mozilla/glam/pull/451))
-- changes curvature of percentile lines ([#447](https://github.com/mozilla/glam/pull/447))
+Date: 2020-04-30
+
+- Change the violin plot implementation ([#451](https://github.com/mozilla/glam/pull/451))
+- Change curvature of percentile lines ([#447](https://github.com/mozilla/glam/pull/447))
 
 ## [2020.4.1](https://github.com/mozilla/glam/compare/2020.4.0...2020.4.1) (2020-04-28)
 

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -43,6 +43,13 @@ export default {
       },
     },
   },
+  transformProbeForGLAM(probe) {
+    const pr = { ...probe };
+    if (pr.record_in_processes[0] === 'all') {
+      pr.record_in_processes = ['main', 'content', 'gpu'];
+    }
+    return pr;
+  },
   setDefaultsForProbe(store, probe) {
     const state = store.getState();
     if (

--- a/src/routing/Router.svelte
+++ b/src/routing/Router.svelte
@@ -54,7 +54,10 @@
       if (probeName) {
         store.setField('probeName', probeName);
         if ($probeSet) {
-          const newProbe = $probeSet.find((p) => p.name === probeName);
+          let newProbe = $probeSet.find((p) => p.name === probeName);
+          if (productConfig[$store.product].transformProbeForGLAM) {
+            newProbe = productConfig[$store.product].transformProbeForGLAM(newProbe);
+          }
           productConfig[$store.product].setDefaultsForProbe(store, newProbe);
         }
       }

--- a/src/routing/wrappers/Probe.svelte
+++ b/src/routing/wrappers/Probe.svelte
@@ -13,7 +13,6 @@
   import { probe, dataset, store } from '../../state/store';
   import { getProbeViewType, isSelectedProcessValid } from '../../utils/probe-utils';
 
-
   // FIXME: for now, once we have retreived the data set, there are
   // a few additional operations that need to be performed.
   // to start, we will need to reset the activeBuckets in the non-
@@ -43,7 +42,12 @@
   {#if isSelectedProcessValid($store.recordedInProcesses, $store.productDimensions.process)}
     <slot {data} probeType={$temporaryViewTypeStore} />
   {:else}
-    <DataError reason={`This probe does not record in the ${$store.productDimensions.process} process.`} />
+    <div class='graphic-body__content'>
+      <ProbeTitle />
+      <div in:fly={{ duration: 400, y: 10 }}>
+        <DataError reason={`This probe does not record in the ${$store.productDimensions.process} process.`} />
+      </div>
+    </div>
   {/if}
 {:catch err}
   <div class="graphic-body__content">

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -39,7 +39,7 @@ export async function getProbeData(params, token) {
             ? FETCH_ERROR_MESSAGES.code4xx
             : FETCH_ERROR_MESSAGES.code5xx;
       }
-      let error = new Error(msg);
+      const error = new Error(msg);
       error.statusCode = response.status;
       throw error;
     }

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -120,7 +120,9 @@ export const resetFilters = () => {
 
 export const probe = derived([probeSet, store], ([$probeSet, $store]) => {
   if (!$probeSet || !$store.probeName) return undefined;
-  return $probeSet.find((p) => p.name === $store.probeName);
+  let pr = $probeSet.find((p) => p.name === $store.probeName);
+  if (CONFIG.transformProbeForGLAM) pr = CONFIG.transformProbeForGLAM(pr);
+  return pr;
 });
 
 export const searchResults = derived(
@@ -170,7 +172,7 @@ function getParamsForDataAPI(obj) {
   if (obj.product === 'firefoxDesktop') {
     const channelValue = obj.productDimensions.channel;
     const osValue = obj.productDimensions.os;
-    const process = obj.productDimensions.process;
+    const { process } = obj.productDimensions;
     const params = getParamsForQueryString(obj);
     delete params.timeHorizon;
     delete params.proportionMetricType;


### PR DESCRIPTION
Closes #417 

We have some high-value probes that mysteriously have `process=all` such as `keypress_present_latency`. This fixes the case by creating a new `transformProbeForGLAM` function within each config file, which does what you would expect. I am imagining that we'll likely encounter issues that require this kind of function on a per-product basis.