### PR TITLE
Show Glean expiry version number along with expiry date

### DIFF
--- a/src/routing/pages/probe/GleanDetails.svelte
+++ b/src/routing/pages/probe/GleanDetails.svelte
@@ -18,7 +18,12 @@
 
   const parseYMD = timeParse('%Y-%m-%d');
   const mdY = timeFormat('%b %d, %Y');
-  const toNiceDate = (dt) => mdY(parseYMD(dt));
+
+  const expiryFormat = (expiry) => {
+    const date = parseYMD(expiry);
+    // if not null / never, expiry field can be a date or a version number
+    return date ? mdY(date) : `version ${expiry}`;
+  };
 
   const willNeverExpire = (expiry) =>
     expiry === 'never' || expiry === undefined || expiry === null;
@@ -221,7 +226,7 @@
         <dd>
           {willNeverExpire($store.probe.expires)
             ? 'never'
-            : toNiceDate($store.probe.expires)}
+            : expiryFormat($store.probe.expires)}
         </dd>
       </dl>
     </div>


### PR DESCRIPTION
As of currently, Glean apps allow expiry information to be either a version number or a date, if it's not `never` or `null`. This PR handles displaying this information on the front-end.

The example below shows how we handle the expiry date if it's a version number.

![CleanShot 2022-11-08 at 07 18 16@2x](https://user-images.githubusercontent.com/28797553/200562030-708d0450-d756-45ba-834c-c63cf337ebe6.png)

Let's only merge this once https://github.com/mozilla/glean-dictionary/pull/1499 is merged and deployed to prod.
