### PR TITLE
Link to DTMO docs

### DIFF
--- a/src/components/regions/Footer.svelte
+++ b/src/components/regions/Footer.svelte
@@ -13,11 +13,10 @@
   }
   .project-links {
     list-style: none;
-    display: grid;
+    display: flex;
     font-size: var(--text-015);
     font-weight: 400;
-    grid-gap: var(--space-2x);
-    grid-template-columns: auto auto auto;
+    gap: var(--space-2x);
     padding: 0 var(--space-4x);
     margin: 0;
   }
@@ -38,6 +37,9 @@
 <div class="glam-footer">
   <a class="mozilla-logo" href="https://www.mozilla.org/"><MozillaLogo /></a>
   <ul class="project-links">
+    <li>
+      <a href="https://docs.telemetry.mozilla.org/cookbooks/glam.html">Docs</a>
+    </li>
     <li>
       <a href="https://www.mozilla.org/privacy/websites/#cookies">Cookies</a>
     </li>


### PR DESCRIPTION
Add the link to DTMO docs in footer.

<img width="360" alt="Screen Shot 2021-05-06 at 10 13 05 AM" src="https://user-images.githubusercontent.com/28797553/117338647-a9d8ac00-ae53-11eb-94c6-0fa674b17108.png">
