### PR TITLE
Add GLEAN visualizer to FOG metric names

### DIFF
--- a/src/components/regions/ProbeTitle.svelte
+++ b/src/components/regions/ProbeTitle.svelte
@@ -2,8 +2,19 @@
   import { store } from '../../state/store';
 </script>
 
+<style>
+  .glean {
+    color: var(--pantone-red-600);
+    font-weight: 300;
+    font-size: 0.8em;
+  }
+</style>
+
 <h2 class="probe-details-title">
   {$store.route.view}
   /
   <span>{$store.probe.name}</span>
+  {#if $store.product === 'fog'}
+    <span class="glean">(GLEAN)</span>
+  {/if}
 </h2>


### PR DESCRIPTION
Make it more clear, besides the url signal, whether a desktop metric is a Glean metric.

![CleanShot 2022-06-07 at 15 53 02@2x](https://user-images.githubusercontent.com/28797553/172470396-a9a83802-51d0-460e-b4cb-0aaa395a5129.png)
