### PR TITLE
Remove insufficient data filters

### DIFF
--- a/src/components/explore/AggregationComparisonGraph.svelte
+++ b/src/components/explore/AggregationComparisonGraph.svelte
@@ -5,7 +5,6 @@
 
   import { tooltip as tooltipAction } from '@graph-paper/core/actions';
 
-  import { Line } from '@graph-paper/elements';
   import ReferenceSymbol from '../ReferenceSymbol.svelte';
 
   import ChartTitle from './ChartTitle.svelte';
@@ -17,7 +16,6 @@
   import { explorerComparisonSmallMultiple } from '../../utils/constants';
 
   export let description;
-  export let leftLabel;
   export let rightLabel;
   export let leftPoints;
   export let rightPoints;
@@ -37,8 +35,6 @@
 
   if (dataVolume === 1) {
     labelSet = [rightLabel];
-  } else if (dataVolume === 2) {
-    labelSet = [leftLabel, rightLabel];
   }
 
   export let xDomain = labelSet;
@@ -61,9 +57,9 @@
 
   // If insufficient data, let's not use the spring on mount.
   $: if (leftPoints && yScale)
-    dotsAndLines.setHover(leftPoints, dataVolume <= 2);
+    dotsAndLines.setHover(leftPoints, dataVolume === 1);
   $: if (rightPoints && yScale)
-    dotsAndLines.setReference(rightPoints, dataVolume <= 2);
+    dotsAndLines.setReference(rightPoints, dataVolume === 1);
 </script>
 
 <div>
@@ -78,10 +74,7 @@
     {yDomain}
     yType={yScaleType}
     xType="scalePoint"
-    width={explorerComparisonSmallMultiple.width +
-      (dataVolume <= 2
-        ? explorerComparisonSmallMultiple.insufficientDataAdjustment
-        : 0)}
+    width={explorerComparisonSmallMultiple.width}
     height={explorerComparisonSmallMultiple.height}
     bind:xScale
     bind:yScale
@@ -140,31 +133,16 @@
     <g slot="interaction" let:left let:right>
       {#if leftPoints && rightPoints}
         {#each activeBins as bin, i}
-          {#if dataVolume !== 2}
-            <line
-              x1={left}
-              x2={right}
-              y1={$dotsAndLines[bin].leftY}
-              y2={$dotsAndLines[bin].rightY}
-              stroke={$dotsAndLines[bin].color}
-              stroke-width={dataVolume === 1 ? 1 : 2}
-              stroke-opacity={dataVolume === 1 ? 0.5 : 1} />
-          {:else}
-            <!-- This is the case of only having two points. -->
-            <Line
-              scaling={false}
-              y={'y'}
-              x={'label'}
-              useYScale={false}
-              curve={'curveStep'}
-              color={$dotsAndLines[bin].color}
-              data={[
-                { y: $dotsAndLines[bin].leftY, label: leftLabel },
-                { y: $dotsAndLines[bin].rightY, label: rightLabel },
-              ]} />
-          {/if}
+          <line
+            x1={left}
+            x2={right}
+            y1={$dotsAndLines[bin].leftY}
+            y2={$dotsAndLines[bin].rightY}
+            stroke={$dotsAndLines[bin].color}
+            stroke-width={dataVolume === 1 ? 1 : 2}
+            stroke-opacity={dataVolume === 1 ? 0.5 : 1} />
           <circle
-            cx={dataVolume === 2 ? xScale(leftLabel) : left}
+            cx={left}
             cy={$dotsAndLines[bin].leftY}
             r="3"
             fill={$dotsAndLines[bin].color} />
@@ -172,7 +150,7 @@
       {/if}
       {#each activeBins as bin, i}
         <ReferenceSymbol
-          xLocation={dataVolume === 2 ? xScale(rightLabel) : right}
+          xLocation={right}
           yLocation={$dotsAndLines[bin].rightY}
           color={$dotsAndLines[bin].color} />
       {/each}

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -70,13 +70,10 @@
 
   // If there isn't more than one other point to compare,
   // let's turn off the hover.
-  let hoverActive = data.length > 2;
-  $: hoverActive = data.length > 2;
+  let hoverActive = data.length > 1;
+  $: hoverActive = data.length > 1;
 
   // If insufficient data, suppress the main graph
-  // and blow up the other.
-  let insufficientData = data.length <= 2;
-  $: insufficientData = data.length <= 2;
   $: justOne = data.length === 1;
 
   let domain = writable([]);
@@ -107,20 +104,10 @@
     setDomain(timeHorizon);
   }
 
-  export let hovered = !hoverActive ? { x: data[0].label, datum: data[0] } : {};
-
-  function leftLabelForAggComparison(d, aggLevel, x) {
-    if (d.length === 2) {
-      if (aggLevel === 'build_id') return formatBuildIDToDateString(d[0].label);
-      return d[0].label;
-    }
-    if (aggLevel === 'build_id') return formatBuildIDToDateString(x);
-    return x;
-  }
+  export let hovered = hoverActive ? {} : { x: data[0].label, datum: data[0] };
 
   function leftPointsForAggComparison(d, pmt, dt) {
-    if (d.length === 2) return d[0][pmt];
-    if (d.length > 2 && dt) return dt[pmt];
+    if (d.length > 1 && dt) return dt[pmt];
     return undefined;
   }
 
@@ -205,14 +192,14 @@
 <div class="probe-body-overview">
   <ToplineMetrics
     {ref}
-    hovered={data.length > 2 ? hovered.datum : data[0]}
+    hovered={hovered.datum}
     dataLength={data.length}
     {aggregationLevel} />
   <slot name="summary" />
 </div>
 
-<div class="graphic-and-summary" class:no-line-chart={insufficientData}>
-  <div style="display: {insufficientData ? 'none' : 'block'}">
+<div class="graphic-and-summary" class:no-line-chart={justOne}>
+  <div style="display: {justOne ? 'none' : 'block'}">
     <AggregationsOverTimeGraph
       title={aggregationsOverTimeTitle}
       description={aggregationsOverTimeDescription}
@@ -242,7 +229,6 @@
   <AggregationComparisonGraph
     description={compareDescription(aggregationsOverTimeTitle)}
     {yScaleType}
-    leftLabel={leftLabelForAggComparison(data, aggregationLevel, hovered.x)}
     rightLabel={aggregationLevel === 'build_id'
       ? formatBuildIDToDateString(ref.label)
       : ref.label}
@@ -275,7 +261,7 @@
                 2 +
               VIOLIN_PLOT_OFFSET}
             direction={-1}
-            density={data.length < 3 || !hovered.datum
+            density={data.length < 2 || !hovered.datum
               ? data[0][densityMetricType]
               : hovered.datum[densityMetricType]}
             width={(explorerComparisonSmallMultiple.width -
@@ -309,11 +295,11 @@
   </AggregationComparisonGraph>
 
   <ComparisonSummary
-    hovered={data.length === 2 || !!hovered.datum}
+    hovered={data.length === 1 || !!hovered.datum}
     left={leftPointsForAggComparison(data, pointMetricType, hovered.datum)}
     right={ref[pointMetricType]}
-    leftLabel={data.length === 2 ? 'PREV.' : 'HOV.'}
-    rightLabel={data.length <= 2 ? 'LATEST' : 'REF.'}
+    leftLabel={'HOV.'}
+    rightLabel={'REF.'}
     binLabel={summaryLabel}
     keySet={activeBins}
     colorMap={binColorMap}
@@ -321,7 +307,7 @@
     keyFormatter={comparisonKeyFormatter}
     showLeft={data.length > 1}
     showDiff={data.length > 1} />
-  <div style="display: {insufficientData ? 'none' : 'block'}">
+  <div style="display: {justOne ? 'none' : 'block'}">
     <ClientVolumeOverTimeGraph
       title={clientVolumeOverTimeTitle}
       description={clientVolumeOverTimeDescription}
@@ -338,7 +324,7 @@
         }
       }} />
   </div>
-  <div style="display: {insufficientData ? 'none' : 'block'}">
+  <div style="display: {justOne ? 'none' : 'block'}">
     <CompareClientVolumeGraph
       description={compareDescription(clientVolumeOverTimeTitle)}
       yDomain={yClientsDomain}

--- a/src/components/explore/ToplineMetrics.svelte
+++ b/src/components/explore/ToplineMetrics.svelte
@@ -55,9 +55,7 @@
       {aggregationLevel}
       description="Set the reference point ⭑ by clicking on one of the graphs below.">
       <span slot="icon">⭑</span>
-      <span slot="label">
-        {#if dataLength > 2}Reference{:else}Latest{/if}
-      </span>
+      <span slot="label"> Reference </span>
       <span slot="count">
         <span data-value={ref.audienceSize}>
           <span
@@ -78,9 +76,7 @@
         {aggregationLevel}
         description="Hover over the graphs below to compare the hover value ● to the reference ⭑; click to set the hover ● to the reference ⭑.">
         <span slot="icon">●</span>
-        <span slot="label">
-          {#if dataLength > 2}Hovered{:else}Previous{/if}
-        </span>
+        <span slot="label"> Hovered </span>
         <span slot="count">
           <div>
             {#if hovered}


### PR DESCRIPTION
When there are 2 data points show the main chart. Users expect this and
think there is something wrong when the main chart is missing.