### PR TITLE
Improve efficiency of toProportions algorithm

### DIFF
--- a/src/utils/probe-utils.js
+++ b/src/utils/probe-utils.js
@@ -82,9 +82,9 @@ export const transformQuantileResponse = (probeData, key = 'version') =>
   });
 
 function toProportions(obj) {
-  const proportions = { ...obj };
-  const total = Object.values(proportions).reduce((a, b) => a + b, 0);
-  Object.keys(proportions).forEach((p) => {
+  const proportions = {};
+  const total = Object.values(obj).reduce((a, b) => a + b, 0);
+  Object.keys(obj).forEach((p) => {
     proportions[p] /= total;
   });
   return proportions;


### PR DESCRIPTION
We can achieve the same result without making a copy of the object at
the beginning of the algorithm. This improves efficiency from O(n^3) to
O(n^2).