### PR TITLE
adds Architectural Decision Records approach to GLAM's documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   [f11e979](https://github.com/mozilla/glam/commit/f11e9793b4725d2bfc6ebd222d481555918b1c24)
 - Add last updated model and API endpoint
   ([#743](https://github.com/mozilla/glam/pull/743))
-- Add `/docs/adr/` (a directory of Architectural Decision Records)
+- Add `/docs/adr/` (a directory of Architectural Decision Records) ([#854](https://github.com/mozilla/glam/pull/854/))
 
 ## [2020.7.0](https://github.com/mozilla/glam/compare/2020.6.0...2020.7.0) (2020-07-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   [f11e979](https://github.com/mozilla/glam/commit/f11e9793b4725d2bfc6ebd222d481555918b1c24)
 - Add last updated model and API endpoint
   ([#743](https://github.com/mozilla/glam/pull/743))
+- Add `/docs/adr/` (a directory of Architectural Decision Records)
 
 ## [2020.7.0](https://github.com/mozilla/glam/compare/2020.6.0...2020.7.0) (2020-07-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
   [f11e979](https://github.com/mozilla/glam/commit/f11e9793b4725d2bfc6ebd222d481555918b1c24)
 - Add last updated model and API endpoint
   ([#743](https://github.com/mozilla/glam/pull/743))
-- Add `/docs/adr/` (a directory of Architectural Decision Records) ([#854](https://github.com/mozilla/glam/pull/854/))
+- Add `/docs/adr/` (a directory of Architectural Decision Records)
+  ([#854](https://github.com/mozilla/glam/pull/854/))
 
 ## [2020.7.0](https://github.com/mozilla/glam/compare/2020.6.0...2020.7.0) (2020-07-02)
 

--- a/docs/adr/0000-use-madr.md
+++ b/docs/adr/0000-use-madr.md
@@ -1,0 +1,40 @@
+# Use Markdown Architectural Decision Records
+
+- Status: accepted
+- Deciders: Hamilton Ulmer, Rob Hudson, (add yourself here)
+- Date: 2020-08-31
+
+## Context and Problem Statement
+
+We want to record architectural decisions made in GLAM. Which format and
+structure should these records follow?
+
+## Decision Drivers
+
+- Due to changes at Mozilla and Mozilla Data, having a way to onboard new
+  developers onto an older project is important
+- Practice toward better proposal / decision processes that can be referenced
+  later
+- The need for more rigor around big choices
+
+## Considered Options
+
+- Do nothing (the status quo)
+- [MADR](https://adr.github.io/madr/) 2.1.0 - The Markdown Architectural
+  Decision Records
+
+## Decision Outcome
+
+Chosen option: "MADR 2.1.0", because (this is copied from the boilerplate and
+slightly adapted)
+
+- ADRs provide us a way of more quickly onboarding new devs onto a complex
+  project like GLAM.
+- Other teams at Mozilla use ADRs. The social proof is a useful signal.
+- Implicit assumptions should be made explicit. Design documentation is
+  important to enable people understanding the decisions later on. See also
+  [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+- The MADR format is lean and fits our development style. Because of its
+  leanness, if this doesn't work out for us, then we will throw it out or
+  recycle the content.
+- Version 2.1.0 is the latest one available when starting to document ADRs.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,18 @@
+# GLAM Architectural Decision Records (ADRs)
+
+We use ADRs to capture important engineering decisions made. For more
+information, see [this ADR explanation](https://adr.github.io/).
+
+We use [MADRs (markdown ADRs)](https://adr.github.io/madr/). To contribute a new
+ADR,
+
+1. copy `template.md` into a new file in this directory in the format
+   `nnnn-title-with-dashes.md`. The `nnnn` should be the next number up from the
+   highest number in the ADRs in this directory.
+2. fill out the template.
+3. once done, run node scripts/update-adrs to generate a new index.
+4. file a PR with these changes as a branch in the GLAM repository.
+
+## accepted ADRs
+
+- [0000-use-madr.md](/docs/adr/0000-use-madr.md)

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,78 @@
+# [short title of solved problem and solution]
+
+- Status: [proposed | rejected | accepted | deprecated | … | superseded by
+  [ADR-0005](0005-example.md)] <!-- optional -->
+- Deciders: [list everyone involved in the decision] <!-- optional -->
+- Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to
+three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+- [driver 1, e.g., a force, facing concern, …]
+- [driver 2, e.g., a force, facing concern, …]
+- … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+- [option 1]
+- [option 2]
+- [option 3]
+- … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which
+meets k.o. criterion decision driver | which resolves force force | … | comes
+out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+- [e.g., improvement of quality attribute satisfaction, follow-up decisions
+  required, …]
+- …
+
+### Negative Consequences <!-- optional -->
+
+- [e.g., compromising quality attribute, follow-up decisions required, …]
+- …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+- … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+- … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+- … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+- [Link type][link to adr]
+  <!-- example: Refined by [ADR-0005](0005-example.md) -->
+- … <!-- numbers of links can vary -->

--- a/scripts/update-adrs.js
+++ b/scripts/update-adrs.js
@@ -4,8 +4,6 @@ and creates a list of adrs + links in index.md.
 */
 
 const fs = require('fs');
-const path = require('path');
-const { template } = require('@babel/core');
 
 const adrPattern = new RegExp(/\d{4}-[\S]*.md/);
 const adrs = fs

--- a/scripts/update-adrs.js
+++ b/scripts/update-adrs.js
@@ -27,7 +27,7 @@ the highest number in the ADRs in this directory.
 3. once done, run node scripts/update-adrs to generate a new index.
 4. file a PR with these changes as a branch in the GLAM repository.
 
-## accepted ADRs
+## Accepted ADRs
 
 ${adrs}
 

--- a/scripts/update-adrs.js
+++ b/scripts/update-adrs.js
@@ -1,0 +1,40 @@
+/*
+This script looks at docs/adr/, pulls all the available .md files,
+and creates a list of adrs + links in index.md.
+*/
+
+const fs = require('fs');
+const path = require('path');
+const { template } = require('@babel/core');
+
+const adrPattern = new RegExp(/\d{4}-[\S]*.md/);
+const adrs = fs
+  .readdirSync('../docs/adr/')
+  .filter((file) => adrPattern.test(file))
+  .map((file) => `- [${file}](/docs/adr/${file})`)
+  .join('\n');
+
+const indexMD = `# GLAM Architectural Decision Records (ADRs)
+
+We use ADRs to capture important engineering decisions made.
+For more information, see [this ADR explanation](https://adr.github.io/).
+
+We use [MADRs (markdown ADRs)](https://adr.github.io/madr/).
+To contribute a new ADR,
+
+1. copy \`template.md\` into a new file in this directory in the format
+\`nnnn-title-with-dashes.md\`. The \`nnnn\` should be the next number up from
+the highest number in the ADRs in this directory.
+2. fill out the template.
+3. once done, run node scripts/update-adrs to generate a new index.
+4. file a PR with these changes as a branch in the GLAM repository.
+
+## accepted ADRs
+
+${adrs}
+
+`;
+
+// write indexMD to a new file
+
+fs.writeFileSync('../docs/adr/index.md', indexMD);


### PR DESCRIPTION
We're considering following the ADR methodology for noting big decisions. This entails:

- `/docs/adr/` – add an ADR here.
- `/scripts/update-adrs.js` – run this to re-compile the ADR index file.