### PR TITLE
Fix # 2573 - Migrate windows + release sample counts to reflect sampling (10x)

### DIFF
--- a/glam/api/migrations/0026_fix_windows_release_sample_count.py
+++ b/glam/api/migrations/0026_fix_windows_release_sample_count.py
@@ -4,21 +4,22 @@ configs = [
     {
         "model": "desktopreleaseaggregation",
         "pretty_name": "Desktop",
-        "filter": {"os": "Windows"}
+        "filter": {"os": "Windows"},
     },
     # TODO: Leaving this here in case we need to migrate fog in the future
-    #{
+    # {
     #    "model": "fogaggregation",
     #    "pretty_name": "FOG",
     #    "filter": {"os": "Windows", "app_id": "release"}
-    #}
+    # }
 ]
 
-def do_migration(apps, fwd = True):
+
+def do_migration(apps, fwd=True):
     for config in configs:
-        model = config['model']
+        model = config["model"]
         print(f"\nMigrating {config['pretty_name']}...")
-        table = apps.get_model('api', model).objects.filter(**config['filter'])
+        table = apps.get_model("api", model).objects.filter(**config["filter"])
         total = table.count()
         table_iter = table.iterator(100000)
         for i, instance in enumerate(table_iter):
@@ -28,10 +29,15 @@ def do_migration(apps, fwd = True):
                 instance.total_sample /= 10
             instance.save()
             if i % 10000 == 0 or i + 1 == total:
-                print(f"{i} out of {total} rows migrated ({round((i+1)/total*100, 1)}%)", end='\r')
+                print(
+                    f"{i} out of {total} rows migrated ({round((i+1)/total*100, 1)}%)",
+                    end="\r",
+                )
+
 
 def multiply_sample_count_by_10(apps, schema_editor):
     do_migration(apps)
+
 
 def divide_sample_count_by_10(apps, schema_editor):
     do_migration(apps, False)
@@ -43,9 +49,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(code=multiply_sample_count_by_10, reverse_code=migrations.RunPython.noop),
-        migrations.RunSQL("REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_desktop_release_aggregation",
-                          "REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_desktop_release_aggregation"),
-        migrations.RunPython(code=migrations.RunPython.noop, reverse_code=divide_sample_count_by_10),
-
+        migrations.RunPython(
+            code=multiply_sample_count_by_10, reverse_code=migrations.RunPython.noop
+        ),
+        migrations.RunSQL(
+            "REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_desktop_release_aggregation",
+            "REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_desktop_release_aggregation",
+        ),
+        migrations.RunPython(
+            code=migrations.RunPython.noop, reverse_code=divide_sample_count_by_10
+        ),
     ]

--- a/glam/api/migrations/0026_fix_windows_release_sample_count.py
+++ b/glam/api/migrations/0026_fix_windows_release_sample_count.py
@@ -1,0 +1,51 @@
+from django.db import migrations
+
+configs = [
+    {
+        "model": "desktopreleaseaggregation",
+        "pretty_name": "Desktop",
+        "filter": {"os": "Windows"}
+    },
+    # TODO: Leaving this here in case we need to migrate fog in the future
+    #{
+    #    "model": "fogaggregation",
+    #    "pretty_name": "FOG",
+    #    "filter": {"os": "Windows", "app_id": "release"}
+    #}
+]
+
+def do_migration(apps, fwd = True):
+    for config in configs:
+        model = config['model']
+        print(f"\nMigrating {config['pretty_name']}...")
+        table = apps.get_model('api', model).objects.filter(**config['filter'])
+        total = table.count()
+        table_iter = table.iterator(100000)
+        for i, instance in enumerate(table_iter):
+            if fwd:
+                instance.total_sample *= 10
+            else:
+                instance.total_sample /= 10
+            instance.save()
+            if i % 10000 == 0 or i + 1 == total:
+                print(f"{i} out of {total} rows migrated ({round((i+1)/total*100, 1)}%)", end='\r')
+
+def multiply_sample_count_by_10(apps, schema_editor):
+    do_migration(apps)
+
+def divide_sample_count_by_10(apps, schema_editor):
+    do_migration(apps, False)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0025_non_normalized_aggregations"),
+    ]
+
+    operations = [
+        migrations.RunPython(code=multiply_sample_count_by_10, reverse_code=migrations.RunPython.noop),
+        migrations.RunSQL("REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_desktop_release_aggregation",
+                          "REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_desktop_release_aggregation"),
+        migrations.RunPython(code=migrations.RunPython.noop, reverse_code=divide_sample_count_by_10),
+
+    ]

--- a/glam/api/migrations/0027_fix_fog_user_count_after_sampling.py
+++ b/glam/api/migrations/0027_fix_fog_user_count_after_sampling.py
@@ -2,15 +2,10 @@ from django.db import migrations
 
 configs = [
     {
-        "model": "desktopreleaseaggregation",
-        "pretty_name": "Desktop",
-        "filter": {"os": "Windows"},
-    },
-    {
         "model": "fogaggregation",
         "pretty_name": "FOG",
         "filter": {"os": "Windows", "app_id": "release", "version__gt": 118},
-    },
+    }
 ]
 
 
@@ -23,9 +18,9 @@ def do_migration(apps, fwd=True):
         table_iter = table.iterator(100000)
         for i, instance in enumerate(table_iter):
             if fwd:
-                instance.total_sample *= 10
+                instance.total_users *= 10
             else:
-                instance.total_sample /= 10
+                instance.total_users /= 10
             instance.save()
             if i % 10000 == 0 or i + 1 == total:
                 print(
@@ -35,32 +30,28 @@ def do_migration(apps, fwd=True):
     print("\nRefreshing views...")
 
 
-def multiply_sample_count_by_10(apps, schema_editor):
+def multiply_user_count_by_10(apps, schema_editor):
     do_migration(apps)
 
 
-def divide_sample_count_by_10(apps, schema_editor):
+def divide_user_count_by_10(apps, schema_editor):
     do_migration(apps, False)
 
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("api", "0025_non_normalized_aggregations"),
+        ("api", "0026_fix_windows_release_sample_count"),
     ]
 
     operations = [
         migrations.RunPython(
-            code=multiply_sample_count_by_10, reverse_code=migrations.RunPython.noop
-        ),
-        migrations.RunSQL(
-            "REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_desktop_release_aggregation",
-            reverse_sql="REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_desktop_release_aggregation",
+            code=multiply_user_count_by_10, reverse_code=migrations.RunPython.noop
         ),
         migrations.RunSQL(
             "REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_fog_aggregation",
             reverse_sql="REFRESH MATERIALIZED VIEW CONCURRENTLY view_glam_fog_aggregation",
         ),
         migrations.RunPython(
-            code=migrations.RunPython.noop, reverse_code=divide_sample_count_by_10
+            code=migrations.RunPython.noop, reverse_code=divide_user_count_by_10
         ),
     ]


### PR DESCRIPTION
Fixes https://github.com/mozilla/glam/issues/2573
Needs to be merged before its ETL counterpart https://github.com/mozilla/bigquery-etl/pull/4581
This fixes:
- Existing sample counts for Windows - Release probes in legacy telemetry and FOG

This does not fix:
 - Existing sample counts for probes when `all OS` + Release is selected. Because that is a much harder migration - both implementation and execution. I plan to start calculating counts for `all OS/build_id/others`on the glam server.

I ran this migration - back and forth - on my local instance and it's working gud