### PR TITLE
Make it more visually clear that percentile toggles are buttons

### DIFF
--- a/src/components/controls/PercentileSelectionControl.svelte
+++ b/src/components/controls/PercentileSelectionControl.svelte
@@ -59,5 +59,5 @@
   reverse={true}
   bind:selected={percentiles}
   multi={true}
-  level="low"
+  level="medium"
   on:selection />


### PR DESCRIPTION
@ecsmyth pointed out recently that it doesn't look very clear that the percentiles can be toggled on/off because they do not look like buttons. He suggested that we should make the percentiles look more like the Time Horizon buttons (i.e. add borders) so we can better signal to users that these can be toggled.


Before:
![CleanShot 2021-10-12 at 14 54 09](https://user-images.githubusercontent.com/28797553/137012947-ae59a19f-f1e8-40c7-a24e-4e9465634a82.png)

After:
![CleanShot 2021-10-12 at 14 53 30](https://user-images.githubusercontent.com/28797553/137012837-9520083c-37a4-4195-9461-897eb9d97a45.png)
