### PR TITLE
Add histogram distribution view to the table view (fixes #1560)

### DIFF
--- a/src/components/table/TableView.svelte
+++ b/src/components/table/TableView.svelte
@@ -79,7 +79,7 @@
       {currentPage} />
   </div>
 
-  {#if metricsWithPercentileData.includes(data[0].metric_type)}
+  {#if METRICS_WITH_PERCENTILE_DATA.has(data[0].metric_type)}
     <div style="display: flex; justify-content: flex-end; padding: 1em;">
       <ButtonGroup>
         <Button

--- a/src/components/table/TableView.svelte
+++ b/src/components/table/TableView.svelte
@@ -37,7 +37,7 @@
   $: if (data) currentPage = 0;
   $: totalPages = Math.ceil(data.length / pageSize);
 
-  const metricsWithPercentileData = [
+  const METRICS_WITH_PERCENTILE_DATA = new Set([
     'histogram-exponential',
     'histogram-linear',
     'keyed-scalar',
@@ -45,7 +45,7 @@
     'quantity',
     'counter',
     'labeled_counter',
-  ];
+  ]);
 
   let largestAudience;
   $: largestAudience = Math.max(...data.map((d) => d.audienceSize));

--- a/src/components/table/TableView.svelte
+++ b/src/components/table/TableView.svelte
@@ -149,6 +149,7 @@
             </Cell>
           {/each}
         {:else}
+          <!-- show percentile data -->
           {#each visibleBuckets as bucket}
             <Cell
               backgroundColor="var(--cool-gray-subtle)"


### PR DESCRIPTION
The goal of this PR is to surface distribution data in the table view for metrics that currently only show percentile data. The metric types are:

- desktop: exponential, linear, keyed-scalar, scalar
- fenix: quantity, counter, labeled_counter

Other metric types already have distribution data in table view. For example: [categorical](https://glam.telemetry.mozilla.org/firefox/probe/dom_script_loading_source/table?activeBuckets=%5B%22Inline%22%2C%22Source%22%2C%22AltData%22%2C%22SourceFallback%22%5D), [enumerated](https://glam.telemetry.mozilla.org/firefox/probe/pwmgr_prompt_remember_action/table?activeBuckets=%5B%220%22%2C%222%22%2C%221%22%2C%223%22%2C%224%22%5D&process=parent), [boolean](https://glam.telemetry.mozilla.org/fenix/probe/preferences_open_links_in_app_enabled/table?activeBuckets=%5B%22never%22%2C%22always%22%2C%22sometimes%22%5D&aggType=avg&ping_type=*), etc. 

Before:

<img width="1070" alt="CleanShot 2021-09-30 at 14 29 56@2x" src="https://user-images.githubusercontent.com/28797553/135511032-d3cd77d4-f56c-4a75-aa7c-5c1c3fc93f3e.png">

After:

![2021-09-30 14 42 57](https://user-images.githubusercontent.com/28797553/135512899-16a7bbcc-f1e5-4860-87c5-0658d8eaadbe.gif)


