### PR TITLE
Reset query state upon landing on a new probe

### DIFF
--- a/src/components/regions/GLAMMark.svelte
+++ b/src/components/regions/GLAMMark.svelte
@@ -2,7 +2,7 @@
   import { tooltip as tooltipAction } from '@graph-paper/core/actions';
   import Logo from '../icons/GLAMLogo.svelte';
   import Text from '../icons/GLAMText.svelte';
-  import { store, currentQuery } from '../../state/store';
+  import { store } from '../../state/store';
 
   // GLAM logo will resize if screen size
   // is smaller than the viewport min width
@@ -23,7 +23,7 @@
   }
 </style>
 
-<a href={`/${$currentQuery}`} on:click={store.reset}>
+<a href={`/`} on:click={store.reset}>
   <h1
     use:tooltipAction={{
       text: 'The Glean Aggregated Metrics Dashboard',

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -58,7 +58,7 @@
         page.show(
           `/${$store.searchProduct}/probe/${results[
             focusedItem
-          ].name.toLowerCase()}/explore${$currentQuery}`
+          ].name.toLowerCase()}/explore?`
         );
         focusedItem = 0; // reset focused element
       }
@@ -119,6 +119,21 @@
       return 'firefox';
     }
     return undefined;
+  };
+
+  const onClick = () => {
+    // we need to clear the query state here, otherwise the query
+    // will persist into another probe which could break the page
+    store.reset(true);
+    store.setField('ref', '');
+
+    page.show(
+      `/${getProductDimensions(results[focusedItem])}/probe/${results[
+        focusedItem
+      ].name
+        .toLowerCase()
+        .replaceAll('.', '_')}/explore${$currentQuery}`
+    );
   };
 </script>
 
@@ -284,15 +299,7 @@
               role="option"
               id={searchResult.name}
               class:focused={focusedItem === i}
-              on:click={() => {
-                page.show(
-                  `/${getProductDimensions(
-                    results[focusedItem]
-                  )}/probe/${results[focusedItem].name
-                    .toLowerCase()
-                    .replaceAll('.', '_')}/explore${$currentQuery}`
-                );
-              }}
+              on:click={onClick}
               on:mouseover={() => {
                 focusedItem = i;
               }}

--- a/src/routing/pages/Home.svelte
+++ b/src/routing/pages/Home.svelte
@@ -7,7 +7,7 @@
   import QuantileSmallMultiple from '../../components/home/Quantile.svelte';
   import ProportionSmallMultiple from '../../components/home/Proportion.svelte';
   import RandomProbePlaceholder from '../../components/home/RandomProbePlaceholder.svelte';
-  import { store, currentQuery } from '../../state/store';
+  import { store } from '../../state/store';
   import { getRandomProbes } from '../../state/api';
 
   // TODO: add this to the upcoming config.js
@@ -134,7 +134,7 @@
               <a
                 class="probe-sm"
                 on:click={resetSearchProduct}
-                href={`/firefox/probe/${info.name}/explore${$currentQuery}`}
+                href={`/firefox/probe/${info.name}/explore?`}
               >
                 <div
                   class="probe-small-multiple"


### PR DESCRIPTION
Currently state values from store persist from probe to probe, which occasionally breaks the app e.g. when a ref value that exists for one probe doesn't for another. This PR makes sure the query state is reset every time we land on a new probe.