### PR TITLE
Fix transformedPercentiles not found error

### DIFF
--- a/src/components/explore/AggregationsOverTimeGraph.svelte
+++ b/src/components/explore/AggregationsOverTimeGraph.svelte
@@ -66,7 +66,7 @@
     return actives.map((a) => ({
       bin: a,
       series: d.map((di) => {
-        const value = di[accessor][a];
+        const value = di[accessor] && di[accessor][a];
         return {
           y: value,
           x: di.label,
@@ -215,7 +215,9 @@
         visiblePercentiles.forEach((p) => {
           yData = yData.concat([
             ...data.map(
-              (arr) => arr[getTransformedPercentileName(normType)][p]
+              (arr) =>
+                arr[getTransformedPercentileName(normType)] &&
+                arr[getTransformedPercentileName(normType)][p]
             ),
           ]);
         });


### PR DESCRIPTION
Fixing current error on dev:

<img width="784" alt="CleanShot 2023-10-05 at 16 47 34@2x" src="https://github.com/mozilla/glam/assets/28797553/8bc9edd7-d0f7-4a50-b214-ed5b776fd325">
