### PR TITLE
Fix sample chart not showing due to bad data

### DIFF
--- a/src/components/explore/ToplineMetrics.svelte
+++ b/src/components/explore/ToplineMetrics.svelte
@@ -108,9 +108,9 @@
                 class:topline__client-count--highlighted={hovered &&
                   hovered.sample_count > tweenValue}
               >
-                {formatCount(hovered.sample_count)}
+                {hovered.sample_count ? formatCount(hovered.sample_count) : ''}
               </span>
-              samples
+              {hovered.sample_count ? 'samples' : 'No sample data available'}
             {/if}
           </div>
           {#if hovered}

--- a/src/utils/probe-utils.js
+++ b/src/utils/probe-utils.js
@@ -3,7 +3,10 @@ export function clientCounts(arr) {
 }
 
 export function sampleCounts(arr) {
-  return arr.map((a) => ({ totalSample: a.sample_count, label: a.label }));
+  return arr.map((a) => ({
+    totalSample: a.sample_count ? a.sample_count : 0,
+    label: a.label,
+  }));
 }
 
 function uniques(d, k) {


### PR DESCRIPTION
Sample chart was not working on dev and prod due to bad sample data (`null`) that got in between April 9 and May 8 this year.