### PR TITLE
Improve search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased](https://github.com/mozilla/glam/compare/2021.1.1...HEAD) (date TBD)
 
+- Improve search, adds inactive label, pushes inactive metrics to the bottom,
+  includes all search terms in search query
+  ([#1139](https://github.com/mozilla/glam/pull/1139))
+
 ## [2021.1.1](https://github.com/mozilla/glam/compare/2021.1.0...2021.1.1) (2021-01-19)
 
 - Update SQL generation to use mozfun UDF

--- a/public/static/global.css
+++ b/public/static/global.css
@@ -249,7 +249,9 @@
   --scalar-color: var(--pantone-red-700);
   --scalar-bg: var(--pantone-red-200);
   --event-color: var(--blue-slate-400);
-  --event-color: var(--blue-slate-100);
+  --event-bg: var(--blue-slate-100);
+  --inactive-color: var(--bright-yellow-900);
+  --inactive-bg: var(--bright-yellow-400);
 
   --primary-text: white;
 
@@ -556,6 +558,11 @@ main .details {
 .label--scalar {
   color: var(--scalar-color);
   background-color: var(--scalar-bg);
+}
+
+.label--inactive {
+  color: var(--inactive-color);
+  background-color: var(--inactive-bg);
 }
 
 /* TYPOGRAPHY - this is a rough draft. */

--- a/src/components/search/Search.svelte
+++ b/src/components/search/Search.svelte
@@ -45,18 +45,7 @@
     (value) => {
       query = value;
       getSearchResults(query, false, $store.searchProduct).then((r) => {
-        // sort these?
-        if (r.constructor === Array) {
-          results = r.sort((a, b) => {
-            const aHas = a.name.toLowerCase().includes(query);
-            const bHas = b.name.toLowerCase().includes(query);
-            if (aHas && !bHas) return -1;
-            if (bHas && !aHas) return 1;
-            return 0;
-          });
-        } else {
-          results = r;
-        }
+        results = r;
         searchWaiting = false;
       });
       searchIsActive = true;

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -256,10 +256,16 @@
                 focusedItem = i;
               }}>
               <div class="name body-text--short-01">{searchResult.name}</div>
-              <div
-                class="probe-type label label-text--01 label--{searchResult.type}">
-                {searchResult.type}
-              </div>
+              {#if searchResult.info.calculated.active}
+                <div
+                  class="probe-type label label-text--01 label--{searchResult.type}">
+                  {searchResult.type}
+                </div>
+              {:else}
+                <div class="probe-type label label-text--01 label--inactive">
+                  inactive
+                </div>
+              {/if}
               <div class="description body-text--short-01">
                 {@html searchResult.description}
               </div>

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -64,7 +64,6 @@ export function getSearchResults(
 ) {
   const getFormattedSearchURL = (str) => {
     const URLResult = new URL('__BASE_SEARCH_DOMAIN__');
-    const strFragments = str.split(/\s+/);
 
     const params = new URLSearchParams();
     const queryOptions = [];
@@ -75,11 +74,7 @@ export function getSearchResults(
     if (!exactSearch) {
       queryOptions.push(`search.plfts(simple).${str}`);
       queryOptions.push(`description.phfts(english).${str}`);
-      queryOptions.push(
-        `name.ilike.*${
-          strFragments.length ? strFragments[strFragments.length - 1] : str
-        }*`
-      );
+      queryOptions.push(`name.ilike.*${str.split(/\s+/).join('*')}*`);
     }
 
     params.set('limit', resultsLimit);
@@ -87,6 +82,8 @@ export function getSearchResults(
     params.set('type', 'neq.event');
     params.set('or', `(${queryOptions.join(',')})`);
     params.set('not.and', stringScalars);
+    // Show active probes first.
+    params.set('order', 'info->calculated->>active.desc');
 
     if (product === 'firefox') {
       URLResult.pathname = 'telemetry'; // hint: change this to test 404 error case


### PR DESCRIPTION
This moves inactive probes to the bottom of the list and adds a label to them as inactive. This also updates the params passed to the SQL query to include all terms in the query.

Before:
![glam-search-before](https://user-images.githubusercontent.com/1106/106070472-608cf980-60b9-11eb-9b44-71c5f9c1ee35.png)

After:
![glam-search -after](https://user-images.githubusercontent.com/1106/106070475-62ef5380-60b9-11eb-9cc5-b64571c8c2b8.png)
