### PR TITLE
Provide a more descriptive 404 message

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -5,7 +5,8 @@ const randomProbeURL = '__BASE_DOMAIN__/api/v1/probes/random/';
 const FETCH_ERROR_MESSAGES = {
   code5xx: 'Oh no! The server encountered an error.',
   code4xx: 'Oh no! Your client sent an invalid request.',
-  code404: '404: No data found for the selected dimensions.',
+  code404:
+    '404: No data found for the selected dimensions. Try changing the dimension value, or check if the probe is still active.',
   code405: '405: Method not allowed.',
 };
 


### PR DESCRIPTION
More descriptive 404 message for 404 cases where there's data available, just not with the default dimensions. Fixes #1942.