### PR TITLE
Properly reset default state on homepage

### DIFF
--- a/src/routing/pages/Home.svelte
+++ b/src/routing/pages/Home.svelte
@@ -23,6 +23,7 @@
     store.setField('searchProduct', 'firefox');
   }
 
+  store.reset(true);
   $: selectedProcess = $store.productDimensions.process;
 </script>
 

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -71,8 +71,12 @@ function getDefaultState(
 
 export const store = createStore(getDefaultState({ basedOnQueryParams: true }));
 
-store.reset = () => {
+store.reset = (home = false) => {
   store.reinitialize();
+  if (home) {
+    // if user clicks on home page, reset state to not include query params
+    store.setState(getDefaultState());
+  }
 };
 
 export function getActiveProductConfig() {

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -72,10 +72,11 @@ function getDefaultState(
 export const store = createStore(getDefaultState({ basedOnQueryParams: true }));
 
 store.reset = (home = false) => {
-  store.reinitialize();
   if (home) {
     // if user clicks on home page, reset state to not include query params
     store.setState(getDefaultState());
+  } else {
+    store.reinitialize();
   }
 };
 

--- a/src/utils/create-store.js
+++ b/src/utils/create-store.js
@@ -77,6 +77,10 @@ export function createStore(initialStore) {
     INTERNAL_STORE.set({ ...initialStore, ...stateToKeep });
   }
 
+  function setState(state) {
+    INTERNAL_STORE.set(state);
+  }
+
   return {
     dispatch,
     connect,
@@ -85,5 +89,6 @@ export function createStore(initialStore) {
     setField,
     setDimension,
     reinitialize,
+    setState,
   };
 }


### PR DESCRIPTION
Since the default state is initialized with information from URL query params, we need to properly reset store when user clicks on home page so that state of one probe doesn't get transferred to another.
