### PR TITLE
Fix boolean metric data not displaying

### DIFF
--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -66,7 +66,7 @@
   }
 
   function filterResponseData(d, agg, key) {
-    // filter out true/false aggregate results in boolean metrics. See: https://github.com/mozilla/glam/pull/1525#issue-714577595
+    // filter out true/false aggregate results in boolean metrics. See: https://github.com/mozilla/glam/pull/1525#discussion_r694135079
     if (d[0].metric_type === 'boolean')
       return d.filter((di) => di.client_agg_type === '');
     // filter by key selected for other probes

--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -66,6 +66,10 @@
   }
 
   function filterResponseData(d, agg, key) {
+    // filter out true/false aggregate results in boolean metrics. See: https://github.com/mozilla/glam/pull/1525#issue-714577595
+    if (d[0].metric_type === 'boolean')
+      return d.filter((di) => di.client_agg_type === '');
+    // filter by key selected for other probes
     return d.filter(
       (di) => di.client_agg_type === agg && di.metric_key === key
     );


### PR DESCRIPTION
This should fix #1524. I think the cause for this problem is the way we transform API data on the front end. 

For example, I noticed something odd when I looked at the direct [JSON data](https://gist.github.com/Iinh/6386f414856fe8f0b7d278b07924fd05) that populates [android_autofill_supported](https://glam.telemetry.mozilla.org/fenix/probe/android_autofill_supported/explore?). Besides some dimension data, we only have `percentiles` data available, which doesn’t look correct for boolean metrics. I expected to see data for `true/false` keys, as in Glean a boolean metric value is either true or false. However, as @rafrombrc pointed out in slack, since we aggregate by client Id, the values that we display for boolean in GLAM are `always, never, sometimes`. But we don’t have this data either.

I then queried our cloud database to make sure that we do have these aggregate data, which we do (see the histogram column in [this query output](https://gist.github.com/Iinh/894f20f0536c70373ed225b526800188)). So at some point the boolean data we got from the database was transformed incorrectly. 

I believe [this function](https://github.com/mozilla/glam/blob/94b6fb370d1dd83cf44e8e209482af6edf0239b3/src/components/explore/ProportionExplorerView.svelte#L68-L72) is where we filtered data incorrectly. I was able to confirm that before we apply this filter function, the data we get from our API does include the correct aggregates. See: https://gist.github.com/Iinh/02327f2c69688a1d23c3b6f86b382956

However, since the initial data includes percentiles for `true`, `false`, but we we only need `always, never, sometimes` I added a filter condition specifically for boolean metrics to just get this data. 

This seems to have solved the issue.

Before:
<img width="1005" alt="CleanShot 2021-08-17 at 14 48 17@2x" src="https://user-images.githubusercontent.com/28797553/129805157-1e51d82c-27cd-4db3-b7e5-9fd357156342.png">

After:
<img width="1015" alt="CleanShot 2021-08-17 at 14 24 00@2x" src="https://user-images.githubusercontent.com/28797553/129803008-4324cb07-b8d2-4248-966d-097f7addfcbc.png">
