### PR TITLE
Add "Select All" button for categorical histograms (fixes #1085)

### DIFF
--- a/src/components/explore/CategoricalMenu.svelte
+++ b/src/components/explore/CategoricalMenu.svelte
@@ -1,0 +1,152 @@
+<script>
+  import { OptionMenu, Option, OptionDivider } from '@graph-paper/optionmenu';
+
+  import { store } from '../../state/store';
+
+  import KeySelectionControl from '../controls/KeySelectionControl.svelte';
+  import ColorSwatch from '../controls/ColorSwatch.svelte';
+
+  import { Button } from '@graph-paper/button';
+
+  import { numericStringsSort } from '../../utils/sort';
+  import { numHighlightedBuckets } from '../../config/shared';
+
+  export let data;
+  export let activeBuckets;
+  export let bucketColorMap;
+  export let bucketOptions;
+
+  export let bucketSortOrder = (a, b) => (a < b ? 1 : -1);
+
+  function makeSelection() {
+    return function onSelection(event) {
+      store.setField('activeBuckets', event.detail.selection);
+    };
+  }
+
+  let showOptionMenu = false;
+  let coloredBuckets = [];
+  let everActiveBuckets = [];
+  let sortedImportantBuckets = [];
+  let sortedUnimportantBuckets = [];
+
+  if (bucketOptions.length > numHighlightedBuckets) {
+    showOptionMenu = true;
+    const lastDataset = data[data.length - 1];
+
+    coloredBuckets = Object.entries(lastDataset.counts)
+      .sort(([bucketAName, bucketAValue], [bucketBName, bucketBValue]) => {
+        const bucketValueDifference = bucketAValue - bucketBValue;
+        if (bucketValueDifference === 0) {
+          return bucketBName - bucketAName;
+        }
+        return bucketValueDifference;
+      })
+      .slice(-numHighlightedBuckets)
+      .map(([bucket]) => bucket);
+  }
+
+  let selectAllCategories = false;
+
+  $: if (showOptionMenu) {
+    everActiveBuckets = [...new Set([...activeBuckets, ...everActiveBuckets])];
+
+    // An important bucket is any bucket that:
+    //
+    //   (a) is colored
+    //   (b) is currently active
+    //   (c) has been active at some point in the past
+    //
+    // Rule (c) improves usability: if the user goes out of their way to enable a
+    // bucket that we consider to be unimportant, we should consider it to be
+    // important for the rest of the interaction. If we did not do this, the bucket
+    // would switch between the important group and the unimportant group as it's
+    // toggled, which would be annoying.
+    sortedImportantBuckets = [
+      ...new Set([...everActiveBuckets, ...coloredBuckets]),
+    ].sort(numericStringsSort);
+
+    // An unimportant bucket is any other bucket
+    sortedUnimportantBuckets = bucketOptions
+      .filter((bucket) => !sortedImportantBuckets.includes(bucket))
+      .sort(numericStringsSort);
+  }
+
+  function handleSelectAllCategories() {
+    store.setField('activeBuckets', bucketOptions);
+  }
+
+  $: selectAllCategories =
+    $store.activeBuckets.length == bucketOptions.length ? true : false;
+</script>
+
+<style>
+  .body-content {
+    margin-top: var(--space-2x);
+  }
+
+  .data-graphics {
+    margin-top: var(--space-4x);
+  }
+
+  .small-multiple {
+    margin-bottom: var(--space-8x);
+  }
+</style>
+
+<div class="body-control-set">
+  <label class="body-control-set--label">Categories</label>
+  {#if showOptionMenu}
+    <OptionMenu
+      multi
+      on:selection={(evt) => {
+        store.setField('activeBuckets', evt.detail.keys);
+      }}>
+      <div style="margin-left: 4.5em">
+        <Button
+          tooltip={'select all available categories'}
+          on:click={handleSelectAllCategories}
+          level={$store.activeBuckets.length == bucketOptions.length
+            ? 'small'
+            : 'low'}
+          compact>
+          Select All
+        </Button>
+      </div>
+      {#each sortedImportantBuckets as importantBucket, i (importantBucket)}
+        <Option
+          selected={activeBuckets.includes(importantBucket)}
+          key={importantBucket}
+          label={importantBucket}>
+          <div class="option-menu__list-item__slot-right" slot="right">
+            <ColorSwatch color={bucketColorMap(importantBucket)} />
+          </div>
+        </Option>
+      {/each}
+      {#if sortedImportantBuckets.length && sortedUnimportantBuckets.length}
+        <OptionDivider />
+      {/if}
+      {#each sortedUnimportantBuckets as unimportantBucket, i (unimportantBucket)}
+        <!--
+                By definition, an unimportantBucket is never a selected bucket,
+                hence selected={false}
+              -->
+        <Option
+          selected={false}
+          key={unimportantBucket}
+          label={unimportantBucket}>
+          <div slot="right">
+            <ColorSwatch color={bucketColorMap(unimportantBucket)} />
+          </div>
+        </Option>
+      {/each}
+    </OptionMenu>
+  {:else}
+    <KeySelectionControl
+      sortFunction={bucketSortOrder}
+      options={bucketOptions}
+      selections={activeBuckets}
+      on:selection={makeSelection()}
+      colorMap={bucketColorMap} />
+  {/if}
+</div>

--- a/src/components/explore/CategoricalMenu.svelte
+++ b/src/components/explore/CategoricalMenu.svelte
@@ -6,8 +6,6 @@
   import KeySelectionControl from '../controls/KeySelectionControl.svelte';
   import ColorSwatch from '../controls/ColorSwatch.svelte';
 
-  import { Button } from '@graph-paper/button';
-
   import { numericStringsSort } from '../../utils/sort';
   import { numHighlightedBuckets } from '../../config/shared';
 
@@ -77,7 +75,7 @@
   }
 
   $: selectAllCategories =
-    $store.activeBuckets.length == bucketOptions.length ? true : false;
+    $store.activeBuckets.length === bucketOptions.length && true;
 </script>
 
 <style>
@@ -92,6 +90,20 @@
   .small-multiple {
     margin-bottom: var(--space-8x);
   }
+
+  .select-all-button {
+    border: none;
+    width: 100%;
+    font-family: var(--main-text-font);
+    color: var(--digital-blue-600);
+    font-weight: 500;
+    font-size: 0.8em;
+    padding: 0.5em;
+  }
+
+  .inactive {
+    color: var(--cool-gray-350);
+  }
 </style>
 
 <div class="body-control-set">
@@ -102,17 +114,13 @@
       on:selection={(evt) => {
         store.setField('activeBuckets', evt.detail.keys);
       }}>
-      <div style="margin-left: 4.5em">
-        <Button
-          tooltip={'select all available categories'}
-          on:click={handleSelectAllCategories}
-          level={$store.activeBuckets.length == bucketOptions.length
-            ? 'small'
-            : 'low'}
-          compact>
-          Select All
-        </Button>
-      </div>
+      <button
+        class="select-all-button {$store.activeBuckets.length ===
+          bucketOptions.length && 'inactive'}"
+        disabled={$store.activeBuckets.length === bucketOptions.length}
+        on:click={handleSelectAllCategories}>
+        SELECT ALL
+      </button>
       {#each sortedImportantBuckets as importantBucket, i (importantBucket)}
         <Option
           selected={activeBuckets.includes(importantBucket)}

--- a/src/components/explore/CategoricalMenu.svelte
+++ b/src/components/explore/CategoricalMenu.svelte
@@ -74,8 +74,7 @@
     store.setField('activeBuckets', bucketOptions);
   }
 
-  $: selectAllCategories =
-    $store.activeBuckets.length === bucketOptions.length && true;
+  $: selectAllCategories = $store.activeBuckets.length === bucketOptions.length;
 </script>
 
 <style>

--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -12,8 +12,6 @@
 
   import CategoricalMenu from './CategoricalMenu.svelte';
 
-  import { Button } from '@graph-paper/button';
-
   import {
     formatPercent,
     formatCount,
@@ -123,12 +121,8 @@
       .sort(numericStringsSort);
   }
 
-  function handleSelectAllCategories() {
-    store.setField('activeBuckets', bucketOptions);
-  }
-
   $: selectAllCategories =
-    $store.activeBuckets.length == bucketOptions.length ? true : false;
+    $store.activeBuckets.length === bucketOptions.length && true;
 </script>
 
 <style>

--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -13,6 +13,9 @@
   import ProbeKeySelector from '../controls/ProbeKeySelector.svelte';
   import ColorSwatch from '../controls/ColorSwatch.svelte';
 
+  import { Checkbox, CheckboxBlank } from '@graph-paper/icons';
+  import { Button } from '@graph-paper/button';
+
   import {
     formatPercent,
     formatCount,
@@ -112,11 +115,9 @@
     // important for the rest of the interaction. If we did not do this, the bucket
     // would switch between the important group and the unimportant group as it's
     // toggled, which would be annoying.
-    sortedImportantBuckets = selectAll
-      ? bucketOptions
-      : [...new Set([...everActiveBuckets, ...coloredBuckets])].sort(
-          numericStringsSort
-        );
+    sortedImportantBuckets = [
+      ...new Set([...everActiveBuckets, ...coloredBuckets]),
+    ].sort(numericStringsSort);
 
     // An unimportant bucket is any other bucket
     sortedUnimportantBuckets = bucketOptions
@@ -124,14 +125,26 @@
       .sort(numericStringsSort);
   }
 
-  $: {
-    selectAll
-      ? store.setField(
-          'activeBuckets2',
-          bucketOptions.length ? bucketOptions : 'yes'
-        )
-      : store.setField('activeBuckets2', $store.activeBuckets);
+  function clicky() {
+    store.setField('activeBuckets', bucketOptions);
   }
+  $: {
+    if ($store.activeBuckets.length == bucketOptions.length) {
+      selectAll = true;
+    } else {
+      selectAll = false;
+    }
+  }
+
+  $: console.log(
+    'sortedImportant',
+    sortedImportantBuckets,
+    'activeBuckets',
+    $store.activeBuckets,
+    'ever',
+    everActiveBuckets,
+    activeBuckets
+  );
 </script>
 
 <style>
@@ -150,7 +163,6 @@
 
 <div class="body-content">
   <slot />
-  <input type="checkbox" bind:checked={selectAll} />
   <div class="body-control-row body-control-row--stretch">
     <div class="body-control-set">
       {#if aggregationLevel === 'build_id'}
@@ -162,9 +174,12 @@
     </div>
 
     <div class="body-control-set">
-      <label class="body-control-set--label">Categories</label>
+      <span>
+        <label class="body-control-set--label">Categories
+        </label>
+      <!-- <Button compact level="low" on:click={clicky}>Select All</Button> -->
+</span>
       {#if showOptionMenu}
-        <input type="checkbox" bind:checked={selectAll} />
         <OptionMenu
           multi
           on:selection={(evt) => {

--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -175,10 +175,8 @@
 
     <div class="body-control-set">
       <span>
-        <label class="body-control-set--label">Categories
-        </label>
-      <!-- <Button compact level="low" on:click={clicky}>Select All</Button> -->
-</span>
+        <label class="body-control-set--label">Categories </label>
+      </span>
       {#if showOptionMenu}
         <OptionMenu
           multi
@@ -188,6 +186,10 @@
               type: 'activeBuckets',
             });
           }}>
+          <input type="checkbox" bind={selectAll} />
+          <Button style="margin-left: 10px;" compact level="low" on:click={clicky}>Select All</Button>
+
+      <OptionDivider />
           {#each sortedImportantBuckets as importantBucket, i (importantBucket)}
             <Option
               selected={activeBuckets.includes(importantBucket)}

--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -2,18 +2,16 @@
   import { createEventDispatcher } from 'svelte';
   import { tweened } from 'svelte/motion';
   import { cubicOut as easing } from 'svelte/easing';
-  import { OptionMenu, Option, OptionDivider } from '@graph-paper/optionmenu';
 
   import { store } from '../../state/store';
 
   import ProbeExplorer from './ProbeExplorer.svelte';
-  import KeySelectionControl from '../controls/KeySelectionControl.svelte';
   import TimeHorizonControl from '../controls/TimeHorizonControl.svelte';
   import ProportionMetricTypeControl from '../controls/ProportionMetricTypeControl.svelte';
   import ProbeKeySelector from '../controls/ProbeKeySelector.svelte';
-  import ColorSwatch from '../controls/ColorSwatch.svelte';
 
-  import { Checkbox, CheckboxBlank } from '@graph-paper/icons';
+  import CategoricalMenu from './CategoricalMenu.svelte';
+
   import { Button } from '@graph-paper/button';
 
   import {
@@ -99,7 +97,7 @@
       .slice(-numHighlightedBuckets)
       .map(([bucket]) => bucket);
   }
-  let selectAll = false;
+  let selectAllCategories = false;
 
   $: if (showOptionMenu) {
     everActiveBuckets = [...new Set([...activeBuckets, ...everActiveBuckets])];
@@ -125,26 +123,12 @@
       .sort(numericStringsSort);
   }
 
-  function clicky() {
+  function handleSelectAllCategories() {
     store.setField('activeBuckets', bucketOptions);
   }
-  $: {
-    if ($store.activeBuckets.length == bucketOptions.length) {
-      selectAll = true;
-    } else {
-      selectAll = false;
-    }
-  }
 
-  $: console.log(
-    'sortedImportant',
-    sortedImportantBuckets,
-    'activeBuckets',
-    $store.activeBuckets,
-    'ever',
-    everActiveBuckets,
-    activeBuckets
-  );
+  $: selectAllCategories =
+    $store.activeBuckets.length == bucketOptions.length ? true : false;
 </script>
 
 <style>
@@ -173,60 +157,7 @@
       {/if}
     </div>
 
-    <div class="body-control-set">
-      <span>
-        <label class="body-control-set--label">Categories </label>
-      </span>
-      {#if showOptionMenu}
-        <OptionMenu
-          multi
-          on:selection={(evt) => {
-            dispatch('selection', {
-              selection: evt.detail.keys,
-              type: 'activeBuckets',
-            });
-          }}>
-          <input type="checkbox" bind={selectAll} />
-          <Button style="margin-left: 10px;" compact level="low" on:click={clicky}>Select All</Button>
-
-      <OptionDivider />
-          {#each sortedImportantBuckets as importantBucket, i (importantBucket)}
-            <Option
-              selected={activeBuckets.includes(importantBucket)}
-              key={importantBucket}
-              label={importantBucket}>
-              <div class="option-menu__list-item__slot-right" slot="right">
-                <ColorSwatch color={bucketColorMap(importantBucket)} />
-              </div>
-            </Option>
-          {/each}
-          {#if sortedImportantBuckets.length && sortedUnimportantBuckets.length}
-            <OptionDivider />
-          {/if}
-          {#each sortedUnimportantBuckets as unimportantBucket, i (unimportantBucket)}
-            <!--
-              By definition, an unimportantBucket is never a selected bucket,
-              hence selected={false}
-            -->
-            <Option
-              selected={false}
-              key={unimportantBucket}
-              label={unimportantBucket}>
-              <div slot="right">
-                <ColorSwatch color={bucketColorMap(unimportantBucket)} />
-              </div>
-            </Option>
-          {/each}
-        </OptionMenu>
-      {:else}
-        <KeySelectionControl
-          sortFunction={bucketSortOrder}
-          options={bucketOptions}
-          selections={activeBuckets}
-          on:selection={makeSelection('activeBuckets')}
-          colorMap={bucketColorMap} />
-      {/if}
-    </div>
+    <CategoricalMenu {data} {activeBuckets} {bucketColorMap} {bucketOptions} />
   </div>
 
   <div class="body-control-row  body-control-row--stretch">

--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -121,8 +121,7 @@
       .sort(numericStringsSort);
   }
 
-  $: selectAllCategories =
-    $store.activeBuckets.length === bucketOptions.length && true;
+  $: selectAllCategories = $store.activeBuckets.length === bucketOptions.length;
 </script>
 
 <style>

--- a/src/components/table/ProbeTableView.svelte
+++ b/src/components/table/ProbeTableView.svelte
@@ -18,6 +18,7 @@
   export let probeKeys = gatherProbeKeys(data);
   export let colorMap;
   export let visibleBuckets;
+  export let bucketOptions;
 
   let currentKey = probeKeys[0];
   let currentAggregation = aggregationTypes[0];
@@ -71,6 +72,7 @@
     data={selectedData}
     {aggregationLevel}
     colorMap={probeType === 'categorical' ? colorMap : percentileLineColorMap}
+    {bucketOptions}
     visibleBuckets={probeType === 'categorical' ? visibleBuckets : PERCENTILES}
     keyFormatter={probeType === 'categorical' ? (v) => v : (v) => `${v}%`}
     valueFormatter={probeType === 'categorical'

--- a/src/components/table/TableView.svelte
+++ b/src/components/table/TableView.svelte
@@ -6,8 +6,10 @@
   import Cell from './Cell.svelte';
 
   import ProportionSM from './ProportionSM.svelte';
+  import CategoricalMenu from '../../components/explore/CategoricalMenu.svelte';
 
   import Pagination from '../controls/Pagination.svelte';
+  import { store } from '../../state/store';
 
   import {
     formatCount,
@@ -29,6 +31,7 @@
   export let colorMap; // bucketColorMap
   export let pageSize = 10;
   export let bucketTypeLabel = 'Categories';
+  export let bucketOptions;
 
   let showHistogramData = false;
 
@@ -91,6 +94,16 @@
           toggled={showHistogramData}
           compact />
       </ButtonGroup>
+    </div>
+  {/if}
+
+  {#if $store.probe.kind === 'categorical'}
+    <div style="display: flex; justify-content: flex-end; padding: 1em;">
+      <CategoricalMenu
+        {data}
+        activeBuckets={$store.activeBuckets}
+        bucketColorMap={colorMap}
+        {bucketOptions} />
     </div>
   {/if}
 

--- a/src/components/table/TableView.svelte
+++ b/src/components/table/TableView.svelte
@@ -6,7 +6,7 @@
   import Cell from './Cell.svelte';
 
   import ProportionSM from './ProportionSM.svelte';
-  import CategoricalMenu from '../../components/explore/CategoricalMenu.svelte';
+  import CategoricalMenu from '../explore/CategoricalMenu.svelte';
 
   import Pagination from '../controls/Pagination.svelte';
   import { store } from '../../state/store';

--- a/src/routing/pages/probe/Table.svelte
+++ b/src/routing/pages/probe/Table.svelte
@@ -15,6 +15,7 @@
         <ProbeTableView
           data={data.data}
           {probeType}
+          bucketOptions={data.bucketOptions}
           colorMap={data.bucketColorMap}
           visibleBuckets={[...$store.activeBuckets]}
           aggregationLevel={$store.productDimensions.aggregationLevel}>


### PR DESCRIPTION
This PR makes 2 UI changes:

1) A "Select All" button to the category dropdown menu

- enabled:
<img width="334" alt="CleanShot 2022-02-09 at 03 29 23@2x" src="https://user-images.githubusercontent.com/28797553/153236220-da65cb18-226f-46e1-980b-10d2428cc16a.png">

- disabled:
<img width="327" alt="CleanShot 2022-02-09 at 03 29 41@2x" src="https://user-images.githubusercontent.com/28797553/153236182-593fcd9b-9257-4843-bb29-2545ce51de8a.png">

2) Include the dropdown selector on the Table view page
<img width="820" alt="CleanShot 2022-02-09 at 10 44 57@2x" src="https://user-images.githubusercontent.com/28797553/153236435-91da4efb-c0e9-4a68-8eb5-54cafbc791a1.png">

Some example probes to test out locally:
- https://glam.telemetry.mozilla.org/firefox/probe/avif_cicp_mc/explore?activeBuckets=%5B%22BT601%22%2C%22BT709%22%2C%22IDENTITY%22%2C%22UNSPECIFIED%22%2C%22RESERVED%22%2C%22FCC%22%2C%22BT470BG%22%2C%22SMPTE240%22%2C%22YCGCO%22%2C%22BT2020_NCL%22%5D
- https://glam.telemetry.mozilla.org/firefox/probe/external_protocol_handler_dialog_context_scheme/explore?activeBuckets=%5B%22magnet%22%2C%22OTHER%22%2C%22MICROSOFT_APP%22%2C%22mailto%22%2C%22TELEGRAM%22%2C%22tel%22%2C%22steam%22%2C%22whatsapp%22%2C%22ftp%22%2C%22vscode%22%5D&process=parent

Fixes #1085.