### PR TITLE
Fix FOG bugs: Looker links, release marker, ping types

### DIFF
--- a/src/components/ReleaseVersionMarkers.svelte
+++ b/src/components/ReleaseVersionMarkers.svelte
@@ -10,7 +10,7 @@
   const xScale = getContext('xScale');
 
   let markers = [];
-  switch ($store.product) {
+  switch ($store.searchProduct) {
     case 'firefox':
       firefoxVersionMarkers.subscribe((m) => {
         markers = m;
@@ -26,7 +26,7 @@
   }
 </script>
 
-{#if ['firefox', 'fenix'].includes($store.product)}
+{#if ['firefox', 'fenix'].includes($store.searchProduct)}
   <g class="firefox-release-version-markers">
     {#if markers && markers.length}
       {#each markers.filter((d) => d.date !== undefined && d.date >= $xScale.domain()[0] && d.date <= $xScale.domain()[1]) as { label, date }, i (date)}

--- a/src/config/glean.js
+++ b/src/config/glean.js
@@ -37,8 +37,12 @@ export const FIREFOX_ON_GLEAN = {
     ping_type: {
       title: 'Ping Type',
       key: 'ping_type',
-      values: [{ key: '*', label: 'All' }],
-      defaultValue: '*',
+      values: [
+        { key: '*', label: 'All' },
+        { key: 'metrics', label: 'Metrics' },
+        { key: 'baseline', label: 'Baseline' },
+      ],
+      defaultValue: 'metrics',
       isValidKey(key, probe) {
         return key === '*' ? true : probe.send_in_pings.includes(key);
       },

--- a/src/routing/pages/probe/GleanDetails.svelte
+++ b/src/routing/pages/probe/GleanDetails.svelte
@@ -28,6 +28,11 @@
     if (willNeverExpire(item.expires)) return false;
     return new Date() > new Date(item.expires);
   };
+
+  const GLEAN_DICTIONARY_PRODUCT_IDS = {
+    fog: 'firefox_desktop',
+    fenix: 'fenix',
+  };
 </script>
 
 <style>
@@ -185,7 +190,9 @@
           {@html marked($store.probe.description)}
           <a
             class="more-info-link"
-            href={`https://dictionary.telemetry.mozilla.org/apps/fenix/metrics/${$store.probeName}`}
+            href={`https://dictionary.telemetry.mozilla.org/apps/${
+              GLEAN_DICTIONARY_PRODUCT_IDS[$store.product]
+            }/metrics/${$store.probeName}`}
             target="_blank">
             more info
             <ExternalLink size="12" />
@@ -220,8 +227,11 @@
         <dd>
           {#each $store.probe.send_in_pings as ping}
             <a
-              href="https://dictionary.telemetry.mozilla.org/apps/fenix/pings/{ping}"
-              >{ping}</a>
+              href={`https://dictionary.telemetry.mozilla.org/apps/${
+                GLEAN_DICTIONARY_PRODUCT_IDS[$store.product]
+              }/metrics/${$store.probeName}`}
+              >{ping}
+            </a>
           {/each}
         </dd>
       </dl>
@@ -267,9 +277,9 @@
         Export to JSON
       </button>
       <LookerLink
-        product="fenix"
+        product="glean"
         variants={$store.probe.variants}
-        sendInPings={$store.probe.send_in_pings}
+        sendInPings={$store.productDimensions.ping_type}
         channel={$store.productDimensions.app_id} />
     </div>
   </div>


### PR DESCRIPTION
This PR fixes the bugs that I found while testing FOG page on dev. Details are in the comment below. 

There is still one outstanding bug: we're not getting the correct version data. For some reason, we're getting `1024` as the version number (instead of standard Firefox versions 98, 99, 100) for all Glean probes now. This is most likely a bug in our ETL.

![CleanShot 2022-04-14 at 15 32 47@2x](https://user-images.githubusercontent.com/28797553/163463000-6b2ce579-4d59-4577-b4a3-79acc6eb4c77.png)

Database check:

```
postgres=# select version from glam_fog_aggregation group by version;
 version 
---------
    1024
(1 row)
```