### PR TITLE
Fix #2578 - Distribution Comparison slowness/OOM for non-norm data

### DIFF
--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -306,36 +306,39 @@
   />
   <slot name="summary" />
 </div>
-{#if distViewTopChartData && distViewBottomChartData}
-  <DistributionComparisonModal
-    {densityMetricType}
-    topChartData={distViewTopChartData}
-    bottomChartData={distViewBottomChartData}
-    {distViewButtonId}
-  >
-    <div slot="comparisonSummary" class="dist-comp-percentile-tbl">
-      <ComparisonSummary
-        hovered={data.length === 1 || !!hovered.datum}
-        left={leftPoints}
-        right={rightPoints}
-        hov={leftPointsForAggComparison(data, pointMetricType, hovered.datum)}
-        ref={ref[pointMetricType]}
-        leftLabel={topLabels[0]}
-        rightLabel={topLabels[1]}
-        binLabel={summaryLabel}
-        keySet={activeBins}
-        colorMap={binColorMap}
-        valueFormatter={summaryNumberFormatter}
-        keyFormatter={comparisonKeyFormatter}
-        showLeft={data.length > 1}
-        showDiff={data.length > 1}
-        viewType={$store.viewType}
-        {justOne}
-        title="Percentiles"
-      />
-    </div>
-  </DistributionComparisonModal>
-{/if}
+{#key distViewTopChartData}
+  {#key distViewBottomChartData}
+    <DistributionComparisonModal
+      {densityMetricType}
+      topChartData={distViewTopChartData}
+      bottomChartData={distViewBottomChartData}
+      {distViewButtonId}
+    >
+      <div slot="comparisonSummary" class="dist-comp-percentile-tbl">
+        <ComparisonSummary
+          hovered={data.length === 1 || !!hovered.datum}
+          left={leftPoints}
+          right={rightPoints}
+          hov={leftPointsForAggComparison(data, pointMetricType, hovered.datum)}
+          ref={ref[pointMetricType]}
+          leftLabel={topLabels[0]}
+          rightLabel={topLabels[1]}
+          binLabel={summaryLabel}
+          keySet={activeBins}
+          colorMap={binColorMap}
+          valueFormatter={summaryNumberFormatter}
+          keyFormatter={comparisonKeyFormatter}
+          showLeft={data.length > 1}
+          showDiff={data.length > 1}
+          viewType={$store.viewType}
+          {justOne}
+          title="Percentiles"
+        />
+      </div>
+    </DistributionComparisonModal>
+  {/key}
+{/key}
+
 
 <div class="graphic-and-summary" class:no-line-chart={justOne}>
   <div>


### PR DESCRIPTION
I don't know exactly the root cause of the issue, but during my tests I noticed that the slowness/OOM happened whenever the `DistributionComparisonModal` component wasn't re-created after changing the normalization type from `Client Id` to `None`. So now I'm forcing a re-creation of the `DistributionComparisonModal` component every time any of the charts (top or bottom chart) data changes.