### PR TITLE
Link to STMO comparison dashboard instead of query

### DIFF
--- a/src/components/ChartContextMenu.svelte
+++ b/src/components/ChartContextMenu.svelte
@@ -75,14 +75,12 @@
       'p_Build 2': hovered,
       'p_Start Date': dateFormatter(getDateFromPoint(clicked)),
       'p_Start Date 2': dateFormatter(getDateFromPoint(hovered)),
+      // do not add OS filter to the query if 'All OSes' is selected
+      'p_OS Filter':
+        $store.productDimensions.os === '*'
+          ? ' '
+          : `AND normalized_os="${$store.productDimensions.os}"`,
     });
-    // do not add OS filter to the query if 'All OSes' is selected
-    queryParams.append(
-      'p_OS Filter',
-      $store.productDimensions.os === '*'
-        ? ' '
-        : `AND normalized_os="${$store.productDimensions.os}"`
-    );
     return REDASH_PROBE_COMPARISON_URL + queryParams.toString();
   };
 

--- a/src/components/ChartContextMenu.svelte
+++ b/src/components/ChartContextMenu.svelte
@@ -65,18 +65,24 @@
       : 'main_1pct';
 
   const REDASH_PROBE_COMPARISON_URL =
-    'https://sql.telemetry.mozilla.org/queries/82247/source?';
+    'https://sql.telemetry.mozilla.org/dashboard/test_38?';
 
   const getComparisonViewinSTMO = (clicked, hovered) => {
     const queryParams = new URLSearchParams({
       p_Table: `telemetry.${table}`,
       p_Probe: getTelemetryPath(),
-      p_OS: $store.productDimensions.os,
       'p_Build 1': clicked,
       'p_Build 2': hovered,
       'p_Start Date': dateFormatter(getDateFromPoint(clicked)),
       'p_Start Date 2': dateFormatter(getDateFromPoint(hovered)),
     });
+    // do not add OS filter to the query if 'All OSes' is selected
+    queryParams.append(
+      'p_OS Filter',
+      $store.productDimensions.os === '*'
+        ? ' '
+        : `AND normalized_os="${$store.productDimensions.os}"`
+    );
     return REDASH_PROBE_COMPARISON_URL + queryParams.toString();
   };
 


### PR DESCRIPTION
This PR addresses Eric's feedback:

- Link to a dashboard that can display the data in a single view and could support explanatory text describing methodology/interpretation
- Make sure that we only add OS filter to the query if a specific OS is selected
