### PR TITLE
Fetch top 3 versions per probe before querying for data

### DIFF
--- a/glam/api/views.py
+++ b/glam/api/views.py
@@ -196,21 +196,24 @@ def get_glean_aggregations(request, **kwargs):
     }
     model = MODEL_MAP[kwargs.get("product")]
     product = kwargs.get("product")
+    probe = kwargs["probe"]
 
     num_versions = kwargs.get("versions", 3)
     try:
-        max_version = int(model.objects.aggregate(Max("version"))["version__max"])
+        versions = list(
+            model.objects.filter(Q(metric=probe))
+            .order_by("-version")
+            .values_list("version", flat=True)
+            .distinct("version")[:num_versions]
+        )
     except (ValueError, KeyError):
         raise ValidationError("Query version cannot be determined")
     except TypeError:
-        # This happens when `version_max` is NULL and cannot be converted to an int,
+        # This happens when `version` is NULL,
         # suggesting that we have no data for this model.
         raise NotFound("No data found for the provided parameters")
 
-    versions = list(map(str, range(max_version, max_version - num_versions, -1)))
-
     app_id = kwargs["app_id"]
-    probe = kwargs["probe"]
     ping_type = kwargs["ping_type"]
     os = kwargs.get("os", "*")
 


### PR DESCRIPTION
This fixes a problem that we've been seeing from time that was caused by unofficial builds with high version numbers leaking into ETL aggregates.
When probes from such build (say `999` when the latest official build is `106`) were in the database, GLAM backend was filtering for versions (`999`, `998`, `997`) when fetching probe data which in most cases returned empty results (because usually these unofficial versions did not contribute much data).
This PR makes backend to first fetch 3 latest versions for the requested probe that exist in the aggregate table which should fix the problem.

This is inspired by https://github.com/mozilla/glam/pull/1895 by @cmharlow, the only difference being the metric filtering that is added here.