### PR TITLE
Update time horizons to show more data (#716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [unreleased](https://github.com/mozilla/glam/compare/2020.10.0...HEAD) (date TBD)
 
+- Update time horizon to be able to view more data
+  ([#928](https://github.com/mozilla/glam/pull/928))
+
 ## [2020.10.0](https://github.com/mozilla/glam/compare/2020.9.0...2020.10.0) (2020-10-01)
 
 - Add `keyed-scalar` to list of probe types
-  ((b876a80)[https://github.com/mozilla/glam/commit/b876a80f9b627ecd9409781164e52f93b70d273e])
+  ([b876a80](https://github.com/mozilla/glam/commit/b876a80f9b627ecd9409781164e52f93b70d273e))
 
 ## [2020.9.1](https://github.com/mozilla/glam/compare/2020.9.0...2020.9.1) (2020-09-29)
 

--- a/src/components/controls/TimeHorizonControl.svelte
+++ b/src/components/controls/TimeHorizonControl.svelte
@@ -2,10 +2,29 @@
   import BodyControl from './BodyControl.svelte';
 
   export let horizon = 'MONTH';
+
+  const options = [
+    {
+      label: 'week',
+      value: 'WEEK',
+      tooltip: 'show the last week of build ids',
+    },
+    {
+      label: 'month',
+      value: 'MONTH',
+      tooltip: 'show the last month of build ids',
+    },
+    {
+      label: 'quarter',
+      value: 'QUARTER',
+      tooltip: 'show the last 3 months of build ids',
+    },
+    {
+      label: 'all',
+      value: 'ALL',
+      tooltip: 'show all available data',
+    },
+  ];
 </script>
 
-<BodyControl
-  options={[{ label: 'last week', value: 'WEEK', tooltip: 'show the last week of build ids' }, { label: 'last month', value: 'MONTH', tooltip: 'show the last month of build ids' }, { label: 'all time', value: 'ALL_TIME', tooltip: 'show all build ids available for this probe' }]}
-  selected={horizon}
-  level="medium"
-  on:selection />
+<BodyControl {options} selected={horizon} level="medium" on:selection />

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -102,6 +102,7 @@ export default {
       probe: storeValue.probeName,
       process: storeValue.productDimensions.process,
       aggregationLevel: storeValue.productDimensions.aggregationLevel,
+      versions: 10,
     };
   },
   fetchData(params, appStore) {


### PR DESCRIPTION
I consider this a working, work in progress.

TODO:
- [ ] Investigate triggering a re-fetch when the time horizon changes to > MONTH, and default back to a smaller number of versions requested from the API to keep the data response smaller by default
- [ ] Investigate making the API align more with the UI by request a number of builds rather than number of versions