### PR TITLE
Distribution comparison chart supports Glean probes

### DIFF
--- a/src/components/ChartContextMenu.svelte
+++ b/src/components/ChartContextMenu.svelte
@@ -95,7 +95,9 @@
   const canCompareDistributions = function () {
     return (
       ['firefox', 'fog'].includes($store.product) &&
-      ['histogram', 'scalar'].concat(GLEAN_METRICS).includes($store.probe.type) &&
+      ['histogram', 'scalar']
+        .concat(GLEAN_METRICS)
+        .includes($store.probe.type) &&
       !!document.getElementById(distViewButtonId)
     );
   };

--- a/src/components/ChartContextMenu.svelte
+++ b/src/components/ChartContextMenu.svelte
@@ -5,6 +5,7 @@
   import ZoomIn from './icons/ZoomIn.svelte';
   import Graphs from './icons/Graphs.svelte';
   import BarGraph from './icons/BarGraph.svelte';
+  import { SUPPORTED_METRICS as GLEAN_METRICS } from '../config/glean';
 
   export let data;
   export let x;
@@ -93,8 +94,8 @@
 
   const canCompareDistributions = function () {
     return (
-      $store.product === 'firefox' &&
-      ['histogram', 'scalar'].includes($store.probe.type) &&
+      ['firefox', 'fog'].includes($store.product) &&
+      ['histogram', 'scalar'].concat(GLEAN_METRICS).includes($store.probe.type) &&
       !!document.getElementById(distViewButtonId)
     );
   };

--- a/src/components/explore/DistributionChart.svelte
+++ b/src/components/explore/DistributionChart.svelte
@@ -41,7 +41,8 @@
     opacity: 0;
   }
   .hovd:hover {
-    opacity: 0.3;
+    opacity: 1;
+    fill: var(--cool-gray-100);
     z-index: 999;
   }
 </style>

--- a/src/components/explore/DistributionComparisonGraph.svelte
+++ b/src/components/explore/DistributionComparisonGraph.svelte
@@ -21,6 +21,15 @@
 
   let bins = density.map((d) => d.bin);
 
+  const getXTicks = (data) => {
+    // for probes with too many data points, we only want to get
+    // a limited amount of ticks to avoid crowding the x axis
+    if (data.length < 20) {
+      return data;
+    }
+    return data.filter((value, index) => (index + 1) % 10 === 0);
+  };
+
   let allTicks = Array.from(
     Array(Math.ceil(topTick * 100) + tickIncrement).keys()
   )
@@ -63,7 +72,7 @@
       <slot name="glam-body" {top} {bottom} {left} {right} {yScale} {xScale} />
       <Axis
         side="bottom"
-        ticks={density.map((d) => d.bin)}
+        ticks={getXTicks(bins)}
         tickFormatter={xTickFormatter}
       />
       <Axis side="left" {ticks} tickFormatter={yTickFormatter} />

--- a/src/components/explore/DistributionComparisonGraph.svelte
+++ b/src/components/explore/DistributionComparisonGraph.svelte
@@ -24,9 +24,7 @@
   const getXTicks = (data) => {
     // for probes with too many data points, we only want to get
     // a limited amount of ticks to avoid crowding the x axis
-    if (data.length < 20) {
-      return data;
-    }
+    if (data.length < 20) return data;
     return data.filter((value, index) => (index + 1) % 10 === 0);
   };
 


### PR DESCRIPTION
This adds support to Glean probes to the Distribution Comparison chart.
I tested this with a few glean probes and the chart does not look awesome, due to a couple things:
* Seems like different builds' histograms have different number of buckets, which prevents both charts proper alignment and leads to confusion during comparison. This effect seems to be already present in the violin plot. This seems to be a data problem.
* A high number of buckets makes the x-axis labels overlap and impossible to read. This can be addressed in the visualization components, but it's hard because AFAIK [graph-paper](https://github.com/graph-paper-org/graph-paper) does not allow the x-axis to skip labels or anything that would help accomplish this
![Screenshot 2023-11-06 at 4 18 40 PM](https://github.com/mozilla/glam/assets/5804462/c8b42aab-6631-41ef-abe3-91f00db9039a)
