### PR TITLE
Get the correct expiry status for Fenix probes

### DIFF
--- a/src/routing/pages/probe/FenixDetails.svelte
+++ b/src/routing/pages/probe/FenixDetails.svelte
@@ -20,11 +20,12 @@
   const mdY = timeFormat('%b %d, %Y');
   const toNiceDate = (dt) => mdY(parseYMD(dt));
 
+  const willNeverExpire = (expiry) =>
+    expiry === 'never' || expiry === undefined || expiry === null;
+
   // taken from glean dictionary
   const isExpired = (item) => {
-    if (item.expires === 'never' || item.expires === undefined) {
-      return false;
-    }
+    if (willNeverExpire(item.expires)) return false;
     return new Date() > new Date(item.expires);
   };
 </script>
@@ -204,16 +205,14 @@
           </dd>
         </dl>
       {/if}
-      {#if $store.probe.expires}
-        <dl>
-          <dt>Expires</dt>
-          <dd>
-            {$store.probe.expires === 'never'
-              ? 'never'
-              : toNiceDate($store.probe.expires)}
-          </dd>
-        </dl>
-      {/if}
+      <dl>
+        <dt>Expires</dt>
+        <dd>
+          {willNeverExpire($store.probe.expires)
+            ? 'never'
+            : toNiceDate($store.probe.expires)}
+        </dd>
+      </dl>
     </div>
     <div class="drawer-section">
       <dl>


### PR DESCRIPTION
The Glean Dictionary search API returns `null` for probes that don't have an expiry date, i.e. they never expire. However we're not including this condition in the expiry check for front-end, which marks active probe as expired.

For example, this probe is still active, but on dev it's marked as expired: https://dev.glam.nonprod.dataops.mozgcp.net/fenix/probe/addons_has_enabled_addons/explore?activeBuckets=%5B%22never%22%2C%22always%22%2C%22sometimes%22%5D&aggType=avg&currentPage=1

It's because the API returns the expiry value as `null`: https://dictionary.telemetry.mozilla.org/api/v1/metrics_search_fenix?search=addons.has_enabled_addons

This PR fixes it, and the probe now has the correct expiry status.

<img width="1357" alt="CleanShot 2022-03-23 at 15 44 23@2x" src="https://user-images.githubusercontent.com/28797553/159782959-e8abcbdd-cb44-4740-9e89-31e3464f08c2.png">

