### PR TITLE
Fix broken Looker links

### DIFF
--- a/src/components/LookerLink.svelte
+++ b/src/components/LookerLink.svelte
@@ -17,6 +17,7 @@
 
     lookerURL =
       variant &&
+      variant.etl.ping_data[sendInPings] &&
       variant.etl.ping_data[sendInPings].looker &&
       variant.etl.ping_data[sendInPings].looker.metric.url;
 


### PR DESCRIPTION
When Looker data is not available, don't link to it. This prevents broken pages due to unavailable Looker links.

For example: https://dev.glam.nonprod.dataops.mozgcp.net/fog/probe/glean_baseline_duration/explore?aggType=avg&app_id=release&currentPage=1&ping_type=* 

is broken and the error message is:

`Uncaught (in promise) TypeError: can't access property "looker", r.etl.ping_data[s] is undefined`

<img width="1233" alt="CleanShot 2022-05-23 at 18 25 01@2x" src="https://user-images.githubusercontent.com/28797553/169914613-07f6d4bc-4e51-46d5-a025-a0ecce8e88ab.png">

