### PR TITLE
Validate metric type before fetching aggregation data (fixes #2199)

### DIFF
--- a/src/components/errors/DataErrorGeneric.svelte
+++ b/src/components/errors/DataErrorGeneric.svelte
@@ -1,8 +1,15 @@
 <script>
   import GlamErrorShapes from './GlamErrorShapes.svelte';
+  import { store } from '../../state/store';
 
   export let reason;
   export let moreInformation;
+
+  const DICTIONARY_LINKS = {
+    firefox: `https://probes.telemetry.mozilla.org/?view=detail&probeId=${$store.probe.id}`,
+    fenix: `https://dictionary.telemetry.mozilla.org/apps/fenix/metrics/${$store.probeName}`,
+    fog: `https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/${$store.probeName}`,
+  };
 </script>
 
 <style>
@@ -65,6 +72,11 @@
   <div class="data-error-msg__reason">{reason}</div>
   {#if moreInformation}
     <div class="data-error-msg__more-information">{moreInformation}</div>
+    <div class="data-error-msg__more-information">
+      For more resources, visit the <a href={DICTIONARY_LINKS[$store.product]}
+        >dictionary</a
+      >.
+    </div>
   {/if}
   <div class="data-error-msg__call-to-action">
     If you think this is a bug, report this on the

--- a/src/config/firefox-desktop.js
+++ b/src/config/firefox-desktop.js
@@ -122,7 +122,7 @@ export default {
       const metricType = payload.response[0].metric_type;
       validate(payload, (p) => {
         noResponse(p);
-        noUnknownMetrics(p, Object.keys(this.probeView));
+        noUnknownMetrics(Object.keys(this.probeView), metricType);
       });
       const viewType =
         this.probeView[metricType] === 'categorical'

--- a/src/utils/data-validation.js
+++ b/src/utils/data-validation.js
@@ -1,6 +1,5 @@
-export const noUnknownMetrics = (payload, probeViews = []) => {
+export const noUnknownMetrics = (probeViews = [], metricType) => {
   // Ensure the probe metric type is in our list of `probeView`s.
-  const metricType = payload.response[0].metric_type;
   if (!probeViews.includes(metricType)) {
     const er = new Error('This metric type is currently unsupported.');
     er.moreInformation =


### PR DESCRIPTION
For each product, we have a list of metrics we're currently supporting. If a metric type is not in this list, we throw an error message. However, because the type validation step is after fetching data, if there's no aggregation data for a type, it throws an ambiguous 404 error instead of "metric not supported", which causes problems like #2199.

This PR fixes the problem by adding the type check before we fetch aggregation data for Fenix and FOG. In the error message, we also link out to the dictionary to direct users to more resources.

Events should now throw the correct error message. Example:

<img width="1068" alt="CleanShot 2022-11-14 at 17 21 34@2x" src="https://user-images.githubusercontent.com/28797553/201780439-f5ef2272-464b-4bc8-be9a-73261713e857.png">

