### PR TITLE
Fix BodyControl component not showing (fixes #1364 and closes #1365)

### DIFF
--- a/src/components/controls/KeySelectionControl.svelte
+++ b/src/components/controls/KeySelectionControl.svelte
@@ -10,6 +10,7 @@
     label: opt,
     value: opt,
     labelColor: colorMap(opt),
+    enabled: true,
   }));
 </script>
 

--- a/src/components/controls/PercentileSelectionControl.svelte
+++ b/src/components/controls/PercentileSelectionControl.svelte
@@ -12,11 +12,35 @@
 
 <BodyControl
   options={[
-    { label: '5%', value: 5, labelColor: cmp(5), tooltip: t(5) },
-    { label: '25%', value: 25, labelColor: cmp(25), tooltip: t(25) },
-    { label: '50%', value: 50, labelColor: cmp(50), tooltip: t(50) },
-    { label: '75%', value: 75, labelColor: cmp(75), tooltip: t(75) },
-    { label: '95%', value: 95, labelColor: cmp(95), tooltip: t(95) },
+    { label: '5%', value: 5, labelColor: cmp(5), tooltip: t(5), enabled: true },
+    {
+      label: '25%',
+      value: 25,
+      labelColor: cmp(25),
+      tooltip: t(25),
+      enabled: true,
+    },
+    {
+      label: '50%',
+      value: 50,
+      labelColor: cmp(50),
+      tooltip: t(50),
+      enabled: true,
+    },
+    {
+      label: '75%',
+      value: 75,
+      labelColor: cmp(75),
+      tooltip: t(75),
+      enabled: true,
+    },
+    {
+      label: '95%',
+      value: 95,
+      labelColor: cmp(95),
+      tooltip: t(95),
+      enabled: true,
+    },
   ]}
   reverse={true}
   bind:selected={percentiles}

--- a/src/components/controls/ProbeViewControl.svelte
+++ b/src/components/controls/ProbeViewControl.svelte
@@ -12,12 +12,14 @@
       label: 'Explore',
       component: LineChart,
       tooltip: "explore this probe's aggregated values over time",
+      enabled: true,
     },
     {
       value: 'table',
       label: 'Table',
       component: Table,
       tooltip: "view this probe's aggregated data in tabular form",
+      enabled: true,
     },
   ];
 </script>

--- a/src/components/controls/ProportionMetricTypeControl.svelte
+++ b/src/components/controls/ProportionMetricTypeControl.svelte
@@ -10,11 +10,13 @@
       label: 'proportion',
       value: 'proportions',
       tooltip: 'shows proportions of clients for each category',
+      enabled: true,
     },
     {
       label: 'total clients',
       value: 'counts',
       tooltip: 'shows the volume of clients for each category',
+      enabled: true,
     },
   ]}
   selected={metricType}


### PR DESCRIPTION
In #1243 we [added the `enabled` property to `options`](https://github.com/mozilla/glam/pull/1243/files#diff-6484fee8af831fc6220645e6aee7e6443b02644c8d1a5009bf99fdcf124ed296) in `TimeHorizonControl`, but we didn't add it to the other `options` objects. This causes `BodyControl` -- the toggle component -- to dissapear because it relies on `options.enabled` to be true

https://github.com/mozilla/glam/blob/7d3c016e1186a66148a4ae1f18b2ce3144959ab1/src/components/controls/BodyControl.svelte#L50

Adding `options.enabled` back fixes #1364 and #1365.