### PR TITLE
Lint repair fix distribution sql

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ scripts
 !.env-dist
 *.md
 docker-compose.yml
+.vscode

--- a/src/components/explore/AggregationsOverTimeGraph.svelte
+++ b/src/components/explore/AggregationsOverTimeGraph.svelte
@@ -48,7 +48,7 @@
   export let yAccessor;
 
   // set default reference point to be used in distribution sql
-  let defaultRef = data[data.length - 1]['build_id'];
+  let defaultRef = data[data.length - 1].build_id;
   store.setField('defaultRef', defaultRef);
 
   const pushlogUrlTemplate = _.template(


### PR DESCRIPTION
Ticket: fixes bug introduced in https://github.com/mozilla/glam/pull/2038

What this PR does:
* fixes CI frontend-tests (from running eslint) error in src/components/explore/AggregationsOverTimeGraph.svelte
* has docker image build ignore .vscode directory (to help standardize running npm run test either locally or in CI)
* linting error in question: 
```
/Users/charlow/Work/src/github.com/mozilla/glam/src/components/explore/AggregationsOverTimeGraph.svelte
  51:42  error  ["build_id"] is better written in dot notation  dot-notation
```

I have no idea if there is a reason to ignore eslint here, so feel free to push / repurpose this branch & PR to fix the CI linting issue another way.