### PR TITLE
Show full words in summary table

### DIFF
--- a/src/components/explore/ComparisonSummary.svelte
+++ b/src/components/explore/ComparisonSummary.svelte
@@ -120,9 +120,7 @@
   .value-label {
     min-width: calc(var(--space-base) * 7);
     max-width: calc(var(--space-base) * 10);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-wrap: break-word;
   }
 
   .value-change {


### PR DESCRIPTION
Because we use ellipses for overflow content, it's hard to read what is in the column, as shown in #1135. This is fixed by removing overflow ellipses and and increasing the width of the column for more real estate.

**Before**

![image](https://user-images.githubusercontent.com/28797553/117035405-208d7200-acb9-11eb-9370-450f0881cef9.png)

**After**

<img width="1289" alt="Screen Shot 2021-05-04 at 9 07 03 AM" src="https://user-images.githubusercontent.com/28797553/117035376-166b7380-acb9-11eb-87bc-60d9c9eb7e85.png">
