### PR TITLE
Use Glean Dictionary updated search API

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -58,7 +58,7 @@ export async function getProbeData(params) {
 
 function getProbeSearchURL(productId, queryString, resultsLimit) {
   const URLResult = new URL(
-    `__GLEAN_DICTIONARY_DOMAIN__/.netlify/functions/metrics_search_${productId}`
+    `__GLEAN_DICTIONARY_DOMAIN__/api/v1/metrics_search_${productId}`
   );
 
   const params = new URLSearchParams();


### PR DESCRIPTION
Fixes #1761.

With the new Glean Dictionary release, we can now start using the new official search API. 

E.g: https://dictionary.telemetry.mozilla.org/api/v1/metrics_search_firefox_legacy?search=video_dropped