### PR TITLE
Make it more clear that View SQL query is not available for FOG yet

### DIFF
--- a/src/components/SqlModal.svelte
+++ b/src/components/SqlModal.svelte
@@ -246,8 +246,8 @@
   </div>
   <div slot="title">Explore the data...</div>
   <div>
-    {#if $store.product == 'fog'}
-      <p>This feature is not available for Glean metrics yet.</p>
+    {#if $store.product === 'fog'}
+      <p>Sorry, this feature is not available for Glean metrics yet.</p>
     {:else}
       <p>
         The following SQL query can be copy/pasted and used in the BigQuery

--- a/src/components/SqlModal.svelte
+++ b/src/components/SqlModal.svelte
@@ -246,10 +246,14 @@
   </div>
   <div slot="title">Explore the data...</div>
   <div>
-    <p>
-      The following SQL query can be copy/pasted and used in the BigQuery
-      console to explore this data further:
-    </p>
+    {#if $store.product == 'fog'}
+      <p>This feature is not available for Glean metrics yet.</p>
+    {:else}
+      <p>
+        The following SQL query can be copy/pasted and used in the BigQuery
+        console to explore this data further:
+      </p>
+    {/if}
     <ul>
       {#each tabs as tab}
         <li class:active={activeTab === tab.id}>


### PR DESCRIPTION
Recently we got a user asking why it doesn't return anything when they clicked on View SQL query for FOG metric. Even though we're working on providing it, until we have it available let's add some UI signal that it's not available yet.