### PR TITLE
Add more information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Glean Aggregation Metrics (GLAM)
 
+GLAM is Mozilla's interactive dashboard for examining the distribution of
+telemetry values over time and across different user populations. You can check
+out GLAM at [glam.telemetry.mozilla.org](glam.telemetry.mozilla.org).
+
 This repository contains:
 
 - The GLAM server which provides the API
 - The GLAM front-end code
 - The design system for building new front-end components
+
+For more information about GLAM, visit
+[Introduction to GLAM](https://docs.telemetry.mozilla.org/cookbooks/glam.html).
+If you're looking to contribute, see
+[the development docs](https://github.com/mozilla/glam/tree/main/docs) on how to
+get started.


### PR DESCRIPTION
Now that we've landed documentation for GLAM ([intro](https://docs.telemetry.mozilla.org/cookbooks/glam.html) and [dataset](https://docs.telemetry.mozilla.org/datasets/glam.html)) on DTMO, I think it would be helpful to also reference it in our README. 