### PR TITLE
Minor improvements to probe search UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "d3-scale-chromatic": "3.0.0",
         "d3-shape": "3.0.1",
         "d3-time-format": "3.0.0",
-        "page": "1.11.6",
-        "throttle-debounce": "3.0.1"
+        "page": "1.11.6"
       },
       "devDependencies": {
         "@babel/core": "7.15.8",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "d3-scale-chromatic": "3.0.0",
     "d3-shape": "3.0.1",
     "d3-time-format": "3.0.0",
-    "page": "1.11.6",
-    "throttle-debounce": "3.0.1"
+    "page": "1.11.6"
   },
   "scripts": {
     "build": "rollup --config --environment NODE_ENV:production",

--- a/src/components/search/Search.svelte
+++ b/src/components/search/Search.svelte
@@ -1,7 +1,7 @@
 <script>
   import { tick } from 'svelte';
   import { fade } from 'svelte/transition';
-  import { throttle } from 'throttle-debounce';
+  import { debounce } from 'lodash';
   import { Search as SearchIcon } from '@graph-paper/icons';
 
   import LineSegSpinner from '../LineSegSpinner.svelte';
@@ -15,7 +15,7 @@
   let searchIsActive = false;
   let searchQuery = '';
 
-  const SEARCH_THROTTLE_TIME = 500; // how often to send the PSS fetch (in ms)
+  const SEARCH_DEBOUNCE_TIME = 100; // defer getting search results until user input has stopped for a short interval
 
   function turnOnSearch() {
     searchIsActive = true;
@@ -40,18 +40,14 @@
 
   let query = '';
 
-  const handleSearchInput = throttle(
-    SEARCH_THROTTLE_TIME,
-    (value) => {
-      query = value;
-      getSearchResults(query, false, $store.searchProduct).then((r) => {
-        results = r;
-        searchWaiting = false;
-      });
-      searchIsActive = true;
-    },
-    false
-  );
+  const handleSearchInput = debounce((value) => {
+    query = value;
+    getSearchResults(query, false, $store.searchProduct).then((r) => {
+      results = r;
+      searchWaiting = false;
+    });
+    searchIsActive = true;
+  }, SEARCH_DEBOUNCE_TIME);
 </script>
 
 <style>


### PR DESCRIPTION
* Use lodash (which we were using already) instead of debounce-throttle
* Use debounce instead of throttle (this prevents us from fetching
  repeatedly while the user is still typing)
* Take advantage of that and fetch results faster (this improves
  the user experience a bit)
