### PR TITLE
Persist aggregation type and key in URL

### DIFF
--- a/src/components/controls/AggregationTypeSelector.svelte
+++ b/src/components/controls/AggregationTypeSelector.svelte
@@ -3,6 +3,8 @@
   import { FloatingMenu, MenuList, MenuListItem } from '@graph-paper/menu';
   import { tooltip as tooltipAction } from '@graph-paper/core/actions';
 
+  import { store } from '../../state/store';
+
   export let aggregationTypes;
   export let currentAggregation;
   export let active;
@@ -18,6 +20,7 @@
 
   function setValue(event) {
     currentAggregation = event.detail.key;
+    store.setField('aggType', currentAggregation);
     active = false;
   }
 

--- a/src/components/controls/ProbeKeySelector.svelte
+++ b/src/components/controls/ProbeKeySelector.svelte
@@ -3,6 +3,8 @@
   import { FloatingMenu, MenuList, MenuListItem } from '@graph-paper/menu';
   import { tooltip as tooltipAction } from '@graph-paper/core/actions';
 
+  import { store } from '../../state/store';
+
   export let options;
   export let currentKey;
   export let active;
@@ -18,6 +20,7 @@
 
   function setValue(event) {
     currentKey = event.detail.key;
+    store.setField('aggKey', currentKey);
     active = false;
   }
 </script>

--- a/src/components/explore/QuantileExplorerView.svelte
+++ b/src/components/explore/QuantileExplorerView.svelte
@@ -17,6 +17,7 @@
     gatherProbeKeys,
     gatherAggregationTypes,
   } from '../../utils/probe-utils';
+  import { store } from '../../state/store';
 
   const dispatch = createEventDispatcher();
 
@@ -32,10 +33,10 @@
   let aggregationTypes = gatherAggregationTypes(data);
   let probeKeys = gatherProbeKeys(data);
 
-  let currentKey = probeKeys[0];
+  let currentKey = $store.aggKey || probeKeys[0];
   let currentAggregation = aggregationTypes.includes('summed_histogram')
     ? 'summed_histogram'
-    : 'avg';
+    : $store.aggType;
 
   let aggregationInfo;
 

--- a/src/config/fenix.js
+++ b/src/config/fenix.js
@@ -80,6 +80,8 @@ export default {
       activeBuckets: storeValue.activeBuckets,
       visiblePercentiles: storeValue.visiblePercentiles,
       ref: storeValue.ref,
+      aggKey: storeValue.aggKey,
+      aggType: storeValue.aggType,
     };
     return stripDefaultValues(params, {
       ...sharedDefaults,

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -36,7 +36,8 @@ function getDefaultState(
   state.timeHorizon = getFromQueryString('timeHorizon') || 'MONTH';
   state.route = {};
   state.searchProduct = state.product || 'firefox';
-
+  state.aggKey = getFromQueryString('aggKey') || '';
+  state.aggType = getFromQueryString('aggType') || 'avg';
   state.probe = {
     name: '',
     loaded: false,


### PR DESCRIPTION
Fixes #1182. Selected aggregation types and keys are now persisted in the URL. 