### PR TITLE
Revert "Bump google-cloud-bigquery from 2.28.0 to 2.28.1 (#1627)"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ django-configurations==2.2
 djangorestframework==3.12.4
 dockerflow==2021.7.0
 drf-orjson-renderer==1.1.5
-google-cloud-bigquery==2.28.1
+google-cloud-bigquery==2.28.0
 google-cloud-storage==1.42.3
 gunicorn==20.1.0
 psycopg2-binary==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ google-auth==1.34.0
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
-google-cloud-bigquery==2.28.1
+google-cloud-bigquery==2.28.0
     # via -r requirements.in
 google-cloud-core==1.7.2
     # via


### PR DESCRIPTION
Revert back to google-cloud-bigquery 2.28.0 to fix this deployment error: https://app.circleci.com/pipelines/github/mozilla/glam/4063/workflows/be5d5be6-640a-459b-9c5f-b23f24489b69/jobs/7935.

This reverts commit 520535d6710af38f6e22beb74d615257d0e500a4.