### PR TITLE
Change default aggregation option to "average" (fixes #1183)

### DIFF
--- a/src/components/controls/AggregationTypeSelector.svelte
+++ b/src/components/controls/AggregationTypeSelector.svelte
@@ -10,6 +10,8 @@
   let button;
   let width;
 
+  aggregationTypes.sort();
+
   function toggle() {
     active = !active;
   }

--- a/src/components/explore/QuantileExplorerView.svelte
+++ b/src/components/explore/QuantileExplorerView.svelte
@@ -35,7 +35,7 @@
   let currentKey = probeKeys[0];
   let currentAggregation = aggregationTypes.includes('summed_histogram')
     ? 'summed_histogram'
-    : aggregationTypes[0];
+    : 'avg';
 
   let aggregationInfo;
 


### PR DESCRIPTION
The default option for scalar aggregation is now "average". I also sort the aggregation options in the dropdown menu for a more cohesive look.

<img width="1001" alt="CleanShot 2021-04-27 at 16 35 32@2x" src="https://user-images.githubusercontent.com/28797553/116325263-9bfd9980-a776-11eb-8320-7434dc276989.png">

Fixes #1183.
