### PR TITLE
Fix FOGAggregationView to display FOG metrics

### DIFF
--- a/glam/api/models.py
+++ b/glam/api/models.py
@@ -107,7 +107,6 @@ class FOGAggregation(AbstractGleanAggregation):
 class FOGAggregationView(AbstractGleanAggregation):
     class Meta:
         managed = False
-        abstract = True
         db_table = "view_glam_fog_aggregation"
 
 


### PR DESCRIPTION
This reverts https://github.com/mozilla/glam/pull/2084#pullrequestreview-1067086819, which introduced an error that prevented FOG metrics from being fetched and displayed.