### PR TITLE
Show sample count on Explore page

### DIFF
--- a/glam/api/views.py
+++ b/glam/api/views.py
@@ -254,6 +254,7 @@ def get_glean_aggregations(request, **kwargs):
             "metric_key": row.metric_key,
             "client_agg_type": row.client_agg_type,
             "total_users": row.total_users,
+            "sample_count": row.total_sample,
             "histogram": row.histogram and orjson.loads(row.histogram) or "",
             "percentiles": row.percentiles and orjson.loads(row.percentiles) or "",
         }

--- a/glam/api/views.py
+++ b/glam/api/views.py
@@ -123,6 +123,7 @@ def get_firefox_aggregations(request, **kwargs):
             "metric_key": row.metric_key,
             "metric_type": row.metric_type,
             "total_users": row.total_users,
+            "sample_count": row.total_sample,
             "histogram": row.histogram and orjson.loads(row.histogram) or "",
             "percentiles": row.percentiles and orjson.loads(row.percentiles) or "",
         }

--- a/glam/tests/test_api.py
+++ b/glam/tests/test_api.py
@@ -82,6 +82,7 @@ def _create_glean_aggregation(model, data=None, multiplier=1.0):
         "metric_key": "",
         "client_agg_type": "avg",
         "total_users": 111 * multiplier,
+        "total_sample": 1000,
         "histogram": json.dumps(
             {
                 "0": round(10.00001111 * multiplier, 4),
@@ -496,6 +497,7 @@ class TestGleanAggregationsApi:
             "percentiles": {"5": 50, "25": 250, "50": 500, "75": 750, "95": 950},
             "ping_type": "*",
             "total_users": 1110,
+            "sample_count": 1000,
             "version": 2,
             #"total_addressable_market": 888,
         }

--- a/glam/tests/test_api.py
+++ b/glam/tests/test_api.py
@@ -31,6 +31,7 @@ def _create_aggregation(data=None, multiplier=1.0, model=None):
         "client_agg_type": "summed-histogram",
         "metric_type": "histogram-exponential",
         "total_users": 111 * multiplier,
+        "total_sample": 1000,
         "histogram": json.dumps(
             {
                 "0": round(10.00001111 * multiplier, 4),
@@ -321,6 +322,7 @@ class TestDesktopAggregationsApi:
             "process": "parent",
             #"total_addressable_market": 999,
             "total_users": 1110,
+            "sample_count": 1000,
             "version": 72,
         }
 
@@ -359,6 +361,7 @@ class TestDesktopAggregationsApi:
             "process": "parent",
             #"total_addressable_market": 999,
             "total_users": 1110,
+            "sample_count": 1000,
             "version": 72,
         }
 

--- a/src/components/explore/ClientVolumeOverTimeGraph.svelte
+++ b/src/components/explore/ClientVolumeOverTimeGraph.svelte
@@ -29,6 +29,14 @@
   export let hoverValue = {};
 </script>
 
+<style>
+  .count-view {
+    font-weight: 300;
+    font-size: 0.7em;
+    cursor: pointer;
+  }
+</style>
+
 <div>
   <ChartTitle
     {description}
@@ -36,7 +44,7 @@
     right={totalClientsGraph.right}>
     {title}
     <a
-      style="font-weight: 300; font-size: 0.7em; cursor: pointer;"
+      class="count-view"
       on:click={() => store.setField('countView', 'samples')}
       >View Sample Count</a>
   </ChartTitle>

--- a/src/components/explore/ClientVolumeOverTimeGraph.svelte
+++ b/src/components/explore/ClientVolumeOverTimeGraph.svelte
@@ -1,6 +1,7 @@
 <script>
   import { Axis } from '@graph-paper/guides';
   import { Line } from '@graph-paper/elements';
+  import { store } from '../../state/store';
 
   import Tweenable from '../Tweenable.svelte';
   import DataGraphic from '../datagraphic/DataGraphic.svelte';
@@ -34,6 +35,10 @@
     left={totalClientsGraph.left}
     right={totalClientsGraph.right}>
     {title}
+    <a
+      style="font-weight: 300; font-size: 0.7em; cursor: pointer;"
+      on:click={() => store.setField('countView', 'samples')}
+      >View Sample Count</a>
   </ChartTitle>
   <DataGraphic
     yType="linear"

--- a/src/components/explore/CompareSampleCountGraph.svelte
+++ b/src/components/explore/CompareSampleCountGraph.svelte
@@ -7,7 +7,7 @@
   import Tweenable from '../Tweenable.svelte';
   import ChartTitle from './ChartTitle.svelte';
   import { compareClientCountsGraph, tween } from '../../utils/constants';
-  import { kFormatter } from '../../utils/formatters';
+  import { millionFormatter } from '../../utils/formatters';
 
   export let description;
   export let hoverValue;
@@ -69,7 +69,10 @@
           location: 'top',
           alignment: 'center',
         }} />
-      <Axis side="right" tickFormatter={kFormatter} ticks={yScale.ticks(4)} />
+      <Axis
+        side="right"
+        tickFormatter={millionFormatter}
+        ticks={yScale.ticks(4)} />
       <Axis side="bottom" ticks={['HOV.', 'REF.']} />
     </g>
     <g slot="body" let:top let:bottom let:xScale let:yScale>

--- a/src/components/explore/CompareSampleCountGraph.svelte
+++ b/src/components/explore/CompareSampleCountGraph.svelte
@@ -7,7 +7,7 @@
   import Tweenable from '../Tweenable.svelte';
   import ChartTitle from './ChartTitle.svelte';
   import { compareClientCountsGraph, tween } from '../../utils/constants';
-  import { millionFormatter } from '../../utils/formatters';
+  import { formatMillion } from '../../utils/formatters';
 
   export let description;
   export let hoverValue;
@@ -71,7 +71,7 @@
         }} />
       <Axis
         side="right"
-        tickFormatter={millionFormatter}
+        tickFormatter={formatMillion}
         ticks={yScale.ticks(4)} />
       <Axis side="bottom" ticks={['HOV.', 'REF.']} />
     </g>

--- a/src/components/explore/CompareSampleCountGraph.svelte
+++ b/src/components/explore/CompareSampleCountGraph.svelte
@@ -1,0 +1,106 @@
+<script>
+  import { tooltip as tooltipAction } from '@graph-paper/core/actions/tooltip';
+
+  import { Axis } from '@graph-paper/guides';
+  import DataGraphic from '../datagraphic/DataGraphic.svelte';
+
+  import Tweenable from '../Tweenable.svelte';
+  import ChartTitle from './ChartTitle.svelte';
+  import { compareClientCountsGraph, tween } from '../../utils/constants';
+  import { kFormatter } from '../../utils/formatters';
+
+  export let description;
+  export let hoverValue;
+  export let referenceValue;
+  export let yDomain;
+</script>
+
+<style>
+  .client-bar {
+    fill: var(--cool-gray-250);
+  }
+
+  .client-peak {
+    stroke: var(--cool-gray-550);
+  }
+</style>
+
+<div>
+  <ChartTitle
+    {description}
+    left={compareClientCountsGraph.left}
+    right={compareClientCountsGraph.right}>
+    Compare
+  </ChartTitle>
+
+  <DataGraphic
+    width={compareClientCountsGraph.width}
+    height={compareClientCountsGraph.height}
+    top={compareClientCountsGraph.top}
+    bottom={compareClientCountsGraph.bottom}
+    left={compareClientCountsGraph.left}
+    right={compareClientCountsGraph.right}
+    xDomain={['HOV.', 'REF.']}
+    {yDomain}
+    xType="scalePoint"
+    yType="linear"
+    bottomBorder
+    borderColor={compareClientCountsGraph.borderColor}>
+    <g slot="background" let:left let:top let:right let:bottom let:yScale>
+      <rect
+        x={left}
+        y={top}
+        width={(right - left) / 2}
+        height={bottom - top}
+        fill={compareClientCountsGraph.bgColor}
+        use:tooltipAction={{
+          text: 'Shows the distribution of the currently-hovered point on the line chart',
+          location: 'top',
+          alignment: 'center',
+        }} />
+      <rect
+        x={(left + right) / 2}
+        y={top}
+        width={(right - left) / 2}
+        height={bottom - top}
+        fill={compareClientCountsGraph.bgColor}
+        use:tooltipAction={{
+          text: 'Shows the distribution of the current reference point on the line chart',
+          location: 'top',
+          alignment: 'center',
+        }} />
+      <Axis side="right" tickFormatter={kFormatter} ticks={yScale.ticks(4)} />
+      <Axis side="bottom" ticks={['HOV.', 'REF.']} />
+    </g>
+    <g slot="body" let:top let:bottom let:xScale let:yScale>
+      <Tweenable params={tween} value={referenceValue} let:tweenValue={tw}>
+        <rect
+          class="client-bar"
+          x={xScale('REF.') - xScale.step() / 4}
+          y={yScale(tw)}
+          width={xScale.step() / 2}
+          height={bottom - yScale(tw)} />
+        <line
+          class="client-peak"
+          x1={xScale('REF.') - xScale.step() / 4}
+          x2={xScale('REF.') + xScale.step() / 4}
+          y1={yScale(tw)}
+          y2={yScale(tw)} />
+      </Tweenable>
+      {#if hoverValue}
+        <rect
+          class="client-bar"
+          x={xScale('HOV.') - xScale.step() / 4}
+          y={yScale(hoverValue)}
+          width={xScale.step() / 2}
+          height={bottom - yScale(hoverValue)} />
+        <line
+          class="client-peak"
+          x1={xScale('HOV.') - xScale.step() / 4}
+          x2={xScale('HOV.') + xScale.step() / 4}
+          y1={yScale(hoverValue)}
+          y2={yScale(hoverValue)} />
+      {/if}
+    </g>
+  </DataGraphic>
+</div>

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -161,13 +161,6 @@
 
   $: yClientsDomain = [0, yMaxClient * MULT];
   $: ySamplesDomain = [0, yMaxSample * MULT];
-  // $: if (['total_users', 'both'].includes($store.productDimensions.countView)) {
-  //   yVals = clientCountsData.map((d) => d.totalClients);
-  //   yMax = Math.max(50, Math.max(...yVals));
-  // } else if (['sample_count', 'both'].includes($store.productDimensions.countView)){
-  //   yVals = sampleCountsData.map((d) => d.totalSample);
-  //   yMax = Math.max(50, Math.max(...yVals));
-  // }
 
   let hoverValue = {};
   let lastHoverValue = {};

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -23,7 +23,7 @@
   import {
     explorerComparisonSmallMultiple,
     overTimeTitle,
-    clientVolumeOverTimeDescription as clientDescription,
+    volumeOverTimeDescription as clientDescription,
     compareDescription,
   } from '../../utils/constants';
 
@@ -68,8 +68,10 @@
     'clientVolume',
     aggregationLevel
   );
-  export let clientVolumeOverTimeDescription =
-    clientDescription(aggregationLevel);
+  export let volumeOverTimeDescription = clientDescription(
+    aggregationLevel,
+    $store.countView
+  );
 
   // If there isn't more than one other point to compare,
   // let's turn off the hover.
@@ -375,11 +377,11 @@
     showDiff={data.length > 1}
     viewType={$store.viewType}
     {justOne} />
-  {#if ['total_users', 'both'].includes($store.productDimensions.countView)}
+  {#if $store.countView === 'clients'}
     <div style="display: {justOne ? 'none' : 'block'}">
       <ClientVolumeOverTimeGraph
         title={clientVolumeOverTimeTitle}
-        description={clientVolumeOverTimeDescription}
+        description={clientDescription(aggregationLevel, $store.countView)}
         data={clientCountsData}
         xDomain={$domain}
         yDomain={yClientsDomain}
@@ -401,10 +403,10 @@
         referenceValue={ref.audienceSize} />
     </div>
   {/if}
-  {#if ['sample_count', 'both'].includes($store.productDimensions.countView)}
+  {#if $store.countView === 'samples'}
     <SampleCountOverTimeGraph
-      title={overTimeTitle('sampleCounts', aggregationLevel)}
-      description={clientVolumeOverTimeDescription}
+      title={overTimeTitle('sampleVolume', aggregationLevel)}
+      description={clientDescription(aggregationLevel, $store.countView)}
       data={sampleCountsData}
       xDomain={$domain}
       yDomain={ySamplesDomain}
@@ -419,7 +421,9 @@
       }} />
     <div style="display: {justOne ? 'none' : 'block'}">
       <CompareSampleCountGraph
-        Sampleiption={compareDescription(clientVolumeOverTimeTitle)}
+        description={compareDescription(
+          overTimeTitle('sampleVolume', aggregationLevel)
+        )}
         yDomain={ySamplesDomain}
         hoverValue={hovered.datum ? hovered.datum.sample_count : 0}
         referenceValue={ref.sample_count} />

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -154,12 +154,13 @@
 
   // client counts.
   const MULT = 1.1;
+  const MAX_DEFAULT_VALUE = 50;
   $: clientCountsData = clientCounts(data);
   $: sampleCountsData = sampleCounts(data);
   $: yValsSample = sampleCountsData.map((d) => d.totalSample);
   $: yVals = clientCountsData.map((d) => d.totalClients);
-  $: yMaxClient = Math.max(50, Math.max(...yVals));
-  $: yMaxSample = Math.max(50, Math.max(...yValsSample));
+  $: yMaxClient = Math.max(MAX_DEFAULT_VALUE, Math.max(...yVals));
+  $: yMaxSample = Math.max(MAX_DEFAULT_VALUE, Math.max(...yValsSample));
 
   $: yClientsDomain = [0, yMaxClient * MULT];
   $: ySamplesDomain = [0, yMaxSample * MULT];

--- a/src/components/explore/SampleCountOverTimeGraph.svelte
+++ b/src/components/explore/SampleCountOverTimeGraph.svelte
@@ -1,0 +1,136 @@
+<script>
+  import { Axis } from '@graph-paper/guides';
+  import { Line } from '@graph-paper/elements';
+
+  import Tweenable from '../Tweenable.svelte';
+  import DataGraphic from '../datagraphic/DataGraphic.svelte';
+
+  import FirefoxReleaseVersionMarkers from '../FirefoxReleaseVersionMarkers.svelte';
+
+  import { totalClientsGraph, tween } from '../../utils/constants';
+  import { kFormatter } from '../../utils/formatters';
+
+  import ReferenceSymbol from '../ReferenceSymbol.svelte';
+  import TrackingLine from './TrackingLine.svelte';
+  import TrackingLabel from './TrackingLabel.svelte';
+
+  import ChartTitle from './ChartTitle.svelte';
+
+  export let data;
+  export let title;
+  export let description;
+  export let aggregationLevel;
+  export let xDomain;
+  export let yDomain;
+  export let ref;
+  export let hovered;
+
+  export let hoverValue = {};
+</script>
+
+<div>
+  <ChartTitle
+    {description}
+    left={totalClientsGraph.left}
+    right={totalClientsGraph.right}>
+    {title}
+  </ChartTitle>
+  <DataGraphic
+    yType="linear"
+    xType={aggregationLevel === 'build_id' ? 'time' : 'scalePoint'}
+    {xDomain}
+    {yDomain}
+    height={totalClientsGraph.height}
+    top={totalClientsGraph.top}
+    left={totalClientsGraph.left}
+    right={totalClientsGraph.right}
+    bottom={totalClientsGraph.bottom}
+    bottomBorder
+    borderColor={totalClientsGraph.borderColor}
+    bind:mousePosition={hoverValue}
+    on:click>
+    <g slot="background" let:yScale>
+      <Axis
+        side="left"
+        lineStyle="short"
+        ticks={yScale.ticks(4)}
+        tickFormatter={kFormatter} />
+      {#if aggregationLevel === 'build_id'}
+        <Axis side="bottom" />
+      {:else if xDomain.length <= 5}
+        <Axis side="bottom" ticks={xDomain} />
+      {:else}
+        <Axis side="bottom" />
+      {/if}
+    </g>
+    <g slot="body">
+      <Line
+        scaling={false}
+        curve="curveLinear"
+        {data}
+        x="label"
+        y="totalSample"
+        color="var(--cool-gray-600)"
+        areaColor="var(--cool-gray-200)"
+        area={true} />
+    </g>
+    <g slot="annotation" let:top let:xScale let:yScale let:bottom let:width>
+      {#if hovered && hovered.datum}
+        <TrackingLine x={hovered.datum.label} />
+      {/if}
+      {#if ref}
+        <Tweenable
+          params={tween}
+          value={{
+            location: xScale(ref.label),
+            y: yScale(ref.sample_count),
+            sample_count: ref.sample_count,
+          }}
+          let:tweenValue={tv1}>
+          <TrackingLine xr={tv1.location} />
+        </Tweenable>
+      {/if}
+      {#if hovered && hovered.datum}
+        <TrackingLabel
+          align="top"
+          x={hovered.datum.label}
+          background="var(--cool-gray-100)"
+          label="Hov." />
+        <circle
+          cx={xScale(hovered.datum.label)}
+          cy={yScale(hovered.datum.sample_count)}
+          r="3"
+          fill="var(--cool-gray-700)" />
+      {/if}
+      {#if ref && ref.label && ref.sample_count !== undefined}
+        <Tweenable
+          params={tween}
+          value={{
+            x: xScale(ref.label),
+            y: yScale(ref.sample_count),
+            sample_count: ref.sample_count,
+          }}
+          from={{
+            x: xScale(ref.label),
+            y: yScale(ref.sample_count),
+            sample_count: ref.sample_count,
+          }}
+          let:tweenValue>
+          <ReferenceSymbol
+            size={20}
+            xLocation={tweenValue.x}
+            yLocation={tweenValue.y}
+            color="var(--cool-gray-700)" />
+          <TrackingLabel
+            align="bottom"
+            label="Ref."
+            xr={tweenValue.x}
+            background={bottom - tweenValue.y < 10
+              ? 'var(--cool-gray-100)'
+              : 'var(--cool-gray-200)'} />
+        </Tweenable>
+      {/if}
+    </g>
+    <FirefoxReleaseVersionMarkers labels={false} />
+  </DataGraphic>
+</div>

--- a/src/components/explore/SampleCountOverTimeGraph.svelte
+++ b/src/components/explore/SampleCountOverTimeGraph.svelte
@@ -1,6 +1,7 @@
 <script>
   import { Axis } from '@graph-paper/guides';
   import { Line } from '@graph-paper/elements';
+  import { store } from '../../state/store';
 
   import Tweenable from '../Tweenable.svelte';
   import DataGraphic from '../datagraphic/DataGraphic.svelte';
@@ -8,7 +9,7 @@
   import FirefoxReleaseVersionMarkers from '../FirefoxReleaseVersionMarkers.svelte';
 
   import { totalClientsGraph, tween } from '../../utils/constants';
-  import { millionFormatter } from '../../utils/formatters';
+  import { formatMillion } from '../../utils/formatters';
 
   import ReferenceSymbol from '../ReferenceSymbol.svelte';
   import TrackingLine from './TrackingLine.svelte';
@@ -34,6 +35,10 @@
     left={totalClientsGraph.left}
     right={totalClientsGraph.right}>
     {title}
+    <a
+      style="font-weight: 300; font-size: 0.7em; cursor: pointer;"
+      on:click={() => store.setField('countView', 'clients')}
+      >View Client Count</a>
   </ChartTitle>
   <DataGraphic
     yType="linear"
@@ -54,7 +59,7 @@
         side="left"
         lineStyle="short"
         ticks={yScale.ticks(4)}
-        tickFormatter={millionFormatter} />
+        tickFormatter={formatMillion} />
       {#if aggregationLevel === 'build_id'}
         <Axis side="bottom" />
       {:else if xDomain.length <= 5}

--- a/src/components/explore/SampleCountOverTimeGraph.svelte
+++ b/src/components/explore/SampleCountOverTimeGraph.svelte
@@ -8,7 +8,7 @@
   import FirefoxReleaseVersionMarkers from '../FirefoxReleaseVersionMarkers.svelte';
 
   import { totalClientsGraph, tween } from '../../utils/constants';
-  import { kFormatter } from '../../utils/formatters';
+  import { millionFormatter } from '../../utils/formatters';
 
   import ReferenceSymbol from '../ReferenceSymbol.svelte';
   import TrackingLine from './TrackingLine.svelte';
@@ -54,7 +54,7 @@
         side="left"
         lineStyle="short"
         ticks={yScale.ticks(4)}
-        tickFormatter={kFormatter} />
+        tickFormatter={millionFormatter} />
       {#if aggregationLevel === 'build_id'}
         <Axis side="bottom" />
       {:else if xDomain.length <= 5}

--- a/src/components/explore/SampleCountOverTimeGraph.svelte
+++ b/src/components/explore/SampleCountOverTimeGraph.svelte
@@ -29,6 +29,14 @@
   export let hoverValue = {};
 </script>
 
+<style>
+  .count-view {
+    font-weight: 300;
+    font-size: 0.7em;
+    cursor: pointer;
+  }
+</style>
+
 <div>
   <ChartTitle
     {description}
@@ -36,7 +44,7 @@
     right={totalClientsGraph.right}>
     {title}
     <a
-      style="font-weight: 300; font-size: 0.7em; cursor: pointer;"
+      class="count-view"
       on:click={() => store.setField('countView', 'clients')}
       >View Client Count</a>
   </ChartTitle>

--- a/src/components/explore/ToplineMetrics.svelte
+++ b/src/components/explore/ToplineMetrics.svelte
@@ -33,6 +33,7 @@
 
   .topline__client-count {
     transition: font-weight 200ms;
+    margin-left: 4em;
   }
 
   .topline__client-count--highlighted {
@@ -66,6 +67,14 @@
           </span>
           clients
         </span>
+        <span data-value={ref.sample_count}>
+          <span
+            class="topline__client-count"
+            class:topline--client-count--highlighted={hovered &&
+              hovered.sample_count < tweenValue}>
+            {formatCount(ref.sample_count)}
+          </span>
+          samples</span>
       </span>
     </ToplineRow>
     {#if dataLength > 1}
@@ -87,6 +96,13 @@
                 {formatCount(hovered.audienceSize)}
               </span>
               clients
+              <span
+                class="topline__client-count"
+                class:topline__client-count--highlighted={hovered &&
+                  hovered.sample_count > tweenValue}>
+                {formatCount(hovered.sample_count)}
+              </span>
+              samples
             {/if}
           </div>
           {#if hovered}
@@ -96,6 +112,13 @@
                 >{formatParenPercent(
                   '.0%',
                   absDiff(hovered.audienceSize, tweenValue, true),
+                  7
+                )}</span>
+              {formatSignCount(absDiff(hovered.sample_count, ref.sample_count))}
+              <span style="font-weight: 500;"
+                >{formatParenPercent(
+                  '.0%',
+                  absDiff(hovered.sample_count, ref.sample_count, true),
                   7
                 )}</span>
             </div>

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -61,16 +61,6 @@ export default {
       ],
       defaultValue: 'build_id',
     },
-    countView: {
-      title: 'Submission Count',
-      key: 'countView',
-      values: [
-        { key: 'total_users', label: 'User Count' },
-        { key: 'sample_count', label: 'Sample Count' },
-        { key: 'both', label: 'User and Sample Count' },
-      ],
-      defaultValue: 'total_users',
-    },
   },
   // the probeView object maps a probe type for this product
   // to one of a few options: "linear"  "log", and "categorical". Quantile type probes

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -61,6 +61,16 @@ export default {
       ],
       defaultValue: 'build_id',
     },
+    countView: {
+      title: 'Submission Count',
+      key: 'countView',
+      values: [
+        { key: 'total_users', label: 'User Count' },
+        { key: 'sample_count', label: 'Sample Count' },
+        { key: 'both', label: 'User and Sample Count' },
+      ],
+      defaultValue: 'total_users',
+    },
   },
   // the probeView object maps a probe type for this product
   // to one of a few options: "linear"  "log", and "categorical". Quantile type probes

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -46,6 +46,8 @@ function getDefaultState(
   state.aggKey = getFromQueryString('aggKey') || '';
   state.aggType = getFromQueryString('aggType') || 'avg';
   state.currentPage = getFromQueryString('currentPage') || '1';
+  state.countView = getFromQueryString('countView') || 'clients';
+
   state.probe = {
     name: '',
     loaded: false,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -17,6 +17,7 @@ const niceAggregations = {
 const niceMetricTypes = {
   percentiles: 'Percentiles',
   counts: 'Client Counts',
+  sampleCounts: 'Sample Count Volume',
   proportions: 'Proportions',
   clientVolume: 'Client Volume',
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -17,9 +17,9 @@ const niceAggregations = {
 const niceMetricTypes = {
   percentiles: 'Percentiles',
   counts: 'Client Counts',
-  sampleCounts: 'Sample Count Volume',
   proportions: 'Proportions',
   clientVolume: 'Client Volume',
+  sampleVolume: 'Sample Count Volume',
 };
 
 export function overTimeTitle(metricType, aggregationLevel) {
@@ -57,9 +57,9 @@ export function proportionsOverTimeDescription(
   `;
 }
 
-export function clientVolumeOverTimeDescription(aggregationLevel) {
+export function volumeOverTimeDescription(aggregationLevel, countView) {
   return `
-  Shows the total volume of clients that have observed this probe for each given ${
+  Shows the total volume of ${countView} that have observed this probe for each given ${
     niceAggregations[aggregationLevel]
   }.
 

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -17,12 +17,13 @@ export const formatParenPercent = (fmt, v, pad = 0) => {
   return `${p}${f}`;
 };
 
-export const millionFormatter = (num) =>
-  Math.abs(num) > 999
+export const formatMillion = (num) =>
+  // format a number as '1mil' if a million or more
+  Math.abs(num) > 999999
     ? `${format(',d')(
         Math.sign(num) * (Math.abs(num) / 1000000).toFixed(1)
       )}mil`
-    : Math.sign(num) * Math.abs(num);
+    : format(',d')(Math.sign(num) * Math.abs(num));
 
 export const formatBuildIDToDateString = (b) => timeFormat('%Y-%m-%d %H')(b);
 export const ymd = timeFormat('%Y-%m-%d');

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -17,9 +17,11 @@ export const formatParenPercent = (fmt, v, pad = 0) => {
   return `${p}${f}`;
 };
 
-export const kFormatter = (num) =>
+export const millionFormatter = (num) =>
   Math.abs(num) > 999
-    ? `${format(',d')(Math.sign(num) * (Math.abs(num) / 1000).toFixed(1))}k`
+    ? `${format(',d')(
+        Math.sign(num) * (Math.abs(num) / 1000000).toFixed(1)
+      )}mil`
     : Math.sign(num) * Math.abs(num);
 
 export const formatBuildIDToDateString = (b) => timeFormat('%Y-%m-%d %H')(b);

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -17,6 +17,11 @@ export const formatParenPercent = (fmt, v, pad = 0) => {
   return `${p}${f}`;
 };
 
+export const kFormatter = (num) =>
+  Math.abs(num) > 999
+    ? `${format(',d')(Math.sign(num) * (Math.abs(num) / 1000).toFixed(1))}k`
+    : Math.sign(num) * Math.abs(num);
+
 export const formatBuildIDToDateString = (b) => timeFormat('%Y-%m-%d %H')(b);
 export const ymd = timeFormat('%Y-%m-%d');
 export const timecode = timeFormat('%H:%M:%S');

--- a/src/utils/probe-utils.js
+++ b/src/utils/probe-utils.js
@@ -2,6 +2,10 @@ export function clientCounts(arr) {
   return arr.map((a) => ({ totalClients: a.audienceSize, label: a.label }));
 }
 
+export function sampleCounts(arr) {
+  return arr.map((a) => ({ totalSample: a.sample_count, label: a.label }));
+}
+
 function uniques(d, k) {
   return Array.from(new Set(d.map((di) => di[k])));
 }


### PR DESCRIPTION
For now this PR focuses on surfacing sample count data for desktop probes. Sample counts for Glean metrics (Fenix and FOG) will be added later (note that sample count data is already available for both legacy and Glean metrics in GLAM db, thanks to #1853).

Main UI changes:

![CleanShot 2022-04-04 at 20 37 25@2x](https://user-images.githubusercontent.com/28797553/161655820-78499d28-3bd7-4122-b5d8-369aad58d7ff.png)
1. Add a new dropdown that allows toggling between user count, sample count, or both
2. Add sample count data above the graph, next to the user count information
3. Sample count volume graph is below the aggregation graph

Here's what the UI looks like when "both" option is selected:

<img width="1341" alt="CleanShot 2022-04-04 at 20 39 31@2x" src="https://user-images.githubusercontent.com/28797553/161655872-4aef19cd-89d6-4527-93ea-81897c673118.png">

Fixes #1851.
