### PR TITLE
Fix overflow sample count text

### DIFF
--- a/src/components/explore/ToplineMetrics.svelte
+++ b/src/components/explore/ToplineMetrics.svelte
@@ -33,7 +33,7 @@
 
   .topline__client-count {
     transition: font-weight 200ms;
-    margin-left: 4em;
+    margin-left: 1.5em;
   }
 
   .topline__client-count--highlighted {


### PR DESCRIPTION
Before

![CleanShot 2022-06-07 at 16 19 04@2x](https://user-images.githubusercontent.com/28797553/172474742-09e5bfaf-7280-4ec6-8cf0-5a0881156fb3.png)


After (no more overflow text)

<img width="540" alt="CleanShot 2022-06-07 at 16 18 38@2x" src="https://user-images.githubusercontent.com/28797553/172474651-8e199def-c63f-480d-9a1f-2668f148e2b8.png">

