### PR TITLE
Use Glean Dictionary to search for probes/metrics (fixes #1678)

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,16 +10,6 @@ import { terser } from 'rollup-plugin-terser';
 
 const production = process.env.NODE_ENV === 'production';
 
-// We can provide this as another ENV var if desired (uses NODE_ENV currently).
-// FIXME: This will need other real paths. All set to dev currently.
-const SEARCH_DOMAINS = {
-  dev: 'https://dev.probe-search.nonprod.dataops.mozgcp.net',
-  stage: 'https://dev.probe-search.nonprod.dataops.mozgcp.net',
-  production: 'https://dev.probe-search.nonprod.dataops.mozgcp.net',
-};
-const SEARCH_DOMAIN =
-  SEARCH_DOMAINS[process.env.NODE_ENV] || SEARCH_DOMAINS.dev;
-
 export default {
   input: 'src/main.js',
   output: {
@@ -33,7 +23,6 @@ export default {
     replace({
       __BASE_DOMAIN__: production ? '' : 'http://localhost:8000',
       __GA_TRACKING_ID__: process.env.GA_TRACKING_ID,
-      __BASE_SEARCH_DOMAIN__: SEARCH_DOMAIN,
       __GLEAN_DICTIONARY_DOMAIN__: 'https://dictionary.telemetry.mozilla.org',
     }),
     string({ include: 'src/**/*.tpl' }),

--- a/src/components/SqlModal.svelte
+++ b/src/components/SqlModal.svelte
@@ -53,9 +53,7 @@
     const { process } = $store.productDimensions;
     let sqlTemplate = desktopTelemetrySql;
     if (
-      ['categorical', 'count', 'enumerated', 'flag'].includes(
-        $store.probe.info.calculated.latest_history.details.kind
-      )
+      ['categorical', 'count', 'enumerated', 'flag'].includes($store.probe.kind)
     ) {
       sqlTemplate = desktopHistogramProportionsSql;
     }

--- a/src/components/search/Search.svelte
+++ b/src/components/search/Search.svelte
@@ -42,7 +42,7 @@
 
   const handleSearchInput = debounce((value) => {
     query = value;
-    getSearchResults(query, false, $store.searchProduct).then((r) => {
+    getSearchResults($store.searchProduct, query).then((r) => {
       results = r;
       searchWaiting = false;
     });

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -249,16 +249,16 @@
               class:focused={focusedItem === i}
               on:click={() => {
                 page.show(
-                  `/${$store.searchProduct}/probe/${results[
-                    focusedItem
-                  ].name.toLowerCase()}/explore${$currentQuery}`
+                  `/${$store.searchProduct}/probe/${results[focusedItem].name
+                    .toLowerCase()
+                    .replaceAll('.', '_')}/explore${$currentQuery}`
                 );
               }}
               on:mouseover={() => {
                 focusedItem = i;
               }}>
               <div class="name body-text--short-01">{searchResult.name}</div>
-              {#if searchResult.info.calculated && searchResult.info.calculated.active === false}
+              {#if searchResult.active === false}
                 <div class="probe-type label label-text--01 label--inactive">
                   inactive
                 </div>

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -25,7 +25,7 @@ export default {
       ],
       defaultValue: 'nightly',
       isValidKey(key, probe) {
-        return key in probe.info.history;
+        return key in probe.versions;
       },
     },
     os: {
@@ -49,10 +49,7 @@ export default {
       ],
       defaultValue: 'content',
       isValidKey(key, probe) {
-        return isSelectedProcessValid(
-          probe.info.calculated.seen_in_processes,
-          key
-        );
+        return isSelectedProcessValid(probe.seen_in_processes, key);
       },
     },
     aggregationLevel: {
@@ -138,8 +135,7 @@ export default {
       // Attach labels to histogram if appropriate type.
       if (metricType === 'histogram-categorical') {
         const labels = {
-          ...appStore.getState().probe.info.calculated.latest_history.details
-            .labels,
+          ...appStore.getState().probe.labels,
         };
         data = produce(data, (draft) =>
           draft.map((point) => ({
@@ -187,22 +183,22 @@ export default {
     const { probe } = state; // accommodate only valid processes.
     if (
       !isSelectedProcessValid(
-        probe.info.calculated.seen_in_processes,
+        probe.seen_in_processes,
         state.productDimensions.process
       )
     ) {
-      const newProcess = probe.info.calculated.seen_in_processes[0];
+      const newProcess = probe.seen_in_processes[0];
       store.setDimension('process', newProcess);
     }
     // If channel isn't included in history, reset state to channel that is
-    if (!(state.productDimensions.channel in probe.info.history)) {
-      store.setDimension('channel', Object.keys(probe.info.history)[0]);
+    if (!(state.productDimensions.channel in probe.versions)) {
+      store.setDimension('channel', Object.keys(probe.versions)[0]);
     }
     // accommodate prerelease-only probes by resetting to nightly (if needed)
     if (
       state.productDimensions.channel === 'release' &&
-      'release' in probe.info.history &&
-      !probe.info.history.release[0].optout
+      'release' in probe.versions &&
+      !probe.optout
     ) {
       store.setDimension('channel', 'nightly');
     }

--- a/src/routing/pages/probe/FirefoxLegacyDetails.svelte
+++ b/src/routing/pages/probe/FirefoxLegacyDetails.svelte
@@ -24,7 +24,7 @@
     const data = await $dataset;
     downloadString(JSON.stringify(data), 'text', `${$store.probe.name}.json`);
   }
-  const isProbeActive = $store.probe.info.calculated.active;
+  const isProbeActive = $store.probe.active;
 </script>
 
 <style>
@@ -165,11 +165,11 @@
               class="probe-type-link"
               href={PROBE_TYPE_DOCS[$store.probe.type] ||
                 PROBE_TYPE_DOCS.default}>
-              {$store.probe.info.type}
+              {$store.probe.type}
             </a>
           </dt>
-          {#if $store.probe.info.calculated.latest_history.details.kind}
-            <dd>{$store.probe.info.calculated.latest_history.details.kind}</dd>
+          {#if $store.probe.kind}
+            <dd>{$store.probe.kind}</dd>
           {/if}
         </dl>
       {/if}
@@ -185,17 +185,15 @@
         </div>
       {/if}
     </div>
-    {#if $store.probe.info.history[$store.productDimensions.channel][0].versions}
+    {#if $store.probe.versions[$store.productDimensions.channel]}
       <dl
         class="drawer-section probe-details-overview-left
         probe-details-overview-left--subtle">
         <dt>{$store.productDimensions.channel}</dt>
         <dd class="probe-details-overview-left--padded">
-          {$store.probe.info.history[$store.productDimensions.channel][0]
-            .versions.first}
+          {$store.probe.versions[$store.productDimensions.channel].first}
           &ndash;
-          {$store.probe.info.history[$store.productDimensions.channel][0]
-            .versions.last}
+          {$store.probe.versions[$store.productDimensions.channel].last}
         </dd>
       </dl>
     {/if}
@@ -206,7 +204,7 @@
           <Markdown text={$store.probe.description} />
           <a
             class="more-info-link"
-            href={`https://probes.telemetry.mozilla.org/?view=detail&probeId=${$store.probe.info.type}/${$store.probe.info.name}`}
+            href={`https://probes.telemetry.mozilla.org/?view=detail&probeId=${$store.probe.id}`}
             target="_blank">
             more info
             <ExternalLink size="12" />
@@ -214,11 +212,11 @@
         </div>
       {/if}
     </div>
-    {#if $store.probe.info.calculated.latest_history.bug_numbers && $store.probe.info.calculated.latest_history.bug_numbers.length}
+    {#if $store.probe.bug_numbers && $store.probe.bug_numbers.length}
       <div class="drawer-section">
         <h2 class="detail__heading--01">associated bugs</h2>
         <div class="bug-list helper-text--01">
-          {#each $store.probe.info.calculated.latest_history.bug_numbers as bugID, i (bugID)}
+          {#each $store.probe.bug_numbers as bugID, i (bugID)}
             <a
               href="https://bugzilla.mozilla.org/show_bug.cgi?id={bugID}"
               target="_blank">

--- a/src/routing/wrappers/Probe.svelte
+++ b/src/routing/wrappers/Probe.svelte
@@ -13,7 +13,7 @@
       <Spinner size={48} color={'var(--cool-gray-400)'} />
     </div>
   {:then data}
-    {#if $store.product === 'firefox' && $store.probe.info.calculated.active === false}
+    {#if $store.product === 'firefox' && $store.probe.active === false}
       <div class="graphic-body__content">
         <ProbeTitle />
         <div in:fly={{ duration: 400, y: 10 }}>
@@ -21,7 +21,7 @@
             reason={'This probe is inactive and is no longer collecting data.'} />
         </div>
       </div>
-    {:else if $store.product === 'firefox' && !isSelectedProcessValid($store.probe.info.calculated.seen_in_processes, $store.productDimensions.process)}
+    {:else if $store.product === 'firefox' && !isSelectedProcessValid($store.probe.seen_in_processes, $store.productDimensions.process)}
       <div class="graphic-body__content">
         <ProbeTitle />
         <div in:fly={{ duration: 400, y: 10 }}>


### PR DESCRIPTION
We make use of a new netlify-function based approach in the Glean
Dictionary to replace calls to the probe search service
(https://github.com/mozilla/probe-search). This service is more
straightforward to extend and maintain -- both in terms of code and
operational complexity.
