### PR TITLE
Fix hov/ref swapping edge case when ref point isn't initialized yet

### DIFF
--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -203,7 +203,10 @@
         previous: data[i.previousIndex],
         next: data[i.nextIndex],
       };
-      if ($store.ref && $store.ref > hovered.datum.build_id) {
+      if (
+        ($store.ref && $store.ref > hovered.datum.build_id) ||
+        (!$store.ref && ref > hovered.datum.build_id)
+      ) {
         topLabels = ['HOV.', 'REF.'];
         leftDensity = hovered.datum[densityMetricType];
         rightDensity = ref[densityMetricType];
@@ -217,7 +220,8 @@
           hovered.datum
         );
         rightPoints = ref[pointMetricType];
-      } else {
+      }
+      if ($store.ref && $store.ref < hovered.datum.build_id) {
         topLabels = ['REF.', 'HOV.'];
         leftDensity = ref[densityMetricType];
         rightDensity = hovered.datum[densityMetricType];


### PR DESCRIPTION
Another Slack feedback: on a new page, when ref hasn't been initialized, glam uses a default ref value. The initial conditions didn't include this case, so the initial ref/hov order was wrong. This change fixes that.

Before: on a new page when ref is all the way to the right, the ref/hov order is wrong

![CleanShot 2022-08-17 at 12 36 05@2x](https://user-images.githubusercontent.com/28797553/185194739-00f49e9a-90c7-49f0-b6ea-baf2a6dd521c.png)


After

![CleanShot 2022-08-17 at 12 35 02@2x](https://user-images.githubusercontent.com/28797553/185194564-398ba776-7bfd-4b47-b1f7-b5a3e860fe00.png)
