### PR TITLE
Revert "Bump python from 3.9-slim to 3.10.0-slim (#1618)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # BACKEND IMAGE
-FROM python:3.10.0-slim AS backend
+FROM python:3.9-slim AS backend
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -43,7 +43,7 @@ RUN npm run build
 
 
 # FINAL IMAGE
-FROM python:3.10.0-slim AS final
+FROM python:3.9-slim AS final
 
 EXPOSE 8000
 


### PR DESCRIPTION
Initially from reading the error log I thought that the cause for publish-latest test failing was due to google-cloud-bigquery upgrade:

<img width="1016" alt="CleanShot 2021-10-13 at 10 17 53@2x" src="https://user-images.githubusercontent.com/28797553/137151362-946d2d7d-e2fd-44fb-aa2d-032bbee43745.png">

but reverting that commit in #1638 didn't fix it. Through tracing the steps it seems that test started failing after upgrading Python in commit 7655d08d83c2a331b41ee694e9739191f0813393, so we should revert this commit instead.

I looked at @wlach's prior art https://github.com/mozilla/lookml-generator/pull/108/ to see if there's a way to prevent this going forward but it looks like glam Docker versioning is already tight? 