### PR TITLE
Remove workaround for probeinfo always returning gzip

### DIFF
--- a/glam/api/management/commands/import_probes.py
+++ b/glam/api/management/commands/import_probes.py
@@ -65,9 +65,7 @@ class Command(BaseCommand):
 
     def extract(self):
         # Read in all probes.
-        probes_dict = json.loads(
-            gzip.decompress(urllib.request.urlopen(self.PROBES_URL).read())
-        )
+        probes_dict = json.loads(urllib.request.urlopen(self.PROBES_URL).read())
         print("{} probes loaded from probe dictionary".format(len(probes_dict.keys())))
 
         # Filter probes by histograms or scalars only.


### PR DESCRIPTION
The endpoint no longer returns gzip content