### PR TITLE
Match hov/ref order of summary table and chart labels

### DIFF
--- a/src/components/explore/AggregationComparisonGraph.svelte
+++ b/src/components/explore/AggregationComparisonGraph.svelte
@@ -31,13 +31,13 @@
   export let yScaleType;
   export let key = Math.random().toString(36).substring(7);
 
-  let labelSet = ['LEFT', 'RIGHT'];
+  export let topLabels;
 
   if (dataVolume === 1) {
-    labelSet = [rightLabel];
+    topLabels = [rightLabel];
   }
 
-  export let xDomain = labelSet;
+  export let xDomain;
 
   let xScale;
   let yScale;
@@ -60,6 +60,7 @@
     dotsAndLines.setHover(leftPoints, dataVolume === 1);
   $: if (rightPoints && yScale)
     dotsAndLines.setReference(rightPoints, dataVolume === 1);
+  $: xDomain = topLabels;
 </script>
 
 <div>

--- a/src/components/explore/ComparisonSummary.svelte
+++ b/src/components/explore/ComparisonSummary.svelte
@@ -20,6 +20,8 @@
   export let showDiff = true;
   export let viewType;
   export let justOne;
+  export let hov;
+  export let ref;
 
   function percentChange(l, r) {
     return viewType === 'proportion' ? r - l : (r - l) / l;
@@ -29,15 +31,19 @@
 
   function createNewPercentiles(lVal, rVal, ks) {
     return ks.map((key) => {
+      // leftValue and rightValue are for display
       const leftValue = lVal ? lVal[key] : undefined;
       const rightValue = rVal ? rVal[key] : undefined;
+      // hovValue and refValue are used for percent change calculation
+      const hovValue = hov ? hov[key] : undefined;
+      const refValue = ref ? ref[key] : undefined;
       return {
         key,
         leftValue,
         rightValue,
         percentageChange:
           leftValue && rightValue
-            ? percentChange(leftValue, rightValue)
+            ? percentChange(hovValue, refValue)
             : undefined,
       };
     });

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -190,6 +190,7 @@
     hovered.datum
   );
   let rightPoints = ref[pointMetricType];
+  let topLabels = ['HOV.', 'REF.'];
 
   $: if (hoverValue.x) {
     if ($showContextMenu) {
@@ -203,6 +204,7 @@
         next: data[i.nextIndex],
       };
       if ($store.ref && $store.ref > hovered.datum.build_id) {
+        topLabels = ['HOV.', 'REF.'];
         leftDensity = hovered.datum[densityMetricType];
         rightDensity = ref[densityMetricType];
         leftAudienceValue = hovered.datum.audienceSize;
@@ -216,6 +218,7 @@
         );
         rightPoints = ref[pointMetricType];
       } else {
+        topLabels = ['REF.', 'HOV.'];
         leftDensity = ref[densityMetricType];
         rightDensity = hovered.datum[densityMetricType];
         leftAudienceValue = ref.audienceSize;
@@ -342,6 +345,7 @@
       ? formatBuildIDToDateString(ref.label)
       : ref.label}
     colorMap={binColorMap}
+    {topLabels}
     {yTickFormatter}
     {leftPoints}
     {rightPoints}
@@ -401,10 +405,12 @@
 
   <ComparisonSummary
     hovered={data.length === 1 || !!hovered.datum}
-    left={leftPointsForAggComparison(data, pointMetricType, hovered.datum)}
-    right={ref[pointMetricType]}
-    leftLabel={'HOV.'}
-    rightLabel={'REF.'}
+    left={leftPoints}
+    right={rightPoints}
+    hov={leftPointsForAggComparison(data, pointMetricType, hovered.datum)}
+    ref={ref[pointMetricType]}
+    leftLabel={topLabels[0]}
+    rightLabel={topLabels[1]}
     binLabel={summaryLabel}
     keySet={activeBins}
     colorMap={binColorMap}


### PR DESCRIPTION
Incorporate Slack feedback, namely:
- go back to using chart labels "HOV."/"REF.", instead of LEFT/RIGHT
- also apply the order swapping in comparison summary table
![2022-08-17 10 34 43](https://user-images.githubusercontent.com/28797553/185163276-9d1ea40a-234f-4f45-b770-401b2c5ccbb7.gif)

