### PR TITLE
#2000: add new percentiles to sql telemetry query

### DIFF
--- a/src/stringTemplates/desktop-telemetry.tpl
+++ b/src/stringTemplates/desktop-telemetry.tpl
@@ -81,7 +81,7 @@ percentiles AS (
     build_id,
     mozfun.hist.percentiles(
       merged_${ metric },
-      [.05, .25, .5, .75, .95]
+      [0.001, 0.01, .05, .25, .5, .75, .95, 0.99, 0.999]
     ) AS percentile_nested
   FROM
     as_struct


### PR DESCRIPTION
this fixes #2000 by adding the missing percentiles to the SQL Telemetry query

<img width="942" alt="Screen Shot 2022-06-08 at 4 13 37 PM" src="https://user-images.githubusercontent.com/5804462/172708430-63fbef45-eaef-4cfa-be49-20df2142e113.png">
 