### PR TITLE
Get key values for keyed histogram SQL generation (fixes #1485)

### DIFF
--- a/src/components/SqlModal.svelte
+++ b/src/components/SqlModal.svelte
@@ -69,6 +69,9 @@
       } else {
         telemetryPath = `payload.processes.${process}.histograms.${$store.probe.name}`;
       }
+      if ($store.aggKey) {
+        telemetryPath = `mozfun.map.get_key(${telemetryPath}, ${$store.aggKey})`;
+      }
     }
     const osFilter =
       $store.productDimensions.os === '*'

--- a/src/components/controls/ProbeKeySelector.svelte
+++ b/src/components/controls/ProbeKeySelector.svelte
@@ -23,6 +23,11 @@
     store.setField('aggKey', currentKey);
     active = false;
   }
+
+  // initialize aggregation key if none has been selected yet
+  if (!$store.aggKey && options.length) {
+    store.setField('aggKey', options[0]);
+  }
 </script>
 
 <style>


### PR DESCRIPTION
Fixes #1485. See the linked issue for more context.

An example of updated SQL query for keyed histogram: [dns_trr_success3](https://glam.telemetry.mozilla.org/firefox/probe/dns_trr_success3/explore?activeBuckets=%5B%22Fine%22%2C%22Timeout%22%2C%22Bad%22%5D&process=parentl)

![CleanShot 2022-03-02 at 13 32 02@2x](https://user-images.githubusercontent.com/28797553/156425720-67460b63-18ab-4891-abd3-f38feed4e0e1.png)