### PR TITLE
Get the correct release marker component path for sample count chart

### DIFF
--- a/src/components/explore/SampleCountOverTimeGraph.svelte
+++ b/src/components/explore/SampleCountOverTimeGraph.svelte
@@ -6,7 +6,7 @@
   import Tweenable from '../Tweenable.svelte';
   import DataGraphic from '../datagraphic/DataGraphic.svelte';
 
-  import FirefoxReleaseVersionMarkers from '../FirefoxReleaseVersionMarkers.svelte';
+  import ReleaseVersionMarkers from '../ReleaseVersionMarkers.svelte';
 
   import { totalClientsGraph, tween } from '../../utils/constants';
   import { formatMillion } from '../../utils/formatters';
@@ -144,6 +144,6 @@
         </Tweenable>
       {/if}
     </g>
-    <FirefoxReleaseVersionMarkers labels={false} />
+    <ReleaseVersionMarkers labels={false} />
   </DataGraphic>
 </div>


### PR DESCRIPTION
Oops forgot to change to the correct ReleaseMarker component in the last PR.