### PR TITLE
#2691 - (feat) Cumulative mode

### DIFF
--- a/src/components/DistributionComparisonModal.svelte
+++ b/src/components/DistributionComparisonModal.svelte
@@ -33,10 +33,15 @@
     return Math.min(topTick, 1);
   };
 
+  const roundVal = function(val) {
+    return Math.round(val * 10000)/10000;
+  }
+
   const makeCumulative = function(density) {
     let values = density.map((d) => d[valueSelector])
+    console.log(values)
     let cumulative = []
-    values.reduce((prev, curr, i) => cumulative[i] = Math.min(prev + curr, 1), values[0])
+    values.reduce((prev, curr, i) => cumulative[i] = Math.min(roundVal(prev + curr), 1), 0)
     let cumulDensity = []
     cumulative.map((val, idx) => cumulDensity[idx] = {"bin": density[idx]["bin"], "value": val})
     return cumulDensity

--- a/src/components/DistributionComparisonModal.svelte
+++ b/src/components/DistributionComparisonModal.svelte
@@ -1,5 +1,6 @@
 <script>
   import { Button, ButtonGroup } from '@graph-paper/button';
+  import SliderSwitch from '../components/controls/SliderSwitch.svelte'
   import Modal from './Modal.svelte';
   import DistributionComparisonGraph from './explore/DistributionComparisonGraph.svelte';
   import DistributionChart from './explore/DistributionChart.svelte';
@@ -38,18 +39,17 @@
   }
 
   const makeCumulative = function(density) {
-    let values = density.map((d) => d[valueSelector])
-    console.log(values)
-    let cumulative = []
-    values.reduce((prev, curr, i) => cumulative[i] = Math.min(roundVal(prev + curr), 1), 0)
-    let cumulDensity = []
-    cumulative.map((val, idx) => cumulDensity[idx] = {"bin": density[idx]["bin"], "value": val})
-    return cumulDensity
+    let values = density.map((d) => d[valueSelector]);
+    let cumulative = [];
+    values.reduce((prev, curr, i) => cumulative[i] = Math.min(roundVal(prev + curr), 1), 0);
+    let cumulDensity = [];
+    cumulative.map((val, idx) => cumulDensity[idx] = {"bin": density[idx]["bin"], "value": val});
+    return cumulDensity;
   }
 
   const buildDensity = function(chartData) {
-    let density = normalized ? chartData[densityMetricType] : convertValueToPercentage(chartData[densityMetricType])
-    return cumulative ? makeCumulative(density) : density
+    let density = normalized ? chartData[densityMetricType] : convertValueToPercentage(chartData[densityMetricType]);
+    return cumulative ? makeCumulative(density) : density;
   }
 </script>
 
@@ -108,18 +108,7 @@
     <div class="outer-flex">
       <div class="charts">
         <div style="display: flex; padding: 1em;">
-          <ButtonGroup>
-            <Button
-              tooltip="Toggle Cumulative"
-              on:click={() => {
-                cumulative = !cumulative;
-              }}
-              label="Toggle Cumulative"
-              toggled={cumulative}
-              level="medium"
-              compact
-            />
-          </ButtonGroup>
+          <SliderSwitch bind:checked={cumulative} label="Cumulative mode: " design="slider" />
         </div>
         <div class="chart-fixed">
           <p>Reference</p>

--- a/src/components/DistributionComparisonModal.svelte
+++ b/src/components/DistributionComparisonModal.svelte
@@ -1,5 +1,5 @@
 <script>
-  import SliderSwitch from './controls/SliderSwitch.svelte'
+  import SliderSwitch from './controls/SliderSwitch.svelte';
   import Modal from './Modal.svelte';
   import DistributionComparisonGraph from './explore/DistributionComparisonGraph.svelte';
   import DistributionChart from './explore/DistributionChart.svelte';
@@ -33,21 +33,27 @@
     return Math.min(topTick, 1);
   };
 
-  const roundVal = function(val) {
-    return Math.round(val * 10000)/10000;
-  }
+  const roundVal = function (val) {
+    return Math.round(val * 10000) / 10000;
+  };
 
-  const makeCumulative = function(density) {
+  const makeCumulative = function (density) {
     let values = density.map((d) => d[valueSelector]);
-    let cumulVals = []
-    values.reduce((acc, curr) => { let sum = Math.min(roundVal(acc + curr), 1); cumulVals.push(sum); return sum }, 0);
-    return cumulVals.map((val, idx) => ({"bin": density[idx].bin, "value": val}));;
-  }
+    let cumulVals = [];
+    values.reduce((acc, curr) => {
+      let sum = Math.min(roundVal(acc + curr), 1);
+      cumulVals.push(sum);
+      return sum;
+    }, 0);
+    return cumulVals.map((val, idx) => ({ bin: density[idx].bin, value: val }));
+  };
 
-  const buildDensity = function(chartData) {
-    let density = normalized ? chartData[densityMetricType] : convertValueToPercentage(chartData[densityMetricType]);
+  const buildDensity = function (chartData) {
+    let density = normalized
+      ? chartData[densityMetricType]
+      : convertValueToPercentage(chartData[densityMetricType]);
     return cumulative ? makeCumulative(density) : density;
-  }
+  };
 </script>
 
 <style>
@@ -105,7 +111,11 @@
     <div class="outer-flex">
       <div class="charts">
         <div style="display: flex; padding: 1em;">
-          <SliderSwitch bind:checked={cumulative} label="Cumulative mode: " design="slider" />
+          <SliderSwitch
+            bind:checked={cumulative}
+            label="Cumulative mode: "
+            design="slider"
+          />
         </div>
         <div class="chart-fixed">
           <p>Reference</p>

--- a/src/components/DistributionComparisonModal.svelte
+++ b/src/components/DistributionComparisonModal.svelte
@@ -1,6 +1,5 @@
 <script>
-  import { Button, ButtonGroup } from '@graph-paper/button';
-  import SliderSwitch from '../components/controls/SliderSwitch.svelte'
+  import SliderSwitch from './controls/SliderSwitch.svelte'
   import Modal from './Modal.svelte';
   import DistributionComparisonGraph from './explore/DistributionComparisonGraph.svelte';
   import DistributionChart from './explore/DistributionChart.svelte';
@@ -40,11 +39,9 @@
 
   const makeCumulative = function(density) {
     let values = density.map((d) => d[valueSelector]);
-    let cumulative = [];
-    values.reduce((prev, curr, i) => cumulative[i] = Math.min(roundVal(prev + curr), 1), 0);
-    let cumulDensity = [];
-    cumulative.map((val, idx) => cumulDensity[idx] = {"bin": density[idx]["bin"], "value": val});
-    return cumulDensity;
+    let cumulVals = []
+    values.reduce((acc, curr) => { let sum = Math.min(roundVal(acc + curr), 1); cumulVals.push(sum); return sum }, 0);
+    return cumulVals.map((val, idx) => ({"bin": density[idx].bin, "value": val}));;
   }
 
   const buildDensity = function(chartData) {

--- a/src/components/controls/SliderSwitch.svelte
+++ b/src/components/controls/SliderSwitch.svelte
@@ -5,85 +5,83 @@
 
   export let checked = true;
 
+  const uniqueID = Math.floor(Math.random() * 100);
 
-  const uniqueID = Math.floor(Math.random() * 100)
+  function handleClick(event) {
+    const { target } = event;
 
-  function handleClick(event){
-      const {target} = event
+    const state = target.getAttribute('aria-checked');
 
-      const state = target.getAttribute('aria-checked')
+    checked = state !== 'true';
 
-      checked = state !== 'true'
-
-      value = checked === true ? 'on' : 'off'
+    value = checked === true ? 'on' : 'off';
   }
-
 </script>
-<div class="s s--slider" style="font-size:{fontSize}px">
-  <span id={`switch-${uniqueID}`}>{label}</span>
-  <button
-      role="switch"
-      aria-checked={checked}
-      aria-labelledby={`switch-${uniqueID}`}
-      on:click={handleClick}>
-  </button>
-</div>
 
 <style>
-    :root {
-  --accent-color: CornflowerBlue;
-  --gray: #ccc;
-}
+  :root {
+    --accent-color: CornflowerBlue;
+    --gray: #ccc;
+  }
   .s--slider {
-      display: flex;
-      align-items: center;
+    display: flex;
+    align-items: center;
   }
 
   .s--slider button {
-      width: 3em;
-      height: 1.6em;
-      position: relative;
-      margin: 0 0 0 0.5em;
-      background: var(--gray);
-      border: none;
+    width: 3em;
+    height: 1.6em;
+    position: relative;
+    margin: 0 0 0 0.5em;
+    background: var(--gray);
+    border: none;
   }
 
   .s--slider button::before {
-      content: '';
-      position: absolute;
-      width: 1.3em;
-      height: 1.3em;
-      background: #fff;
-      top: 0.13em;
-      right: 1.5em;
-      transition: transform 0.3s;
+    content: '';
+    position: absolute;
+    width: 1.3em;
+    height: 1.3em;
+    background: #fff;
+    top: 0.13em;
+    right: 1.5em;
+    transition: transform 0.3s;
   }
 
-  .s--slider button[aria-checked='true']{
-      background-color: var(--accent-color)
+  .s--slider button[aria-checked='true'] {
+    background-color: var(--accent-color);
   }
 
-  .s--slider button[aria-checked='true']::before{
-      transform: translateX(1.3em);
-      transition: transform 0.3s;
+  .s--slider button[aria-checked='true']::before {
+    transform: translateX(1.3em);
+    transition: transform 0.3s;
   }
 
   .s--slider button:focus {
-      box-shadow: 0 0px 0px 1px var(--accent-color);
+    box-shadow: 0 0px 0px 1px var(--accent-color);
   }
 
   /* Slider Design Option */
   .s--slider button {
-      border-radius: 1.5em;
+    border-radius: 1.5em;
   }
 
   .s--slider button::before {
-      border-radius: 100%;
+    border-radius: 100%;
   }
 
   .s--slider button:focus {
-      box-shadow: 0 0px 8px var(--accent-color);
-      border-radius: 1.5em;
+    box-shadow: 0 0px 8px var(--accent-color);
+    border-radius: 1.5em;
   }
-
 </style>
+
+<div class="s s--slider" style="font-size:{fontSize}px">
+  <span id={`switch-${uniqueID}`}>{label}</span>
+  <button
+    role="switch"
+    aria-checked={checked}
+    aria-labelledby={`switch-${uniqueID}`}
+    on:click={handleClick}
+  />
+</div>

--- a/src/components/controls/SliderSwitch.svelte
+++ b/src/components/controls/SliderSwitch.svelte
@@ -1,5 +1,4 @@
 <script>
-
   export let label;
   export let fontSize = 16;
   export let value = 'on';
@@ -10,17 +9,14 @@
   const uniqueID = Math.floor(Math.random() * 100)
 
   function handleClick(event){
-      const target = event.target
+      const {target} = event
 
       const state = target.getAttribute('aria-checked')
 
-      checked = state === 'true' ? false : true
+      checked = state !== 'true'
 
       value = checked === true ? 'on' : 'off'
   }
-
-  const slugify = (str = "") =>
-  str.toLowerCase().replace(/ /g, "-").replace(/\./g, "");
 
 </script>
 <div class="s s--slider" style="font-size:{fontSize}px">

--- a/src/components/controls/SliderSwitch.svelte
+++ b/src/components/controls/SliderSwitch.svelte
@@ -1,0 +1,93 @@
+<script>
+
+  export let label;
+  export let fontSize = 16;
+  export let value = 'on';
+
+  export let checked = true;
+
+
+  const uniqueID = Math.floor(Math.random() * 100)
+
+  function handleClick(event){
+      const target = event.target
+
+      const state = target.getAttribute('aria-checked')
+
+      checked = state === 'true' ? false : true
+
+      value = checked === true ? 'on' : 'off'
+  }
+
+  const slugify = (str = "") =>
+  str.toLowerCase().replace(/ /g, "-").replace(/\./g, "");
+
+</script>
+<div class="s s--slider" style="font-size:{fontSize}px">
+  <span id={`switch-${uniqueID}`}>{label}</span>
+  <button
+      role="switch"
+      aria-checked={checked}
+      aria-labelledby={`switch-${uniqueID}`}
+      on:click={handleClick}>
+  </button>
+</div>
+
+<style>
+    :root {
+  --accent-color: CornflowerBlue;
+  --gray: #ccc;
+}
+  .s--slider {
+      display: flex;
+      align-items: center;
+  }
+
+  .s--slider button {
+      width: 3em;
+      height: 1.6em;
+      position: relative;
+      margin: 0 0 0 0.5em;
+      background: var(--gray);
+      border: none;
+  }
+
+  .s--slider button::before {
+      content: '';
+      position: absolute;
+      width: 1.3em;
+      height: 1.3em;
+      background: #fff;
+      top: 0.13em;
+      right: 1.5em;
+      transition: transform 0.3s;
+  }
+
+  .s--slider button[aria-checked='true']{
+      background-color: var(--accent-color)
+  }
+
+  .s--slider button[aria-checked='true']::before{
+      transform: translateX(1.3em);
+      transition: transform 0.3s;
+  }
+
+  .s--slider button:focus {
+      box-shadow: 0 0px 0px 1px var(--accent-color);
+  }
+
+  /* Slider Design Option */
+  .s--slider button {
+      border-radius: 1.5em;
+  }
+
+  .s--slider button::before {
+      border-radius: 100%;
+  }
+
+  .s--slider button:focus {
+      box-shadow: 0 0px 8px var(--accent-color);
+      border-radius: 1.5em;
+  }
+
+</style>


### PR DESCRIPTION
Resolves https://github.com/mozilla/glam/issues/2691
Distribution Comparison chart has a switchable Cumulative Mode

off:
<img width="2944" alt="Screenshot 2024-03-27 at 5 25 55 PM" src="https://github.com/mozilla/glam/assets/5804462/cfcaf27b-c91e-4fe1-9fe4-8d5452480870">

on:
<img width="2956" alt="Screenshot 2024-03-27 at 5 27 00 PM" src="https://github.com/mozilla/glam/assets/5804462/75406c9c-ceaa-44be-a748-298214f6bbbc">
