### PR TITLE
Link to Fenix pings in Glean Dictionary

### DIFF
--- a/src/routing/pages/probe/FenixDetails.svelte
+++ b/src/routing/pages/probe/FenixDetails.svelte
@@ -218,7 +218,9 @@
         <dt>Send in Pings</dt>
         <dd>
           {#each $store.probe.send_in_pings as ping}
-            <div>{ping}</div>
+            <a
+              href="https://dictionary.telemetry.mozilla.org/apps/fenix/pings/{ping}"
+              >{ping}</a>
           {/each}
         </dd>
       </dl>


### PR DESCRIPTION
Link to their ping page in the Glean Dictionary for send in pings.

![CleanShot 2021-10-15 at 13 14 19@2x](https://user-images.githubusercontent.com/28797553/137527063-5e06cba5-09c6-424f-93d9-df99fc3d334d.png)
