### PR TITLE
Show absolute difference when comparing percentage data points (fixes #1136)

### DIFF
--- a/src/components/explore/ComparisonSummary.svelte
+++ b/src/components/explore/ComparisonSummary.svelte
@@ -18,9 +18,10 @@
   export let showLeft = true;
   export let showRight = true;
   export let showDiff = true;
+  export let viewType;
 
   function percentChange(l, r) {
-    return (r - l) / l;
+    return viewType === 'proportion' ? r - l : (r - l) / l;
   }
 
   let displayValues = [];

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -322,7 +322,8 @@
     valueFormatter={summaryNumberFormatter}
     keyFormatter={comparisonKeyFormatter}
     showLeft={data.length > 1}
-    showDiff={data.length > 1} />
+    showDiff={data.length > 1}
+    viewType={$store.viewType} />
   <div style="display: {justOne ? 'none' : 'block'}">
     <ClientVolumeOverTimeGraph
       title={clientVolumeOverTimeTitle}

--- a/src/config/fenix.js
+++ b/src/config/fenix.js
@@ -112,6 +112,8 @@ export default {
         this.probeView[metricType] === 'categorical'
           ? 'proportion'
           : 'quantile';
+      appStore.setField('viewType', viewType);
+
       const data = transformAPIResponse[viewType](
         payload.response,
         aggregationLevel,

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -130,6 +130,9 @@ export default {
         this.probeView[metricType] === 'categorical'
           ? 'proportion'
           : 'quantile';
+
+      appStore.setField('viewType', viewType);
+
       let data = payload.response;
 
       // Attach labels to histogram if appropriate type.


### PR DESCRIPTION
Currently we're showing the relative change (in percentage) in the "DIFF." column in the summary table. This works in the case of exponential and linear probes with quantile data points. However, categorical probes have percentage data, therefore showing relative change isn't as helpful. This pain point is reflected in #1136. To improve this, for categorical probe types, we should switch to calculating actual differences for the DIFF. colum (Δ = ref. - hov.) instead of relative change (ref. - hov. / ref.)
