### PR TITLE
Fix memory distribution display for Fenix

### DIFF
--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -50,7 +50,7 @@
   if (data[0].metric_type === 'timing_distribution') {
     yTickFormatter = formatFromNanoseconds;
   } else if (data[0].metric_type === 'memory_distribution') {
-    yTickFormatter = formatMemory($store.probe.info.memory_unit);
+    yTickFormatter = formatMemory($store.probe.memory_unit);
   }
   export let summaryNumberFormatter = yTickFormatter;
   export let comparisonKeyFormatter = (v) => v;

--- a/src/config/fenix.js
+++ b/src/config/fenix.js
@@ -41,7 +41,7 @@ export default {
       ],
       defaultValue: 'metrics',
       isValidKey(key, probe) {
-        return key === '*' ? true : probe.info.send_in_pings.includes(key);
+        return key === '*' ? true : probe.send_in_pings.includes(key);
       },
     },
     aggregationLevel: {


### PR DESCRIPTION
We were assuming the format of the old probe info service for fenix,
which we're no longer using. Also fix another instance of us assuming
the old format (which is harmless, because we're not using it, but still).
