### PR TITLE
Update explore view for probes with only 1 histogram

### DIFF
--- a/src/components/explore/AggregationComparisonGraph.svelte
+++ b/src/components/explore/AggregationComparisonGraph.svelte
@@ -15,6 +15,7 @@
   import { explorerComparisonSmallMultiple } from '../../utils/constants';
 
   export let description;
+  export let justOne;
   export let rightLabel;
   export let leftPoints;
   export let rightPoints;
@@ -63,7 +64,9 @@
 
 <div>
   <ChartTitle
-    {description}
+    description={justOne
+      ? `${description}. Please note that currently this probe doesn't have enough data to produce a meaningful comparison yet.`
+      : description}
     left={explorerComparisonSmallMultiple.left}
     right={0}>
     compare

--- a/src/components/explore/ComparisonSummary.svelte
+++ b/src/components/explore/ComparisonSummary.svelte
@@ -138,7 +138,7 @@
       use:tooltipAction={{
         text: `Compares the numeric values of the reference ⭑ to the hovered values ●. ${
           justOne
-            ? `Please note that currently this probe doesn't have enough data to produce a meaningful comparison yet.`
+            ? `Currently we don't have enough data to generate a meaningful comparison yet, please use this chart as a histogram distribution graph.`
             : ''
         }`,
         location: 'top',

--- a/src/components/explore/ComparisonSummary.svelte
+++ b/src/components/explore/ComparisonSummary.svelte
@@ -19,6 +19,7 @@
   export let showRight = true;
   export let showDiff = true;
   export let viewType;
+  export let justOne;
 
   function percentChange(l, r) {
     return viewType === 'proportion' ? r - l : (r - l) / l;
@@ -135,7 +136,11 @@
     Summary
     <span
       use:tooltipAction={{
-        text: 'Compares the numeric values of the reference ⭑ to the hovered values ●',
+        text: `Compares the numeric values of the reference ⭑ to the hovered values ●. ${
+          justOne
+            ? `Please note that currently this probe doesn't have enough data to produce a meaningful comparison yet.`
+            : ''
+        }`,
         location: 'top',
       }}
       class="data-graphic__element-title__icon"><Help size={14} /></span>

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -3,6 +3,7 @@
 
   import { window1D } from '@graph-paper/core/utils/window-functions';
   import ToplineMetrics from './ToplineMetrics.svelte';
+  import GlamErrorShapes from '../errors/GlamErrorShapes.svelte';
 
   import AggregationsOverTimeGraph from './AggregationsOverTimeGraph.svelte';
   import AggregationComparisonGraph from './AggregationComparisonGraph.svelte';
@@ -203,6 +204,23 @@
     justify-items: start;
     margin-bottom: var(--space-4x);
   }
+
+  .data-error-msg__bg {
+    background: radial-gradient(var(--cool-gray-100), var(--cool-gray-100));
+    width: 200px;
+    height: 200px;
+    padding: var(--space-4x);
+    margin: 0 auto;
+    border-radius: 50%;
+    margin-top: var(--space-2x);
+  }
+
+  .detail-title {
+    font-size: var(--text-015);
+    font-weight: 300;
+    color: var(--cool-gray-700);
+    padding: 10px 40px;
+  }
 </style>
 
 <div class="probe-body-overview">
@@ -215,31 +233,53 @@
 </div>
 
 <div class="graphic-and-summary" class:no-line-chart={justOne}>
-  <div style="display: {justOne ? 'none' : 'block'}">
-    <AggregationsOverTimeGraph
-      title={aggregationsOverTimeTitle}
-      description={aggregationsOverTimeDescription}
-      {data}
-      xDomain={$domain}
-      {yDomain}
-      lineColorMap={binColorMap}
-      {key}
-      yAccessor={overTimePointMetricType}
-      xScaleType={aggregationLevel === 'version' ? 'scalePoint' : 'time'}
-      {yScaleType}
-      {yTickFormatter}
-      metricKeys={activeBins}
-      {ref}
-      {hovered}
-      bind:hoverValue
-      {aggregationLevel}
-      on:click={() => {
-        if (hovered.datum) {
-          ref = hovered.datum;
-        }
-      }}>
-      <slot name="additional-plot-elements" />
-    </AggregationsOverTimeGraph>
+  <div style="display: block">
+    {#if justOne}
+      <div class="data-error-msg">
+        <div class="data-error-msg__bg">
+          <GlamErrorShapes />
+        </div>
+        <div>
+          <p class="detail-title">
+            Currently we don't have enough data to generate an over-time graph
+            for this metric. Please refer to the Table View to see the available
+            data, or use the SQL query generator for <a
+              href="https://docs.telemetry.mozilla.org/cookbooks/main_ping_exponential_histograms.html"
+              >further STMO analysis</a
+            >.
+            <br /> <br />
+            Please reach out in
+            <a href="https://mozilla.slack.com/archives/CB1EQ437S">#glam</a> if you
+            need more help.
+          </p>
+        </div>
+      </div>
+    {:else}
+      <AggregationsOverTimeGraph
+        title={aggregationsOverTimeTitle}
+        description={aggregationsOverTimeDescription}
+        {data}
+        xDomain={$domain}
+        {yDomain}
+        lineColorMap={binColorMap}
+        {key}
+        yAccessor={overTimePointMetricType}
+        xScaleType={aggregationLevel === 'version' ? 'scalePoint' : 'time'}
+        {yScaleType}
+        {yTickFormatter}
+        metricKeys={activeBins}
+        {ref}
+        {hovered}
+        bind:hoverValue
+        {aggregationLevel}
+        on:click={() => {
+          if (hovered.datum) {
+            ref = hovered.datum;
+          }
+        }}>
+        <slot name="additional-plot-elements" />
+      </AggregationsOverTimeGraph>
+    {/if}
   </div>
 
   <AggregationComparisonGraph

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -219,7 +219,6 @@
     font-size: var(--text-015);
     font-weight: 300;
     color: var(--cool-gray-700);
-    padding: 10px 40px;
   }
 </style>
 
@@ -233,7 +232,7 @@
 </div>
 
 <div class="graphic-and-summary" class:no-line-chart={justOne}>
-  <div style="display: block">
+  <div>
     {#if justOne}
       <div class="data-error-msg">
         <div class="data-error-msg__bg">
@@ -247,7 +246,8 @@
               href="https://docs.telemetry.mozilla.org/cookbooks/main_ping_exponential_histograms.html"
               >further STMO analysis</a
             >.
-            <br /> <br />
+          </p>
+          <p class="detail-title">
             Please reach out in
             <a href="https://mozilla.slack.com/archives/CB1EQ437S">#glam</a> if you
             need more help.
@@ -284,6 +284,7 @@
 
   <AggregationComparisonGraph
     description={compareDescription(aggregationsOverTimeTitle)}
+    {justOne}
     {yScaleType}
     rightLabel={aggregationLevel === 'build_id'
       ? formatBuildIDToDateString(ref.label)
@@ -363,7 +364,8 @@
     keyFormatter={comparisonKeyFormatter}
     showLeft={data.length > 1}
     showDiff={data.length > 1}
-    viewType={$store.viewType} />
+    viewType={$store.viewType}
+    {justOne} />
   <div style="display: {justOne ? 'none' : 'block'}">
     <ClientVolumeOverTimeGraph
       title={clientVolumeOverTimeTitle}

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -219,6 +219,7 @@
     font-size: var(--text-015);
     font-weight: 300;
     color: var(--cool-gray-700);
+    margin-right: 3em;
   }
 </style>
 


### PR DESCRIPTION
For probes that only have 1 data point, add more information to the Explore view to explain why there's no graph available. Fixes #1187.

Since this was an old error (the bug was reported over a year ago), and there's no new probes added recently, it was hard to find a production example to show what the page looks like with only 1 data point. I had to manually import some test data to reproduce the view locally.

Below is what an explore page looks like when there's only 1 histogram.

<img width="955" alt="Screen Shot 2022-03-09 at 11 52 09 AM" src="https://user-images.githubusercontent.com/28797553/157490474-5ebee9ff-0bff-4aa6-aa16-29dbf02009e1.png">

After this change:

<img width="1262" alt="Screen Shot 2022-03-10 at 4 08 07 PM" src="https://user-images.githubusercontent.com/28797553/157754916-e09505e8-9217-4742-a207-c7cef1447f67.png">

