### PR TITLE
Filter boolean data before passing down to component

### DIFF
--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -66,10 +66,6 @@
   }
 
   function filterResponseData(d, agg, key) {
-    // filter out true/false aggregate results in boolean metrics. See: https://github.com/mozilla/glam/pull/1525#discussion_r694135079
-    if (d[0].metric_type === 'boolean')
-      return d.filter((di) => di.client_agg_type === '');
-    // filter by key selected for other probes
     return d.filter(
       (di) => di.client_agg_type === agg && di.metric_key === key
     );

--- a/src/config/fenix.js
+++ b/src/config/fenix.js
@@ -131,21 +131,16 @@ export default {
     // the frontend. It will always run, even against cached data, as a way of
     // resetting the necessary state.
     const viewType = this.probeView[data[0].metric_type];
-
-    const isCategoricalTypeProbe = viewType === 'categorical';
-
     let etc = {};
 
     // filter out true/false aggregate results in boolean metrics. See: https://github.com/mozilla/glam/pull/1525#discussion_r694135079
     if (data[0].metric_type === 'boolean') {
+      // eslint-disable-next-line no-param-reassign
       data = data.filter((di) => di.client_agg_type === '');
     }
 
-    if (isCategoricalTypeProbe) {
+    if (viewType === 'categorical') {
       etc = extractBucketMetadata(data);
-    }
-
-    if (isCategoricalTypeProbe) {
       appStore.setField('activeBuckets', etc.initialBuckets);
     }
 

--- a/src/config/fenix.js
+++ b/src/config/fenix.js
@@ -135,6 +135,12 @@ export default {
     const isCategoricalTypeProbe = viewType === 'categorical';
 
     let etc = {};
+
+    // filter out true/false aggregate results in boolean metrics. See: https://github.com/mozilla/glam/pull/1525#discussion_r694135079
+    if (data[0].metric_type === 'boolean') {
+      data = data.filter((di) => di.client_agg_type === '');
+    }
+
     if (isCategoricalTypeProbe) {
       etc = extractBucketMetadata(data);
     }


### PR DESCRIPTION
After merging #1525 to dev yesterday I noticed that it didn't completely fix the problem for _all_ boolean metrics (for example [this](https://dev.glam.nonprod.dataops.mozgcp.net/fenix/probe/metrics_has_open_tabs/explore?activeBuckets=%5B%22always%22%2C%22never%22%2C%22sometimes%22%5D&aggType=avg) works but [this](https://dev.glam.nonprod.dataops.mozgcp.net/fenix/probe/metrics_has_desktop_bookmarks/explore?aggType=avg) doesn't). After digging more I realize that it's best to filter the boolean data before we pass it down to our components, i.e. in our fenix store, so that the data we get is consistent across all metrics. 

With this change I was able to see locally that graphs for boolean metrics are working again.