### PR TITLE
Make header items more responsive

### DIFF
--- a/public/static/global.css
+++ b/public/static/global.css
@@ -408,10 +408,11 @@ button:focus {
 .app {
   display: grid;
   min-height: 100vh;
-  max-width: var(--app-width);
+  min-width: var(--app-width);
   grid-template-rows: max-content auto;
   margin-left: auto;
   margin-right: auto;
+  padding: 0 10px;
 }
 
 .app--toolbar {

--- a/src/components/icons/GLAMLogo.svelte
+++ b/src/components/icons/GLAMLogo.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { fly } from 'svelte/transition';
 
-  export let size = 24;
+  export let size;
   let mounted = false;
   onMount(() => {
     mounted = true;
@@ -10,6 +10,9 @@
   let y = 50;
   let duration = 400;
   let delay = 200;
+
+  let innerWidth = { window };
+  $: size = innerWidth < 1045 ? 22 : 24;
 </script>
 
 <style>
@@ -23,6 +26,8 @@
     stroke-miterlimit: 2;
   }
 </style>
+
+<svelte:window bind:innerWidth />
 
 {#if mounted}
   <svg

--- a/src/components/icons/GLAMLogo.svelte
+++ b/src/components/icons/GLAMLogo.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { fly } from 'svelte/transition';
 
+  export let viewportMinWidth;
   export let size;
   let mounted = false;
   onMount(() => {
@@ -12,7 +13,7 @@
   let delay = 200;
 
   let innerWidth = { window };
-  $: size = innerWidth < 1045 ? 22 : 24;
+  $: size = innerWidth < viewportMinWidth ? 22 : 24;
 </script>
 
 <style>

--- a/src/components/icons/GLAMText.svelte
+++ b/src/components/icons/GLAMText.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { fly } from 'svelte/transition';
 
+  export let viewportMinWidth;
   export let size;
   let d = 50;
   let duration = 200;
@@ -11,7 +12,7 @@
   });
 
   let innerWidth = { window };
-  $: size = innerWidth < 1045 ? 34 : 40;
+  $: size = innerWidth < viewportMinWidth ? 34 : 40;
 </script>
 
 <svelte:window bind:innerWidth />

--- a/src/components/icons/GLAMText.svelte
+++ b/src/components/icons/GLAMText.svelte
@@ -2,14 +2,19 @@
   import { onMount } from 'svelte';
   import { fly } from 'svelte/transition';
 
-  export let size = 40;
+  export let size;
   let d = 50;
   let duration = 200;
   let mounted = false;
   onMount(() => {
     mounted = true;
   });
+
+  let innerWidth = { window };
+  $: size = innerWidth < 1045 ? 34 : 40;
 </script>
+
+<svelte:window bind:innerWidth />
 
 {#if mounted}
   <svg

--- a/src/components/regions/GLAMMark.svelte
+++ b/src/components/regions/GLAMMark.svelte
@@ -3,6 +3,10 @@
   import Logo from '../icons/GLAMLogo.svelte';
   import Text from '../icons/GLAMText.svelte';
   import { store, currentQuery } from '../../state/store';
+
+  // GLAM logo will resize if screen size
+  // is smaller than the viewport min width
+  let viewportMinWidth = 1045;
 </script>
 
 <style>
@@ -25,7 +29,7 @@
       text: 'The Glean Aggregated Metrics Dashboard',
       distance: 16,
     }}>
-    <Logo />
-    <Text />
+    <Logo {viewportMinWidth} />
+    <Text {viewportMinWidth} />
   </h1>
 </a>


### PR DESCRIPTION
This PR fixes 2 header problems when the viewport is smaller than 1045px.

1) GLAM logo is hidden behind the search bar

<img width="309" alt="CleanShot 2022-06-07 at 12 43 02@2x" src="https://user-images.githubusercontent.com/28797553/172437113-8b06f965-c5f4-47c8-8356-6de975088360.png">


2) Overflown items at the end

<img width="322" alt="CleanShot 2022-06-07 at 12 41 56@2x" src="https://user-images.githubusercontent.com/28797553/172436897-f5aee961-3dac-4e0e-b764-95e4a4730729.png">
 
This is how the app looks with this change: the logo is always visible, and no more overflow items at the end.

![2022-06-07 12 44 19](https://user-images.githubusercontent.com/28797553/172437385-f280734b-3d3d-4226-abcc-4a76a4a25c61.gif)

