### PR TITLE
Persist table pagination in the URL

### DIFF
--- a/src/components/controls/Pagination.svelte
+++ b/src/components/controls/Pagination.svelte
@@ -38,7 +38,9 @@
   <ButtonGroup>
     <Button
       tooltip="move back a page"
-      on:click={() => changePage(currentPage - 1)}
+      on:click={() => {
+        return currentPage === 1 ? undefined : changePage(currentPage - 1);
+      }}
       level="medium"
       compact>
       <CaretLeft size={10} />
@@ -52,7 +54,7 @@
     </Button>
   </ButtonGroup>
   page
-  {currentPage < 9 ? '0' : ''}{currentPage + 1}
+  {currentPage < 9 ? '0' : ''}{currentPage}
   of
   {totalPages < 9 ? '0' : ''}{totalPages}
 </div>

--- a/src/components/table/TableView.svelte
+++ b/src/components/table/TableView.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { store } from '../../state/store';
   import { Button, ButtonGroup } from '@graph-paper/button';
 
   import DataTable from './DataTable.svelte';
@@ -64,9 +65,10 @@
     <Pagination
       on:page={(evt) => {
         currentPage = evt.detail.page;
+        store.setField('currentPage', currentPage);
       }}
       {totalPages}
-      {currentPage} />
+      currentPage={Number($store.currentPage)} />
   </div>
 
   {#if bucketTypeLabel === 'percentiles'}

--- a/src/config/fenix.js
+++ b/src/config/fenix.js
@@ -82,6 +82,7 @@ export default {
       ref: storeValue.ref,
       aggKey: storeValue.aggKey,
       aggType: storeValue.aggType,
+      currentPage: storeValue.currentPage,
     };
     return stripDefaultValues(params, {
       ...sharedDefaults,

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -96,6 +96,7 @@ export default {
       visiblePercentiles: storeValue.visiblePercentiles,
       ref: storeValue.ref,
       hov: storeValue.hov,
+      currentPage: storeValue.currentPage,
     };
     return stripDefaultValues(params, {
       ...sharedDefaults,

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -38,6 +38,8 @@ function getDefaultState(
   state.searchProduct = state.product || 'firefox';
   state.aggKey = getFromQueryString('aggKey') || '';
   state.aggType = getFromQueryString('aggType') || 'avg';
+  state.currentPage = getFromQueryString('currentPage') || '1';
+
   state.probe = {
     name: '',
     loaded: false,


### PR DESCRIPTION
Fixes #308.

Persisting the table page number in the URL. 

Example:

http://localhost:8000/firefox/probe/time_to_non_blank_paint_ms/table?currentPage=10

![CleanShot 2022-02-15 at 12 17 05@2x](https://user-images.githubusercontent.com/28797553/154114433-5ffc224d-e98d-4a37-9198-c56b2659b774.png)

