### PR TITLE
Vertically scale scalar and keyed-scalar probes

### DIFF
--- a/src/components/explore/AggregationsOverTimeGraph.svelte
+++ b/src/components/explore/AggregationsOverTimeGraph.svelte
@@ -147,10 +147,14 @@
 
   const linearMetrics = [
     'histogram-linear',
+    'keyed-scalar',
+    'scalar',
     'quantity',
     'counter',
     'labeled_counter',
   ];
+
+  const desktopLinearMetrics = ['histogram-linear', 'keyed-scalar', 'scalar'];
 
   const getYTicks = (ranges) => {
     // exponential and linear graphs
@@ -208,7 +212,7 @@
     // get proportion and count data of categorical graphs
     if (
       buckets.length &&
-      data[0].metric_type !== 'histogram-linear' &&
+      !desktopLinearMetrics.includes(data[0].metric_type) &&
       yScaleType !== 'scalePoint'
     ) {
       // do not change yDomain when all categories are selected
@@ -236,7 +240,7 @@
         ? [yDomainValues[0], yDomainValues[yDomainValues.length - 1]]
         : [0, 1];
     if (
-      data[0].metric_type !== 'histogram-linear' &&
+      !desktopLinearMetrics.includes(data[0].metric_type) &&
       yScaleType !== 'scalePoint' &&
       buckets.length
     ) {


### PR DESCRIPTION
Add `scalar` and `keyed-scalar` to the list of linear metrics that we vertically scale. 

WIth this change we can vertically scale scalar probes, for example: 

https://glam.telemetry.mozilla.org/firefox/probe/timestamps_about_home_topsites_first_paint/explore?os=Windows&process=parent&ref=20210623214552&timeHorizon=QUARTER

![2021-07-15 13 55 43](https://user-images.githubusercontent.com/28797553/125856391-c2f06d06-9603-4a1e-a286-a612d28bc159.gif)
