### PR TITLE
forgot docker setup for deploy step in reworked CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASSWORD
     steps:
+      - setup_remote_docker
       - restore_cache:
           key: v1-{{.Environment.CIRCLE_SHA1}}
       - run:


### PR DESCRIPTION
Ticket: fixes bug introduced in https://github.com/mozilla/glam/pull/2030

What this PR does:
* fixes CI deploy step to have docker context for final Docker "deploy" (e.g. pushing built & tested Docker image to Dockerhub)
* error fixed:
```
docker load -i /tmp/cache/app.tar
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?

Exited with code exit status 1
CircleCI received exit code 1
```