### PR TITLE
Make it clear when a button in table view is selected

### DIFF
--- a/src/components/table/TableView.svelte
+++ b/src/components/table/TableView.svelte
@@ -87,7 +87,7 @@
           on:click={() => {
             showHistogramData = false;
           }}
-          level="medium"
+          level={showHistogramData ? 'medium' : 'small'}
           compact>
           Percentile Data
         </Button>
@@ -96,7 +96,7 @@
           on:click={() => {
             showHistogramData = true;
           }}
-          level="medium"
+          level={showHistogramData ? 'small' : 'medium'}
           compact>
           Histogram Data
         </Button>

--- a/src/components/table/TableView.svelte
+++ b/src/components/table/TableView.svelte
@@ -87,19 +87,19 @@
           on:click={() => {
             showHistogramData = false;
           }}
-          level={showHistogramData ? 'medium' : 'small'}
-          compact>
-          Percentile Data
-        </Button>
+          label="Percentile Data"
+          toggled={!showHistogramData}
+          level="medium"
+          compact />
         <Button
           tooltip="Show Histogram Data"
           on:click={() => {
             showHistogramData = true;
           }}
-          level={showHistogramData ? 'small' : 'medium'}
-          compact>
-          Histogram Data
-        </Button>
+          label="Histogram Data"
+          level="medium"
+          toggled={showHistogramData}
+          compact />
       </ButtonGroup>
     </div>
   {/if}


### PR DESCRIPTION
Address another feedback of @ecsmyth.

**Before**

<img width="322" alt="CleanShot 2021-10-13 at 09 57 19@2x" src="https://user-images.githubusercontent.com/28797553/137147348-52d61c40-d717-43bf-a8e2-4c330e6f9a02.png">

**After**

<img width="375" alt="CleanShot 2021-10-13 at 09 56 06@2x" src="https://user-images.githubusercontent.com/28797553/137147177-ed217433-ff61-4a7a-a830-8822bb2131a7.png">

Note: I'll also ask for feedback from @ecsmyth in the internal channel later (can't add him as a reviewer in this PR for some reason).
