### PR TITLE
Add aggregation method information (fixes #346)

### DIFF
--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -130,6 +130,7 @@ export default {
           : 'quantile';
 
       appStore.setField('viewType', viewType);
+      appStore.setField('aggMethod', payload.response[0].client_agg_type);
 
       let data = payload.response;
 

--- a/src/config/glean.js
+++ b/src/config/glean.js
@@ -119,7 +119,7 @@ export const FIREFOX_ON_GLEAN = {
           ? 'proportion'
           : 'quantile';
       appStore.setField('viewType', viewType);
-
+      appStore.setField('aggMethod', payload.response[0].client_agg_type);
       const data = transformAPIResponse[viewType](
         payload.response,
         aggregationLevel,

--- a/src/config/glean.js
+++ b/src/config/glean.js
@@ -118,8 +118,10 @@ export const FIREFOX_ON_GLEAN = {
         this.probeView[metricType] === 'categorical'
           ? 'proportion'
           : 'quantile';
+
       appStore.setField('viewType', viewType);
       appStore.setField('aggMethod', payload.response[0].client_agg_type);
+
       const data = transformAPIResponse[viewType](
         payload.response,
         aggregationLevel,
@@ -281,7 +283,9 @@ export const FENIX = {
         this.probeView[metricType] === 'categorical'
           ? 'proportion'
           : 'quantile';
+
       appStore.setField('viewType', viewType);
+      appStore.setField('aggMethod', payload.response[0].client_agg_type);
 
       const data = transformAPIResponse[viewType](
         payload.response,

--- a/src/routing/pages/probe/FirefoxLegacyDetails.svelte
+++ b/src/routing/pages/probe/FirefoxLegacyDetails.svelte
@@ -209,6 +209,10 @@
             more info
             <ExternalLink size="12" />
           </a>
+          {#if $store.aggMethod}
+            <h2 class="detail__heading--01">aggregation method</h2>
+            <p>{$store.aggMethod}</p>
+          {/if}
         </div>
       {/if}
     </div>

--- a/src/routing/pages/probe/GleanDetails.svelte
+++ b/src/routing/pages/probe/GleanDetails.svelte
@@ -197,6 +197,10 @@
             more info
             <ExternalLink size="12" />
           </a>
+          {#if $store.aggMethod}
+            <h2 class="detail-title">aggregation method</h2>
+            <p>{$store.aggMethod}</p>
+          {/if}
         </div>
       {/if}
     </div>


### PR DESCRIPTION
Add aggregation method to both Firefox and Glean detail components. Fixes #346.

![CleanShot 2022-04-20 at 12 42 08@2x](https://user-images.githubusercontent.com/28797553/164281074-d2dbde9e-f2cd-463f-a30e-b5d534054d39.png)

