### PR TITLE
Change how we handle bug/review links

### DIFF
--- a/src/routing/pages/probe/FenixDetails.svelte
+++ b/src/routing/pages/probe/FenixDetails.svelte
@@ -4,7 +4,7 @@
   import Brackets from '../../../components/icons/Brackets.svelte';
   import { store, dataset } from '../../../state/store';
   import { downloadString } from '../../../utils/download';
-  import { extractBugId } from '../../../utils/urls';
+  import { getBugURL, getBugLinkTitle } from '../../../utils/urls';
   import ExternalLink from '../../../components/icons/ExternalLink.svelte';
   import StatusLabel from '../../../components/StatusLabel.svelte';
   import SqlModal from '../../../components/SqlModal.svelte';
@@ -229,7 +229,7 @@
           <dt>bugs</dt>
           <dd>
             {#each $store.probe.bugs as bug}
-              <div><a href={bug}>{extractBugId(bug)}</a></div>
+              <div><a href={getBugURL(bug)}>{getBugLinkTitle(bug)}</a></div>
             {/each}
           </dd>
         </dl>
@@ -241,7 +241,7 @@
           <dt>data reviews</dt>
           <dd>
             {#each $store.probe.data_reviews as bug}
-              <div><a href={bug}>{extractBugId(bug)}</a></div>
+              <div><a href={getBugURL(bug)}>{getBugLinkTitle(bug)}</a></div>
             {/each}
           </dd>
         </dl>

--- a/tests/utils-urls.test.js
+++ b/tests/utils-urls.test.js
@@ -1,27 +1,35 @@
-import { extractBugId } from '../src/utils/urls';
+import { getBugLinkTitle } from '../src/utils/urls';
 
-describe('extractBugId', () => {
-  it('correctly finds bugzilla ids', () => {
-    expect(
-      extractBugId('https://bugzilla.mozilla.org/show_bug.cgi?id=123456')
-    ).toEqual('bugzil.la/123456');
-    expect(
-      extractBugId('https://bugzilla.mozilla.org/show_bug.cgi?id=123456#c7')
-    ).toEqual('bugzil.la/123456');
-  });
-  it('correctly finds github ids', () => {
-    expect(extractBugId('https://github.com/org/project/issues/12345')).toEqual(
-      'org/project#12345'
+describe('Titles for bugzilla URLs', () => {
+  it('works as expected', () => {
+    expect(getBugLinkTitle('https://bugzilla.mozilla.org/1234')).toEqual(
+      'bugzil.la/1234'
     );
+    expect(getBugLinkTitle('https://bugzilla.mozilla.org/1234#c23')).toEqual(
+      'bugzil.la/1234#c23'
+    );
+    expect(getBugLinkTitle('https://bugzil.la/1234')).toEqual('bugzil.la/1234');
+    expect(getBugLinkTitle('https://bugzil.la/show_bug.cgi?id=1234')).toEqual(
+      'bugzil.la/1234'
+    );
+  });
+});
+
+describe('Titles for github URLs', () => {
+  it('works as expected', () => {
     expect(
-      extractBugId(
-        'https://github.com/org/project/pull/12345#issuecomment-123456789'
+      getBugLinkTitle('https://github.com/mozilla-mobile/fenix/issues/1234')
+    ).toEqual('mozilla-mobile/fenix#1234');
+    expect(
+      getBugLinkTitle(
+        'https://github.com/mozilla-mobile/fenix/issues/1234#issuecomment-5678'
       )
-    ).toEqual('org/project#12345');
+    ).toEqual('mozilla-mobile/fenix#1234-comment');
   });
-  it('correctly defaults to returning the url', () => {
-    expect(extractBugId('https://github.com/org/project')).toEqual(
-      'https://github.com/org/project'
-    );
+});
+
+describe('Titles for other issue tracker URLs', () => {
+  it('correctly defaults to returning the url without https://', () => {
+    expect(getBugLinkTitle('https://jira.com/1234')).toEqual('jira.com/1234');
   });
 });


### PR DESCRIPTION
In the past, I believe that we passed in number as Bugzilla references for Glean metadata. This has caused some issues in GLAM, such as failure to load metadata, because GLAM currently assumes that every link passed in is a string.


For example if we look at [metrics.syncing_system](https://glam.telemetry.mozilla.org/fenix/probe/metrics_syncing_items/explore?aggType=avg), the page is blank even though we do have metadata for this metric.

<img width="1090" alt="CleanShot 2021-10-15 at 15 40 21@2x" src="https://user-images.githubusercontent.com/28797553/137544598-3bbfa6e3-ef06-4147-bf45-fac73e01d117.png">

Glean Dictionary handles bug/review links very well, so I copied over the 2 methods we use in Glean Dictionary to fix it.

After:

<img width="1035" alt="CleanShot 2021-10-15 at 15 42 29@2x" src="https://user-images.githubusercontent.com/28797553/137545099-0697be8b-340b-40ea-a751-54caa4dfff3b.png">


