### PR TITLE
Update CircleCI Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@1.5.0
+  docker: circleci/docker@2.1.1
 
 jobs:
   build:


### PR DESCRIPTION
The latest merged PRs were not automatically deployed to dev due to CI unable to find the Docker image. This is because we have an outdated CircleCI orb. Updating to v2.1.1 seems to fix the issue.

<img width="617" alt="CleanShot 2022-06-07 at 16 54 12@2x" src="https://user-images.githubusercontent.com/28797553/172480674-4b9fe1fa-4a9f-4082-aa62-7e208b3d58ba.png">

