### PR TITLE
Adjust SVG container width to let users hover the most recent points

### DIFF
--- a/src/components/datagraphic/DataGraphic.svelte
+++ b/src/components/datagraphic/DataGraphic.svelte
@@ -402,7 +402,7 @@
   class="data-graphic-container"
   style="width: {$graphicWidth}px; height: {$graphicHeight}px;">
   <svg
-    style="width: {$graphicWidth + 90}px; height: {$graphicHeight}px;"
+    style="width: {$graphicWidth}px; height: {$graphicHeight}px;"
     bind:this={svg}
     shape-rendering="auto"
     viewbox="0 0 {$graphicWidth}


### PR DESCRIPTION
Fixes #1580. 

We can hover over the latest dates with this change.

![2021-10-27 10 52 55](https://user-images.githubusercontent.com/28797553/139090919-c2862da0-2566-46e6-8561-e030c01808bb.gif)

