### PR TITLE
Increase buffer size for headers

### DIFF
--- a/dockerfiles/proxy/default.conf.template
+++ b/dockerfiles/proxy/default.conf.template
@@ -45,6 +45,9 @@ server {
 
     client_max_body_size 2g;
 
+    client_header_buffer_size 4k;
+    large_client_header_buffers 4 16k;
+
     # Health checks don't send an x-forwarded-proto header and we need to make
     # sure they don't get infinite redirects
     if ($http_x_forwarded_proto = "http") {


### PR DESCRIPTION
Sometimes the cookies are larger than the default buffers, and the client will get a 400. This should help prevent that from happening.