### PR TITLE
Install Python with node Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,9 @@ jobs:
       - checkout
       - run:
           command: |
-            docker-compose pull
-            docker-compose build
+            cp .env-dist .env
+            make up -v ${PWD}:/app
+            make build -v ${PWD}:/app
 workflows:
   version: 2
   test-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,25 @@ jobs:
             - ./node_modules
       - run: npm run build
       - run: npm run test
-
+  test-environment:
+    docker:
+      - image: cimg/base:2021.10
+    working_directory: ~/mozilla/glam/
+    steps:
+      - checkout
+      - run:
+          command: |
+            docker-compose pull
+            docker-compose build
 workflows:
   version: 2
   test-and-deploy:
     jobs:
       - frontend-tests:
+          filters:
+            tags:
+              only: /.*/
+      - test-environment:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
       - checkout
       - run:
           command: |
+            cp .env-dist .env
             docker-compose pull
             docker-compose build
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ COPY glam /app/glam
 # FRONTEND BUILDER IMAGE
 FROM node:lts-slim AS frontend
 
+RUN apt-get update || : && apt-get install python -y
+
 WORKDIR /app
 
 COPY package*.json /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY glam /app/glam
 # FRONTEND BUILDER IMAGE
 FROM node:lts-slim AS frontend
 
-RUN apt-get update || : && apt-get install python -y
+RUN apt-get update || : && apt-get install python3 -y
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR attemps to fix `publish-latest` job failing. See the error log from the last merged commit: https://app.circleci.com/pipelines/github/mozilla/glam/4184/workflows/ca24fe0e-d036-4219-be26-df904b3e8961/jobs/8209/parallel-runs/0/steps/0-105

The issue is that Docker wasn't able to build node. Initially I thought this might be due to our outdated package-lock.json file, so I updated the lockfile in #1685, but this attempt didn't work.

Upon further investigation, it looks like the reason why Docker wasn't able to build node is that it wasn't able to install `gyp`:

```
npm ERR! code 1
npm ERR! path /app/node_modules/deasync
npm ERR! command failed
npm ERR! command sh -c node ./build.js
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@8.2.0
npm ERR! gyp info using node@16.13.0 | linux | x64
npm ERR! gyp ERR! find Python 
npm ERR! gyp ERR! find Python Python is not set from command line or npm configuration
npm ERR! gyp ERR! find Python Python is not set from environment variable PYTHON
npm ERR! gyp ERR! find Python checking if "python3" can be used
npm ERR! gyp ERR! find Python - "python3" is not in PATH or produced an error
npm ERR! gyp ERR! find Python checking if "python" can be used
npm ERR! gyp ERR! find Python - "python" is not in PATH or produced an error
```

node-gyp requires Python, but our current node image -- `node:lts-slim` -- [doesn't include Python](https://github.com/nodejs/docker-node/issues/12#issuecomment-84025397). I'm suspecting that CI is failing now when it ran fine in the past might be because one of the recent dependency updates started requiring gyp. Regardless, it looks like installing Python with the node image is the way to go from now on.