### PR TITLE
Improve custom distribution check

### DIFF
--- a/src/config/glean.js
+++ b/src/config/glean.js
@@ -9,6 +9,17 @@ import {
   noUnknownMetrics,
 } from '../utils/data-validation';
 
+export const SUPPORTED_METRICS = [
+  'categorical',
+  'linear',
+  'custom_distribution',
+  'labeled_counter',
+  'memory_distribution',
+  'quantity',
+  'timespan',
+  'timing_distribution',
+];
+
 export const FIREFOX_ON_GLEAN = {
   label: 'Firefox on Glean',
   key: 'fog',
@@ -119,7 +130,7 @@ export const FIREFOX_ON_GLEAN = {
 
       validate(payload, (p) => {
         noResponse(p);
-        noUnknownMetrics(Object.keys(this.probeView), metricType);
+        noUnknownMetrics(SUPPORTED_METRICS, metricType);
       });
       const viewType =
         this.probeView[metricType] === 'categorical'
@@ -283,7 +294,7 @@ export const FENIX = {
     });
 
     const metricType = appStore.getState().probe.type;
-    noUnknownMetrics(Object.keys(this.probeView), metricType);
+    noUnknownMetrics(SUPPORTED_METRICS, metricType);
 
     return getProbeData(params).then((payload) => {
       const { aggregationLevel } = appStore.getState().productDimensions;

--- a/src/utils/data-validation.js
+++ b/src/utils/data-validation.js
@@ -1,6 +1,9 @@
-export const noUnknownMetrics = (probeViews = [], metricType) => {
+export const noUnknownMetrics = (supportedMetrics = [], metricType) => {
   // Ensure the probe metric type is in our list of `probeView`s.
-  if (!probeViews.includes(metricType)) {
+  if (
+    !supportedMetrics.includes(metricType) ||
+    !metricType.includes('custom_distribution')
+  ) {
     const er = new Error('This metric type is currently unsupported.');
     er.moreInformation =
       `GLAM doesn't yet know how to aggregate "${metricType}" type metrics. ` +


### PR DESCRIPTION
Explicitly state which metrics we support by having a separate list of the official metric names. 

Currently we rely on another list (probeView, used to determine which graph to display) which only checks for custom_distribution_linear or custom_distribution_exponential, thus excludes all custom_distribution -- the metric type we get back from the glean dictionary.