### PR TITLE
Cast version from string to int to fix version 100 data not showing

### DIFF
--- a/glam/tests/test_api.py
+++ b/glam/tests/test_api.py
@@ -321,7 +321,7 @@ class TestDesktopAggregationsApi:
             "process": "parent",
             "total_addressable_market": 999,
             "total_users": 1110,
-            "version": "72",
+            "version": 72,
         }
 
     def test_revision_lookup(self, client):
@@ -359,7 +359,7 @@ class TestDesktopAggregationsApi:
             "process": "parent",
             "total_addressable_market": 999,
             "total_users": 1110,
-            "version": "72",
+            "version": 72,
         }
 
     def test_versions_provided(self, client):
@@ -380,11 +380,11 @@ class TestDesktopAggregationsApi:
         # Max version in the test data is 72. If we pass versions=4 we should
         # get 4 records back, even though we have 7 in the db.
         _create_aggregation()
-        _create_aggregation({"version": 71})
-        _create_aggregation({"version": 70})
-        _create_aggregation({"version": 69})
-        _create_aggregation({"version": 68})
-        _create_aggregation({"version": 67})
+        _create_aggregation({"version": 101})
+        _create_aggregation({"version": 100})
+        _create_aggregation({"version": 99})
+        _create_aggregation({"version": 98})
+        _create_aggregation({"version": 97})
 
         query = {
             "query": {
@@ -399,7 +399,7 @@ class TestDesktopAggregationsApi:
         data = resp.json()
         assert len(data["response"]) == 4
         versions = sorted([d["version"] for d in data["response"]])
-        assert versions == sorted(["72", "71", "70", "69"])
+        assert versions == sorted([101, 100, 99, 98])
 
     def test_process_filter(self, client):
         _create_aggregation()
@@ -493,7 +493,7 @@ class TestGleanAggregationsApi:
             "percentiles": {"5": 50, "25": 250, "50": 500, "75": 750, "95": 950},
             "ping_type": "*",
             "total_users": 1110,
-            "version": "2",
+            "version": 2,
             "total_addressable_market": 888,
         }
 
@@ -521,7 +521,7 @@ class TestGleanAggregationsApi:
         data = resp.json()
         assert len(data["response"]) == 4
         versions = sorted([d["version"] for d in data["response"]])
-        assert versions == sorted(["6", "5", "4", "3"])
+        assert versions == sorted([6, 5, 4, 3])
 
 
 class TestUpdatesApi:


### PR DESCRIPTION
Fixes  #1870.

Version data is stored as string in our database, so after version 100, we need to make sure to cast it from string to int first, or Max() would return version 99 as the latest version, instead of 100, because `"99" > "100"`.


Seeing version 100 data now that version is converted to int. 

Aggregated by build id:

<img width="1027" alt="CleanShot 2022-03-14 at 10 58 58@2x" src="https://user-images.githubusercontent.com/28797553/158199382-d4a75af1-e16b-46e7-a6ad-2043b0d3c3b7.png">

By version:

<img width="609" alt="CleanShot 2022-03-14 at 11 01 35@2x" src="https://user-images.githubusercontent.com/28797553/158199915-38219a7b-5010-443d-b6dc-06dc5d51127b.png">

