### PR TITLE
Handle Expired labels for version-based expiry

### DIFF
--- a/src/routing/pages/probe/GleanDetails.svelte
+++ b/src/routing/pages/probe/GleanDetails.svelte
@@ -34,7 +34,7 @@
     // if expires is a number, ie a version number, then compare it
     // to the latest release version (only applied to Fx products)
     if (!Number.isNaN(item.expires) && item.latest_fx_release_version) {
-      return Number(item.latest_fx_release_version) > item.expires;
+      return Number(item.latest_fx_release_version) >= item.expires;
     }
     return new Date() > new Date(item.expires);
   };

--- a/src/routing/pages/probe/GleanDetails.svelte
+++ b/src/routing/pages/probe/GleanDetails.svelte
@@ -31,6 +31,11 @@
   // taken from glean dictionary
   const isExpired = (item) => {
     if (willNeverExpire(item.expires)) return false;
+    // if expires is a number, ie a version number, then compare it
+    // to the latest release version (only applied to Fx products)
+    if (!Number.isNaN(item.expires) && item.latest_fx_release_version) {
+      return Number(item.latest_fx_release_version) > item.expires;
+    }
     return new Date() > new Date(item.expires);
   };
 


### PR DESCRIPTION
For version-based expiry we're incorrectly labeling them as "expired" (eg [this metric](https://dev.glam.nonprod.dataops.mozgcp.net/fenix/probe/perf_awesomebar_bookmark_suggestions/explore?aggType=avg&currentPage=1)). I fixed this on the Glean Dictionary already but still need to do this for GLAM.

