### PR TITLE
Show Select All button in Table View for enumerated histograms

### DIFF
--- a/src/components/table/TableView.svelte
+++ b/src/components/table/TableView.svelte
@@ -34,6 +34,7 @@
   export let bucketOptions;
 
   let showHistogramData = false;
+  let categoricalHistograms = ['categorical', 'enumerated'];
 
   let totalPages = 0;
   let currentPage = 0;
@@ -98,7 +99,7 @@
     </div>
   {/if}
 
-  {#if $store.probe.kind === 'categorical'}
+  {#if categoricalHistograms.includes($store.probe.kind)}
     <div style="display: flex; justify-content: flex-end; padding: 1em;">
       <CategoricalMenu
         {data}


### PR DESCRIPTION
I noticed while testing dev today that for enumerated histograms, the table view doesn't have the categorical menu drop down option. See example: https://dev.glam.nonprod.dataops.mozgcp.net/firefox/probe/http_response_version/table?activeBuckets=%5B%2220%22%2C%2211%22%2C%2230%22%2C%2210%22%2C%220%22%2C%221%22%2C%222%22%2C%223%22%2C%224%22%2C%225%22%5D&currentPage=1&process=parent

Since enumerated has bucket categories too, I think it makes sense to add the drop-down selection to its table view.

![CleanShot 2022-03-22 at 10 48 57@2x](https://user-images.githubusercontent.com/28797553/159509773-36b408ca-d8ae-488d-9eaa-a668b164bdea.png)

