### PR TITLE
Fix #993: Tie channel selection to probe.info.history options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## [unreleased](https://github.com/mozilla/glam/compare/2020.10.1...HEAD) (date TBD)
+## [unreleased](https://github.com/mozilla/glam/compare/2020.10.3...HEAD) (date TBD)
 
+- Attach desktop channels to probe.info.history keys
+  ([#996](https://github.com/mozilla/glam/pull/996))
 - Parse glean descriptions with markdown
   ([#995](https://github.com/mozilla/glam/pull/995))
 - Expand widths of main content for larger displays

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -20,7 +20,7 @@ export default {
       ],
       defaultValue: 'nightly',
       isValidKey(key, probe) {
-        return (probe.prerelease && key !== 'release') || !probe.prerelease;
+        return key in probe.info.history;
       },
     },
     os: {
@@ -178,9 +178,14 @@ export default {
       const newProcess = probe.info.calculated.seen_in_processes[0];
       store.setDimension('process', newProcess);
     }
+    // If channel isn't included in history, reset state to channel that is
+    if (!(state.productDimensions.channel in probe.info.history)) {
+      store.setDimension('channel', Object.keys(probe.info.history)[0]);
+    }
     // accommodate prerelease-only probes by resetting to nightly (if needed)
     if (
       state.productDimensions.channel === 'release' &&
+      'release' in probe.info.history &&
       !probe.info.history.release[0].optout
     ) {
       store.setDimension('channel', 'nightly');


### PR DESCRIPTION
Note: This also removes `prerelease` which isn't a key we get from
probe-search.