### PR TITLE
Increase search result limit

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -10,7 +10,7 @@ const FETCH_ERROR_MESSAGES = {
   code405: '405: Method not allowed.',
 };
 
-const DEFAULT_SEARCH_RESULTS_LIMIT = 30; // maximum number of results to show
+const DEFAULT_SEARCH_RESULTS_LIMIT = 100; // maximum number of results to show
 
 export async function getRandomProbes(numProbes, process) {
   const data = await fetch(randomProbeURL, {


### PR DESCRIPTION
When prepping for the presentation demo, we noticed that keeping result limit to only 30 filters out more probes that we would have wanted.