### PR TITLE
Filter out empty non-normalized data

### DIFF
--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -39,7 +39,26 @@
 
   import DistributionComparisonModal from '../DistributionComparisonModal.svelte';
 
-  export let data;
+  export let normalizedData;
+
+  const filterData = (normData, normType) =>
+    // historical context: because non-normalized data
+    // is added to the etl later, there exists
+    // a time period where we don't have non-normalized
+    // data which caused the graph to break.
+    // so, we filter out these empty data points.
+    normType === 'non_normalized'
+      ? normData.filter((d) => d.non_norm_histogram !== '')
+      : normData;
+
+  let data = filterData(
+    normalizedData,
+    $store.productDimensions.normalizationType
+  );
+  $: data = filterData(
+    normalizedData,
+    $store.productDimensions.normalizationType
+  );
   export let key;
   export let timeHorizon;
   export let aggregationLevel;

--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -186,7 +186,7 @@
                 aggregationLevel
               )}
               summaryLabel="cat."
-              data={selectedData}
+              normalizedData={selectedData}
               activeBins={activeBuckets}
               {timeHorizon}
               binColorMap={bucketColorMap}

--- a/src/components/explore/QuantileExplorerView.svelte
+++ b/src/components/explore/QuantileExplorerView.svelte
@@ -160,7 +160,7 @@
                 aggregationLevel
               )}
               summaryLabel="perc."
-              data={selectedData}
+              normalizedData={selectedData}
               activeBins={percentiles}
               {timeHorizon}
               markers={$firefoxVersionMarkers}


### PR DESCRIPTION
Currently if we switch the time horizon to "All" with non-normalized data, the graph will break. As non-normalized data was added to the ETL later, there is period in the past where non-normalized data hadn't exist yet, so the solution here is to filter them out when users switch to viewing non-normalized data.