### PR TITLE
Summary pct diff based on Ref instead of Hov

### DIFF
--- a/src/components/explore/ComparisonSummary.svelte
+++ b/src/components/explore/ComparisonSummary.svelte
@@ -44,7 +44,7 @@
         rightValue,
         percentageChange:
           leftValue && rightValue
-            ? percentChange(hovValue, refValue)
+            ? percentChange(refValue, hovValue)
             : undefined,
       };
     });


### PR DESCRIPTION
The percentage difference is currently based on the hovered value whereas, by definition, it should be based on reference value.