### PR TITLE
Showing 0.1 and 1 percentiles on Explore and Table views (fixes #1645)

### DIFF
--- a/src/components/controls/PercentileSelectionControl.svelte
+++ b/src/components/controls/PercentileSelectionControl.svelte
@@ -12,7 +12,27 @@
 
 <BodyControl
   options={[
-    { label: '5%', value: 5, labelColor: cmp(5), tooltip: t(5), enabled: true },
+    {
+      label: '0.1%',
+      value: 0.1,
+      labelColor: cmp(0.1),
+      tooltip: t(0.1),
+      enabled: true,
+    },
+    {
+      label: '1%',
+      value: 1,
+      labelColor: cmp(1),
+      tooltip: t(1),
+      enabled: true,
+    },
+    {
+      label: '5%',
+      value: 5,
+      labelColor: cmp(5),
+      tooltip: t(5),
+      enabled: true,
+    },
     {
       label: '25%',
       value: 25,

--- a/src/utils/color-maps.js
+++ b/src/utils/color-maps.js
@@ -2,6 +2,8 @@ import { schemeTableau10 } from 'd3-scale-chromatic';
 
 export function percentileLineColorMap(percentile) {
   const p = +percentile;
+  if (p === 0.1) return 'var(--pond-green-200)';
+  if (p === 1) return 'var(--blue-slate-150)';
   if (p === 5) return 'var(--digital-blue-250)';
   if (p === 25) return 'var(--digital-blue-500)';
   if (p === 50) return 'var(--cool-gray-600)';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -144,4 +144,4 @@ export const proportionSmallMultiple = {
   height: 16,
 };
 
-export const PERCENTILES = [5, 25, 50, 75, 95, 99, 99.9];
+export const PERCENTILES = [0.1, 1, 5, 25, 50, 75, 95, 99, 99.9];


### PR DESCRIPTION
Fixes [#1645](https://github.com/mozilla/glam/issues/1645)
Showing 0.1% and 1% (off by default) on Explore and Table views.

![Screen Shot 2022-02-18 at 2 43 01 PM](https://user-images.githubusercontent.com/5804462/154753014-4c3818dc-d57b-498c-b66e-7796ffe03158.png)


![Screen Shot 2022-02-18 at 2 43 10 PM](https://user-images.githubusercontent.com/5804462/154752337-8f39afb0-3290-4073-8949-e7d9dc7c70ed.png)
