### PR TITLE
Fix big number formatting for client volume graph

### DIFF
--- a/src/components/explore/CompareClientVolumeGraph.svelte
+++ b/src/components/explore/CompareClientVolumeGraph.svelte
@@ -7,7 +7,7 @@
   import Tweenable from '../Tweenable.svelte';
   import ChartTitle from './ChartTitle.svelte';
   import { compareClientCountsGraph, tween } from '../../utils/constants';
-  import { formatCount } from '../../utils/formatters';
+  import { formatMillion } from '../../utils/formatters';
 
   export let description;
   export let leftAudienceValue;
@@ -69,7 +69,10 @@
           location: 'top',
           alignment: 'center',
         }} />
-      <Axis side="right" tickFormatter={formatCount} ticks={yScale.ticks(4)} />
+      <Axis
+        side="right"
+        tickFormatter={formatMillion}
+        ticks={yScale.ticks(4)} />
     </g>
     <g slot="body" let:top let:bottom let:xScale let:yScale>
       <Tweenable params={tween} value={rightAudienceValue} let:tweenValue={tw}>


### PR DESCRIPTION
Upon checking on dev I realized that we should also add the number formatting to the compare chart as well. 

On dev currently: https://dev.glam.nonprod.dataops.mozgcp.net/firefox/probe/loaded_tab_count/explore?channel=release&currentPage=1&process=parent
<img width="756" alt="CleanShot 2022-09-13 at 12 12 44@2x" src="https://user-images.githubusercontent.com/28797553/189953000-5a25b7e1-b3cb-42b6-8f19-8040f7ecdef9.png">

After:
<img width="681" alt="CleanShot 2022-09-13 at 12 17 01@2x" src="https://user-images.githubusercontent.com/28797553/189953838-92485169-c2bd-47f2-ad82-7a4f79fe6962.png">

