### PR TITLE
Fix distribution view for categorical probes

### DIFF
--- a/src/components/explore/ProportionExplorerView.svelte
+++ b/src/components/explore/ProportionExplorerView.svelte
@@ -26,7 +26,7 @@
     gatherAggregationTypes,
   } from '../../utils/probe-utils';
   import { numericStringsSort } from '../../utils/sort';
-  import { numHighlightedBuckets } from '../../config/shared';
+  import { getHistogramName, numHighlightedBuckets } from '../../config/shared';
 
   export let aggregationLevel = 'build_id';
   export let data;
@@ -121,6 +121,9 @@
       .sort(numericStringsSort);
   }
 
+  $: densityMetricType = getHistogramName(
+    $store.productDimensions.normalizationType
+  );
   $: selectAllCategories = $store.activeBuckets.length === bucketOptions.length;
 </script>
 
@@ -193,6 +196,7 @@
               showViolins={false}
               {aggregationLevel}
               pointMetricType={metricType}
+              {densityMetricType}
               yTickFormatter={metricType === 'proportions'
                 ? formatPercent
                 : formatCount}

--- a/src/config/shared.js
+++ b/src/config/shared.js
@@ -9,6 +9,10 @@ const dataNormalizationNameMap = {
     non_normalized: 'non_norm_percentiles',
     normalized: 'percentiles',
   },
+  proportions: {
+    non_normalized: 'non_norm_proportions',
+    normalized: 'proportions',
+  },
 };
 
 export const numHighlightedBuckets = 10;
@@ -50,6 +54,13 @@ export function getHistogramName(type = 'normalized') {
     throw new Error(`Unknown normalization type: ${type}`);
   }
   return dataNormalizationNameMap.histogram[type];
+}
+
+export function getProportionName(type = 'proportions') {
+  if (!Object.hasOwn(dataNormalizationNameMap.proportions, type)) {
+    throw new Error(`Unknown normalization type: ${type}`);
+  }
+  return dataNormalizationNameMap.proportions[type];
 }
 
 export function extractBucketMetadata(transformedData) {

--- a/src/utils/transform-data.js
+++ b/src/utils/transform-data.js
@@ -197,6 +197,7 @@ export const standardProportionTransformations = [
   toAudienceSize,
   addProportion,
   proportionsToCounts,
+  responseHistogramToGraphicFormat,
 ];
 
 export const standardQuantileTransformations = [


### PR DESCRIPTION
Fix the issue of distribution chart not working for categorical probes, such as [gc_minor_reason](https://glam.telemetry.mozilla.org/firefox/probe/gc_minor_reason/explore?activeBuckets=%5B%2210%22%2C%2214%22%2C%2247%22%2C%2218%22%2C%228%22%2C%2217%22%2C%2232%22%2C%225%22%2C%226%22%2C%2228%22%5D&currentPage=1). 