### PR TITLE
moves the product params API & querystring parts to firefox-desktop.js

### DIFF
--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -46,6 +46,27 @@ export default {
       },
     },
   },
+  getParamsForQueryString(store) {
+    return {
+      channel: store.productDimensions.channel,
+      os: store.productDimensions.os,
+      aggregationLevel: store.productDimensions.aggregationLevel,
+      process: store.productDimensions.process,
+      timeHorizon: store.timeHorizon,
+      proportionMetricType: store.proportionMetricType,
+      activeBuckets: store.activeBuckets,
+      visiblePercentiles: store.visiblePercentiles,
+    };
+  },
+  getParamsforDataAPI(store) {
+    return {
+      channel: store.productDimensions.channel,
+      os: store.productDimensions.os,
+      probe: store.probeName,
+      process: store.productDimensions.process,
+      aggregationLevel: store.productDimensions.aggregationLevel,
+    };
+  },
   transformProbeForGLAM(probe) {
     const pr = { ...probe };
     if (pr.record_in_processes[0] === 'all') {

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -156,40 +156,13 @@ export const hasDefaultControlFields = derived(store, ($store) =>
 // ///// probe querying infrastructure.
 
 function getParamsForQueryString(obj) {
-  // FIXME: turn this conditional into a function in firefox-desktop.js
-  if (obj.product === 'firefoxDesktop') {
-    return {
-      channel: obj.productDimensions.channel,
-      os: obj.productDimensions.os,
-      aggregationLevel: obj.productDimensions.aggregationLevel,
-      process: obj.productDimensions.process,
-      timeHorizon: obj.timeHorizon,
-      proportionMetricType: obj.proportionMetricType,
-      activeBuckets: obj.activeBuckets,
-      visiblePercentiles: obj.visiblePercentiles,
-    };
-  }
-  throw Error('Product not recognized.');
+  // FIXME: move toward a product-keyed version of this.
+  return CONFIG.getParamsForQueryString(obj);
 }
 
 function getParamsForDataAPI(obj) {
-  // FIXME: turn this conditional into a function in firefox-desktop.js
-  if (obj.product === 'firefoxDesktop') {
-    const channelValue = obj.productDimensions.channel;
-    const osValue = obj.productDimensions.os;
-    const { process } = obj.productDimensions;
-    const params = getParamsForQueryString(obj);
-    delete params.timeHorizon;
-    delete params.proportionMetricType;
-    delete params.activeBuckets;
-    delete params.visiblePercentiles;
-    params.probe = obj.probeName;
-    params.os = osValue;
-    params.channel = channelValue;
-    params.process = process;
-    return params;
-  }
-  throw Error('product not recognized.');
+  // FIXME: move toward a product-keyed version of this.
+  return CONFIG.getParamsforDataAPI(obj);
 }
 
 const toQueryStringPair = (k, v) => {


### PR DESCRIPTION
This is part of #569, closes #592. This moves `getParamsForQueryString` and `getParamsForDataAPI` to `firefox-desktop.js`.