### PR TITLE
Don't use default yDomain scale for timing distributions

### DIFF
--- a/src/components/explore/AggregationsOverTimeGraph.svelte
+++ b/src/components/explore/AggregationsOverTimeGraph.svelte
@@ -200,7 +200,11 @@
     ) {
       // do not change yDomain when all percentiles are selected
       // (we want the graph to match the violin plot initially)
-      if ($store.visiblePercentiles.length === 5) return yDomain;
+      if (
+        $store.visiblePercentiles.length === 5 &&
+        data[0].metric_type !== 'timing_distribution'
+      )
+        return yDomain;
       visiblePercentiles.forEach((p) => {
         yData = yData.concat([...data.map((arr) => arr.percentiles[p])]);
       });


### PR DESCRIPTION
Because we want the line chart scale to match the violin plot's when the user first lands on the page, [we set the y-domain scale to be the default range if there are 5 (default) selected percentiles](https://github.com/mozilla/glam/blob/877daf4ababa56c6e984654bb9f9fe6e758696bc/src/components/explore/AggregationsOverTimeGraph.svelte#L203). However, there are cases when this doesn't work well, especially with timing distribution metrics, as recently reported in our Slack channel. 

This PR makes sure the y-domain for timing distributions is always within range. Let's discuss more in the group meeting to see whether or not we should remove this condition for all metrics.