### PR TITLE
Open STMO link in a new tab

### DIFF
--- a/src/components/ChartContextMenu.svelte
+++ b/src/components/ChartContextMenu.svelte
@@ -191,12 +191,13 @@
       {#if $store.product === 'firefox' && $store.probe.type === 'histogram'}
         <div class="option">
           <div class="option-icon">
-            <a href={STMOComparisonLink}>
+            <a href={STMOComparisonLink} target="_blank">
               <Graphs />
             </a>
           </div>
           <div class="option-link">
-            <a href={STMOComparisonLink}>View Comparison in STMO</a>
+            <a href={STMOComparisonLink} target="_blank"
+              >View Comparison in STMO</a>
           </div>
         </div>
       {/if}


### PR DESCRIPTION
We should let users open the STMO link in a new tab by default to keep external link behavior consistent across our data apps.