### PR TITLE
Make violin plot match the ref/hov order

### DIFF
--- a/src/components/explore/AggregationComparisonGraph.svelte
+++ b/src/components/explore/AggregationComparisonGraph.svelte
@@ -31,7 +31,7 @@
   export let yScaleType;
   export let key = Math.random().toString(36).substring(7);
 
-  let labelSet = ['HOV.', 'REF.'];
+  let labelSet = ['LEFT', 'RIGHT'];
 
   if (dataVolume === 1) {
     labelSet = [rightLabel];
@@ -95,7 +95,7 @@
         height={bottom - top}
         fill={explorerComparisonSmallMultiple.bgColor}
         use:tooltipAction={{
-          text: 'Shows the distribution of the currently-hovered point on the line chart',
+          text: 'Shows the distribution of the left point on the line chart',
           location: 'top',
           alignment: 'center',
         }} />
@@ -106,7 +106,7 @@
         height={bottom - top}
         fill={explorerComparisonSmallMultiple.bgColor}
         use:tooltipAction={{
-          text: 'Shows the distribution of the current reference point on the line chart',
+          text: 'Shows the distribution of the right point on the line chart',
           location: 'top',
           alignment: 'center',
         }} />

--- a/src/components/explore/CompareClientVolumeGraph.svelte
+++ b/src/components/explore/CompareClientVolumeGraph.svelte
@@ -10,8 +10,8 @@
   import { formatCount } from '../../utils/formatters';
 
   export let description;
-  export let hoverValue;
-  export let referenceValue;
+  export let leftAudienceValue;
+  export let rightAudienceValue;
   export let yDomain;
 </script>
 
@@ -54,7 +54,7 @@
         height={bottom - top}
         fill={compareClientCountsGraph.bgColor}
         use:tooltipAction={{
-          text: 'Shows the distribution of the currently-hovered point on the line chart',
+          text: 'Shows the distribution of the left point on the line chart',
           location: 'top',
           alignment: 'center',
         }} />
@@ -65,15 +65,14 @@
         height={bottom - top}
         fill={compareClientCountsGraph.bgColor}
         use:tooltipAction={{
-          text: 'Shows the distribution of the current reference point on the line chart',
+          text: 'Shows the distribution of the right point on the line chart',
           location: 'top',
           alignment: 'center',
         }} />
       <Axis side="right" tickFormatter={formatCount} ticks={yScale.ticks(4)} />
-      <Axis side="bottom" ticks={['HOV.', 'REF.']} />
     </g>
     <g slot="body" let:top let:bottom let:xScale let:yScale>
-      <Tweenable params={tween} value={referenceValue} let:tweenValue={tw}>
+      <Tweenable params={tween} value={rightAudienceValue} let:tweenValue={tw}>
         <rect
           class="client-bar"
           x={xScale('REF.') - xScale.step() / 4}
@@ -87,19 +86,19 @@
           y1={yScale(tw)}
           y2={yScale(tw)} />
       </Tweenable>
-      {#if hoverValue}
+      {#if leftAudienceValue}
         <rect
           class="client-bar"
           x={xScale('HOV.') - xScale.step() / 4}
-          y={yScale(hoverValue)}
+          y={yScale(leftAudienceValue)}
           width={xScale.step() / 2}
-          height={bottom - yScale(hoverValue)} />
+          height={bottom - yScale(leftAudienceValue)} />
         <line
           class="client-peak"
           x1={xScale('HOV.') - xScale.step() / 4}
           x2={xScale('HOV.') + xScale.step() / 4}
-          y1={yScale(hoverValue)}
-          y2={yScale(hoverValue)} />
+          y1={yScale(leftAudienceValue)}
+          y2={yScale(leftAudienceValue)} />
       {/if}
     </g>
   </DataGraphic>

--- a/src/components/explore/CompareSampleCountGraph.svelte
+++ b/src/components/explore/CompareSampleCountGraph.svelte
@@ -10,8 +10,8 @@
   import { formatMillion } from '../../utils/formatters';
 
   export let description;
-  export let hoverValue;
-  export let referenceValue;
+  export let leftSampleValue;
+  export let rightSampleValue;
   export let yDomain;
 </script>
 
@@ -54,7 +54,7 @@
         height={bottom - top}
         fill={compareClientCountsGraph.bgColor}
         use:tooltipAction={{
-          text: 'Shows the distribution of the currently-hovered point on the line chart',
+          text: 'Shows the distribution of the left point on the line chart',
           location: 'top',
           alignment: 'center',
         }} />
@@ -65,7 +65,7 @@
         height={bottom - top}
         fill={compareClientCountsGraph.bgColor}
         use:tooltipAction={{
-          text: 'Shows the distribution of the current reference point on the line chart',
+          text: 'Shows the distribution of the right point on the line chart',
           location: 'top',
           alignment: 'center',
         }} />
@@ -73,10 +73,9 @@
         side="right"
         tickFormatter={formatMillion}
         ticks={yScale.ticks(4)} />
-      <Axis side="bottom" ticks={['HOV.', 'REF.']} />
     </g>
     <g slot="body" let:top let:bottom let:xScale let:yScale>
-      <Tweenable params={tween} value={referenceValue} let:tweenValue={tw}>
+      <Tweenable params={tween} value={rightSampleValue} let:tweenValue={tw}>
         <rect
           class="client-bar"
           x={xScale('REF.') - xScale.step() / 4}
@@ -90,19 +89,19 @@
           y1={yScale(tw)}
           y2={yScale(tw)} />
       </Tweenable>
-      {#if hoverValue}
+      {#if leftSampleValue}
         <rect
           class="client-bar"
           x={xScale('HOV.') - xScale.step() / 4}
-          y={yScale(hoverValue)}
+          y={yScale(leftSampleValue)}
           width={xScale.step() / 2}
-          height={bottom - yScale(hoverValue)} />
+          height={bottom - yScale(leftSampleValue)} />
         <line
           class="client-peak"
           x1={xScale('HOV.') - xScale.step() / 4}
           x2={xScale('HOV.') + xScale.step() / 4}
-          y1={yScale(hoverValue)}
-          y2={yScale(hoverValue)} />
+          y1={yScale(leftSampleValue)}
+          y2={yScale(leftSampleValue)} />
       {/if}
     </g>
   </DataGraphic>

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -178,6 +178,19 @@
     });
   }
 
+  let leftDensity;
+  let rightDensity = ref[densityMetricType];
+  let leftAudienceValue = hovered.datum ? hovered.datum.audienceSize : 0;
+  let rightAudienceValue = ref.audienceSize;
+  let leftSampleValue = hovered.datum ? hovered.datum.sample_count : 0;
+  let rightSampleValue = ref.sample_count;
+  let leftPoints = leftPointsForAggComparison(
+    data,
+    pointMetricType,
+    hovered.datum
+  );
+  let rightPoints = ref[pointMetricType];
+
   $: if (hoverValue.x) {
     if ($showContextMenu) {
       hovered = lastHoverValue;
@@ -189,6 +202,33 @@
         previous: data[i.previousIndex],
         next: data[i.nextIndex],
       };
+      if ($store.ref && $store.ref > hovered.datum.build_id) {
+        leftDensity = hovered.datum[densityMetricType];
+        rightDensity = ref[densityMetricType];
+        leftAudienceValue = hovered.datum.audienceSize;
+        rightAudienceValue = ref.audienceSize;
+        leftSampleValue = hovered.datum.sample_count;
+        rightSampleValue = ref.sample_count;
+        leftPoints = leftPointsForAggComparison(
+          data,
+          pointMetricType,
+          hovered.datum
+        );
+        rightPoints = ref[pointMetricType];
+      } else {
+        leftDensity = ref[densityMetricType];
+        rightDensity = hovered.datum[densityMetricType];
+        leftAudienceValue = ref.audienceSize;
+        rightAudienceValue = hovered.datum.audienceSize;
+        leftSampleValue = ref.sample_count;
+        rightSampleValue = hovered.datum.sample_count;
+        leftPoints = ref[pointMetricType];
+        rightPoints = leftPointsForAggComparison(
+          data,
+          pointMetricType,
+          hovered.datum
+        );
+      }
     }
   } else if ($showContextMenu) {
     hovered = lastHoverValue;
@@ -303,12 +343,8 @@
       : ref.label}
     colorMap={binColorMap}
     {yTickFormatter}
-    leftPoints={leftPointsForAggComparison(
-      data,
-      pointMetricType,
-      hovered.datum
-    )}
-    rightPoints={ref[pointMetricType]}
+    {leftPoints}
+    {rightPoints}
     {activeBins}
     {yDomain}
     dataVolume={data.length}
@@ -332,7 +368,7 @@
             direction={-1}
             density={data.length < 2 || !hovered.datum
               ? data[0][densityMetricType]
-              : hovered.datum[densityMetricType]}
+              : leftDensity}
             width={(explorerComparisonSmallMultiple.width -
               explorerComparisonSmallMultiple.left -
               explorerComparisonSmallMultiple.right) /
@@ -342,7 +378,7 @@
         {#if ref && ref[densityMetricType]}
           <AdHocViolin
             start={justOne ? lp : (lp + rp) / 2}
-            density={ref[densityMetricType]}
+            density={rightDensity}
             width={justOne
               ? rp - lp - VIOLIN_PLOT_OFFSET * 2
               : (explorerComparisonSmallMultiple.width -
@@ -400,8 +436,8 @@
       <CompareClientVolumeGraph
         description={compareDescription(clientVolumeOverTimeTitle)}
         yDomain={yClientsDomain}
-        hoverValue={hovered.datum ? hovered.datum.audienceSize : 0}
-        referenceValue={ref.audienceSize} />
+        {leftAudienceValue}
+        {rightAudienceValue} />
     </div>
   {/if}
   {#if $store.countView === 'samples'}
@@ -426,8 +462,8 @@
           overTimeTitle('sampleVolume', aggregationLevel)
         )}
         yDomain={ySamplesDomain}
-        hoverValue={hovered.datum ? hovered.datum.sample_count : 0}
-        referenceValue={ref.sample_count} />
+        {leftSampleValue}
+        {rightSampleValue} />
     </div>
   {/if}
 </div>


### PR DESCRIPTION
This change includes:
- Match the violin plot direction to hovered/ref order. 
- Match the sample and client count compare graph to hovered/ref order as well.
- Change the label from "Hov"/"Ref" to "Left"/"Right" to better reflect the new UI

![2022-08-16 09 50 09](https://user-images.githubusercontent.com/28797553/184896789-f17d2599-7c2a-44b7-a636-ac00ad09c6d3.gif)

