### PR TITLE
#2693 Improves Distribution Comparison for categorical probes

### DIFF
--- a/src/components/DistributionComparisonModal.svelte
+++ b/src/components/DistributionComparisonModal.svelte
@@ -16,6 +16,7 @@
   let probeType = $store.probe.type;
   let probeKind = $store.probe.details.kind;
   let cumulative = false;
+  let activeCategoricalProbeLabels = probeKind === "categorical" ? $store.probe.details.labels.filter((l) => $store.activeBuckets.includes(l)) : [];
 
   let valueSelector = 'value';
   // Change this value to adjust the minimum tick increment on the chart
@@ -49,9 +50,12 @@
     }, 0);
     return cumulVals.map((val, idx) => ({ bin: density[idx].bin, value: val }));
   };
-
   const buildDensity = function (chartData) {
     let density = chartData[densityMetricType]
+    if(probeKind === "categorical") {
+      let categoricalProbeLabels = $store.probe.details.labels;
+      density = density.filter((v, i) => { if($store.activeBuckets.includes(categoricalProbeLabels[i])) return v})
+    }
     if(probeType === "scalar" || !normalized) {
       density = convertValueToPercentage(chartData[densityMetricType]);
     }
@@ -133,6 +137,7 @@
                   density={topChartDensity}
                   {topTick}
                   {tickIncrement}
+                  {activeCategoricalProbeLabels}
                 >
                   <g slot="glam-body">
                     {#if bottomChartData}
@@ -144,6 +149,7 @@
                         {tickIncrement}
                         sampleCount={topChartSampleCount}
                         tooltipLocation="bottom"
+                        {activeCategoricalProbeLabels}
                       />
                     {/if}
                   </g>
@@ -163,6 +169,7 @@
                   density={bottomChartDensity}
                   {topTick}
                   {tickIncrement}
+                  {activeCategoricalProbeLabels}
                 >
                   <g slot="glam-body">
                     {#if bottomChartData}
@@ -173,6 +180,7 @@
                         {topTick}
                         sampleCount={bottomChartSampleCount}
                         tooltipLocation="top"
+                        {activeCategoricalProbeLabels}
                       />
                     {/if}
                   </g>

--- a/src/components/DistributionComparisonModal.svelte
+++ b/src/components/DistributionComparisonModal.svelte
@@ -16,7 +16,12 @@
   let probeType = $store.probe.type;
   let probeKind = $store.probe.details.kind;
   let cumulative = false;
-  let activeCategoricalProbeLabels = probeKind === "categorical" ? $store.probe.details.labels.filter((l) => $store.activeBuckets.includes(l)) : [];
+  let activeCategoricalProbeLabels =
+    probeKind === 'categorical'
+      ? $store.probe.details.labels.filter((l) =>
+          $store.activeBuckets.includes(l)
+        )
+      : [];
 
   let valueSelector = 'value';
   // Change this value to adjust the minimum tick increment on the chart
@@ -50,13 +55,16 @@
     }, 0);
     return cumulVals.map((val, idx) => ({ bin: density[idx].bin, value: val }));
   };
+
   const buildDensity = function (chartData) {
-    let density = chartData[densityMetricType]
-    if(probeKind === "categorical") {
+    let density = chartData[densityMetricType];
+    if (probeKind === 'categorical') {
       let categoricalProbeLabels = $store.probe.details.labels;
-      density = density.filter((v, i) => { if($store.activeBuckets.includes(categoricalProbeLabels[i])) return v})
+      density = density.filter((v, i) =>
+        $store.activeBuckets.includes(categoricalProbeLabels[i])
+      );
     }
-    if(probeType === "scalar" || !normalized) {
+    if (probeType === 'scalar' || !normalized) {
       density = convertValueToPercentage(chartData[densityMetricType]);
     }
     return cumulative ? makeCumulative(density) : density;
@@ -118,7 +126,7 @@
     <div class="outer-flex">
       <div class="charts">
         <div style="display: flex; padding: 1em;">
-          {#if probeKind !== "categorical"}
+          {#if probeKind !== 'categorical'}
             <SliderSwitch
               bind:checked={cumulative}
               label="Cumulative mode: "

--- a/src/components/DistributionComparisonModal.svelte
+++ b/src/components/DistributionComparisonModal.svelte
@@ -13,6 +13,8 @@
   export let distViewButtonId;
 
   let normalized = $store.productDimensions.normalizationType === 'normalized';
+  let probeType = $store.probe.type;
+  let probeKind = $store.probe.details.kind;
   let cumulative = false;
 
   let valueSelector = 'value';
@@ -49,9 +51,10 @@
   };
 
   const buildDensity = function (chartData) {
-    let density = normalized
-      ? chartData[densityMetricType]
-      : convertValueToPercentage(chartData[densityMetricType]);
+    let density = chartData[densityMetricType]
+    if(probeType === "scalar" || !normalized) {
+      density = convertValueToPercentage(chartData[densityMetricType]);
+    }
     return cumulative ? makeCumulative(density) : density;
   };
 </script>
@@ -111,11 +114,13 @@
     <div class="outer-flex">
       <div class="charts">
         <div style="display: flex; padding: 1em;">
-          <SliderSwitch
-            bind:checked={cumulative}
-            label="Cumulative mode: "
-            design="slider"
-          />
+          {#if probeKind !== "categorical"}
+            <SliderSwitch
+              bind:checked={cumulative}
+              label="Cumulative mode: "
+              design="slider"
+            />
+          {/if}
         </div>
         <div class="chart-fixed">
           <p>Reference</p>

--- a/src/components/explore/DistributionChart.svelte
+++ b/src/components/explore/DistributionChart.svelte
@@ -11,6 +11,7 @@
   export let topTick;
   export let sampleCount;
   export let tooltipLocation;
+  export let activeCategoricalProbeLabels;
 
   let height = (innerHeight * distributionComparisonGraph.heightMult) / 2;
   let color = 'var(--digital-blue-350)';
@@ -23,28 +24,26 @@
   let maxHeight = height - distributionComparisonGraph.top;
   let minHeight = distributionComparisonGraph.bottom;
   let probeKind = $store.probe.details.kind;
-  let categoricalProbeLabels = probeKind !== "categorical" ? [] : $store.probe.details.labels.filter((l) => $store.activeBuckets.includes(l));
   let formatPercent = (t) =>
     Intl.NumberFormat('en-US', {
       style: 'percent',
       maximumFractionDigits: 2,
     }).format(t);
-  let activeDensity = probeKind !== "categorical" ? density : density.filter((v, i) => { if($store.activeBuckets.includes(categoricalProbeLabels[i])) return v} )
 
   $: y = scaleLinear().domain([0, topTick]).range([minHeight, maxHeight]);
 
-  const bucketWidth = (width * 1.0101) / activeDensity.length;
+  const bucketWidth = (width * 1.0101) / density.length;
   const spaceBetweenBars = bucketWidth / 10;
   const barOffsetX = spaceBetweenBars / 2;
   const barWidth = bucketWidth - spaceBetweenBars;
 
   const buildBucketTxt = (index, bin) => {
     if(probeKind === "categorical") {
-      return categoricalProbeLabels[index]
+      return activeCategoricalProbeLabels[index]
     } else {
-      return index === activeDensity.length - 1
+      return index === density.length - 1
         ? `sample value ≥ ${bin}`
-        : `${bin} ≤ sample value ≤ ${activeDensity[index + 1][binSelector]}`
+        : `${bin} ≤ sample value ≤ ${density[index + 1][binSelector]}`
     }
   }
 </script>
@@ -61,7 +60,7 @@
 </style>
 
 <g style="fill: {color};">
-  {#each activeDensity as { bin, value }, i}
+  {#each density as { bin, value }, i}
     <rect
       stroke={color}
       x={offsetX + i * bucketWidth + barOffsetX}
@@ -73,7 +72,7 @@
 </g>
 
 <g style="fill: {'#fafafa'};">
-  {#each activeDensity as { bin, value }, i}
+  {#each density as { bin, value }, i}
     {@const bucketTxt = buildBucketTxt(i, bin)}
     {@const valTxt = `  |  ${formatPercent(value)} of samples (${formatCompact(
       sampleCount * value

--- a/src/components/explore/DistributionChart.svelte
+++ b/src/components/explore/DistributionChart.svelte
@@ -38,14 +38,13 @@
   const barWidth = bucketWidth - spaceBetweenBars;
 
   const buildBucketTxt = (index, bin) => {
-    if(probeKind === "categorical") {
-      return activeCategoricalProbeLabels[index]
-    } else {
-      return index === density.length - 1
-        ? `sample value ≥ ${bin}`
-        : `${bin} ≤ sample value ≤ ${density[index + 1][binSelector]}`
+    if (probeKind === 'categorical') {
+      return activeCategoricalProbeLabels[index];
     }
-  }
+    return index === density.length - 1
+      ? `sample value ≥ ${bin}`
+      : `${bin} ≤ sample value ≤ ${density[index + 1][binSelector]}`;
+  };
 </script>
 
 <style>

--- a/src/components/explore/DistributionChart.svelte
+++ b/src/components/explore/DistributionChart.svelte
@@ -3,6 +3,7 @@
   import { tooltip as tooltipAction } from '@graph-paper/core/actions';
   import { distributionComparisonGraph } from '../../utils/constants';
   import { formatCompact } from '../../utils/formatters';
+  import { store } from '../../state/store';
 
   export let innerHeight;
   export let innerWidth;
@@ -21,18 +22,31 @@
     distributionComparisonGraph.left;
   let maxHeight = height - distributionComparisonGraph.top;
   let minHeight = distributionComparisonGraph.bottom;
+  let probeKind = $store.probe.details.kind;
+  let categoricalProbeLabels = probeKind !== "categorical" ? [] : $store.probe.details.labels.filter((l) => $store.activeBuckets.includes(l));
   let formatPercent = (t) =>
     Intl.NumberFormat('en-US', {
       style: 'percent',
       maximumFractionDigits: 2,
     }).format(t);
+  let activeDensity = probeKind !== "categorical" ? density : density.filter((v, i) => { if($store.activeBuckets.includes(categoricalProbeLabels[i])) return v} )
 
   $: y = scaleLinear().domain([0, topTick]).range([minHeight, maxHeight]);
 
-  const bucketWidth = (width * 1.0101) / density.length;
+  const bucketWidth = (width * 1.0101) / activeDensity.length;
   const spaceBetweenBars = bucketWidth / 10;
   const barOffsetX = spaceBetweenBars / 2;
   const barWidth = bucketWidth - spaceBetweenBars;
+
+  const buildBucketTxt = (index, bin) => {
+    if(probeKind === "categorical") {
+      return categoricalProbeLabels[index]
+    } else {
+      return index === activeDensity.length - 1
+        ? `sample value ≥ ${bin}`
+        : `${bin} ≤ sample value ≤ ${activeDensity[index + 1][binSelector]}`
+    }
+  }
 </script>
 
 <style>
@@ -47,7 +61,7 @@
 </style>
 
 <g style="fill: {color};">
-  {#each density as { bin, value }, i}
+  {#each activeDensity as { bin, value }, i}
     <rect
       stroke={color}
       x={offsetX + i * bucketWidth + barOffsetX}
@@ -59,11 +73,8 @@
 </g>
 
 <g style="fill: {'#fafafa'};">
-  {#each density as { bin, value }, i}
-    {@const bucketTxt =
-      i === density.length - 1
-        ? `sample value ≥ ${bin}`
-        : `${bin} ≤ sample value ≤ ${density[i + 1][binSelector]}`}
+  {#each activeDensity as { bin, value }, i}
+    {@const bucketTxt = buildBucketTxt(i, bin)}
     {@const valTxt = `  |  ${formatPercent(value)} of samples (${formatCompact(
       sampleCount * value
     )})`}

--- a/src/components/explore/DistributionComparisonGraph.svelte
+++ b/src/components/explore/DistributionComparisonGraph.svelte
@@ -15,16 +15,20 @@
   export let density = [];
 
   let probeKind = $store.probe.details.kind;
-  let bins = probeKind === "categorical" ? activeCategoricalProbeLabels : density.map((d) => d.bin);
+  let bins =
+    probeKind === 'categorical'
+      ? activeCategoricalProbeLabels
+      : density.map((d) => d.bin);
 
   export let xTickFormatter = (t) =>
-    probeKind !== 'categorical' ? Intl.NumberFormat('en', { notation: 'compact' }).format(t) : t;
+    probeKind !== 'categorical'
+      ? Intl.NumberFormat('en', { notation: 'compact' }).format(t)
+      : t;
   export let yTickFormatter = (t) =>
     Intl.NumberFormat('en-US', {
       style: 'percent',
       maximumFractionDigits: 2,
     }).format(t);
-
 
   const getXTicks = (data) => {
     // for probes with too many data points, we only want to get

--- a/src/components/explore/DistributionComparisonGraph.svelte
+++ b/src/components/explore/DistributionComparisonGraph.svelte
@@ -3,6 +3,7 @@
   import { quantile } from 'd3-array';
   import DataGraphic from '../datagraphic/DataGraphic.svelte';
   import { distributionComparisonGraph } from '../../utils/constants';
+  import { store } from '../../state/store';
 
   export let innerHeight;
   export let innerWidth;
@@ -11,15 +12,19 @@
   export let key = Math.random().toString(36).substring(7);
 
   export let density = [];
+
+  let probeKind = $store.probe.details.kind;
+  let categoricalProbeLabels = probeKind !== "categorical" ? [] : $store.probe.details.labels.filter((l) => $store.activeBuckets.includes(l));
+  let bins = probeKind === "categorical" ? categoricalProbeLabels : density.map((d) => d.bin);
+
   export let xTickFormatter = (t) =>
-    Intl.NumberFormat('en', { notation: 'compact' }).format(t);
+    probeKind !== 'categorical' ? Intl.NumberFormat('en', { notation: 'compact' }).format(t) : t;
   export let yTickFormatter = (t) =>
     Intl.NumberFormat('en-US', {
       style: 'percent',
       maximumFractionDigits: 2,
     }).format(t);
 
-  let bins = density.map((d) => d.bin);
 
   const getXTicks = (data) => {
     // for probes with too many data points, we only want to get

--- a/src/components/explore/DistributionComparisonGraph.svelte
+++ b/src/components/explore/DistributionComparisonGraph.svelte
@@ -10,12 +10,12 @@
   export let topTick;
   export let tickIncrement;
   export let key = Math.random().toString(36).substring(7);
+  export let activeCategoricalProbeLabels;
 
   export let density = [];
 
   let probeKind = $store.probe.details.kind;
-  let categoricalProbeLabels = probeKind !== "categorical" ? [] : $store.probe.details.labels.filter((l) => $store.activeBuckets.includes(l));
-  let bins = probeKind === "categorical" ? categoricalProbeLabels : density.map((d) => d.bin);
+  let bins = probeKind === "categorical" ? activeCategoricalProbeLabels : density.map((d) => d.bin);
 
   export let xTickFormatter = (t) =>
     probeKind !== 'categorical' ? Intl.NumberFormat('en', { notation: 'compact' }).format(t) : t;

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -333,6 +333,7 @@
       topChartData={distViewTopChartData}
       bottomChartData={distViewBottomChartData}
       {distViewButtonId}
+      keySet={activeBins}
     >
       <div slot="comparisonSummary" class="dist-comp-percentile-tbl">
         <ComparisonSummary


### PR DESCRIPTION
Fix #2693 
Labels are properly displayed on chart
Only selected categories are displayed on chart

Fixed issue with Distribution Comparison showing wrong values for Scalar probes.


https://github.com/mozilla/glam/assets/5804462/21982b70-9351-471f-a10a-ac59ccd2dd3f

