### PR TITLE
Request up to 20 versions of data for all products

### DIFF
--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -112,7 +112,7 @@ export default {
       probe: storeValue.probeName,
       process: storeValue.productDimensions.process,
       aggregationLevel: storeValue.productDimensions.aggregationLevel,
-      versions: 10,
+      versions: 20,
     };
   },
   fetchData(params, appStore) {

--- a/src/config/glean.js
+++ b/src/config/glean.js
@@ -101,6 +101,7 @@ export const FIREFOX_ON_GLEAN = {
       ping_type: storeValue.productDimensions.ping_type,
       probe: storeValue.probeName,
       aggregationLevel: storeValue.productDimensions.aggregationLevel,
+      versions: 20,
     };
   },
   fetchData(params, appStore) {
@@ -266,6 +267,7 @@ export const FENIX = {
       ping_type: storeValue.productDimensions.ping_type,
       probe: storeValue.probeName,
       aggregationLevel: storeValue.productDimensions.aggregationLevel,
+      versions: 20,
     };
   },
   fetchData(params, appStore) {


### PR DESCRIPTION
This addresses 2 issues:
- fix bug #2145 (thanks @edugfilho for the investigation, I can confirm that adding `versions: 10` to the request will return 10 versions of data for Glean products)
- since we have more than 10 versions of data in our cloud database, I think it's more useful to request more -- up to 20 versions to make available under the "All" tab

<img width="694" alt="CleanShot 2022-10-25 at 01 40 54@2x" src="https://user-images.githubusercontent.com/28797553/197601094-2e06c958-37da-4e71-b7c7-0225e3685562.png">


