### PR TITLE
Use non-slim nodeJS v12 for Docker front-end builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY glam /app/glam
 
 
 # FRONTEND BUILDER IMAGE
-FROM node:lts-slim AS frontend
+FROM node:12 AS frontend
 
 RUN apt-get update || : && apt-get install python3 -y
 


### PR DESCRIPTION
Per @robhudson's comment, let's switch to using a non-slim node image. We should go with node v12 because that's the minimum version required for GLAM development: https://github.com/mozilla/glam/blob/main/docs/development.md#development