### PR TITLE
#1888 fix migration warning on FOGAggregationView

### DIFF
--- a/glam/api/models.py
+++ b/glam/api/models.py
@@ -107,6 +107,7 @@ class FOGAggregation(AbstractGleanAggregation):
 class FOGAggregationView(AbstractGleanAggregation):
     class Meta:
         managed = False
+        abstract = True
         db_table = "view_glam_fog_aggregation"
 
 


### PR DESCRIPTION
Added `abstract = True` to FOGAggregationView and that removed the warning.

Tested locally that a full first-time migration still works after the change.

I'm still wondering why [FenixAggregationView](https://github.com/mozilla/glam/blob/17b5e1576f9c083610c30caa319b57596262d06a/glam/api/models.py#L79), which is similar, doesn't behave the same way.