### PR TITLE
Clearer 404 error message

### DIFF
--- a/src/state/api.js
+++ b/src/state/api.js
@@ -6,7 +6,7 @@ const FETCH_ERROR_MESSAGES = {
   code5xx: 'Oh no! The server encountered an error.',
   code4xx: 'Oh no! Your client sent an invalid request.',
   code404:
-    '404: No data found for the selected dimensions. Try changing the dimension value, or check if the probe is still active.',
+    '404: No data found for the selected dimensions. Try changing the filters on the top-right corner of the page and check if the probe is still active.',
   code405: '405: Method not allowed.',
 };
 


### PR DESCRIPTION
Trying to make this error message clearer to avoid confusion such as in https://github.com/mozilla/glam/issues/2643

The result:
<img width="2622" alt="Screenshot 2024-01-16 at 12 52 00 PM" src="https://github.com/mozilla/glam/assets/5804462/92d4028d-7bb0-42eb-a797-c5375d35c6dc">
