### PR TITLE
Fix glean metrics not showing after fix for Categorical probes

### DIFF
--- a/src/components/DistributionComparisonModal.svelte
+++ b/src/components/DistributionComparisonModal.svelte
@@ -14,14 +14,14 @@
 
   let normalized = $store.productDimensions.normalizationType === 'normalized';
   let probeType = $store.probe.type;
-  let isCategoricalProbe = $store.probe.details && $store.probe.details.kind === 'categorical';
+  let isCategoricalProbe =
+    $store.probe.details && $store.probe.details.kind === 'categorical';
   let cumulative = false;
-  let activeCategoricalProbeLabels =
-    isCategoricalProbe
-      ? $store.probe.details.labels.filter((l) =>
-          $store.activeBuckets.includes(l)
-        )
-      : [];
+  let activeCategoricalProbeLabels = isCategoricalProbe
+    ? $store.probe.details.labels.filter((l) =>
+        $store.activeBuckets.includes(l)
+      )
+    : [];
 
   let valueSelector = 'value';
   // Change this value to adjust the minimum tick increment on the chart

--- a/src/components/DistributionComparisonModal.svelte
+++ b/src/components/DistributionComparisonModal.svelte
@@ -14,10 +14,10 @@
 
   let normalized = $store.productDimensions.normalizationType === 'normalized';
   let probeType = $store.probe.type;
-  let probeKind = $store.probe.details.kind;
+  let isCategoricalProbe = $store.probe.details && $store.probe.details.kind === 'categorical';
   let cumulative = false;
   let activeCategoricalProbeLabels =
-    probeKind === 'categorical'
+    isCategoricalProbe
       ? $store.probe.details.labels.filter((l) =>
           $store.activeBuckets.includes(l)
         )
@@ -58,7 +58,7 @@
 
   const buildDensity = function (chartData) {
     let density = chartData[densityMetricType];
-    if (probeKind === 'categorical') {
+    if (isCategoricalProbe) {
       let categoricalProbeLabels = $store.probe.details.labels;
       density = density.filter((v, i) =>
         $store.activeBuckets.includes(categoricalProbeLabels[i])
@@ -126,7 +126,7 @@
     <div class="outer-flex">
       <div class="charts">
         <div style="display: flex; padding: 1em;">
-          {#if probeKind !== 'categorical'}
+          {#if isCategoricalProbe}
             <SliderSwitch
               bind:checked={cumulative}
               label="Cumulative mode: "

--- a/src/components/explore/DistributionChart.svelte
+++ b/src/components/explore/DistributionChart.svelte
@@ -23,7 +23,7 @@
     distributionComparisonGraph.left;
   let maxHeight = height - distributionComparisonGraph.top;
   let minHeight = distributionComparisonGraph.bottom;
-  let probeKind = $store.probe.details.kind;
+  let isCategoricalProbe = $store.probe.details && $store.probe.details.kind === 'categorical';
   let formatPercent = (t) =>
     Intl.NumberFormat('en-US', {
       style: 'percent',
@@ -38,7 +38,7 @@
   const barWidth = bucketWidth - spaceBetweenBars;
 
   const buildBucketTxt = (index, bin) => {
-    if (probeKind === 'categorical') {
+    if (isCategoricalProbe) {
       return activeCategoricalProbeLabels[index];
     }
     return index === density.length - 1

--- a/src/components/explore/DistributionChart.svelte
+++ b/src/components/explore/DistributionChart.svelte
@@ -23,7 +23,8 @@
     distributionComparisonGraph.left;
   let maxHeight = height - distributionComparisonGraph.top;
   let minHeight = distributionComparisonGraph.bottom;
-  let isCategoricalProbe = $store.probe.details && $store.probe.details.kind === 'categorical';
+  let isCategoricalProbe =
+    $store.probe.details && $store.probe.details.kind === 'categorical';
   let formatPercent = (t) =>
     Intl.NumberFormat('en-US', {
       style: 'percent',

--- a/src/components/explore/DistributionComparisonGraph.svelte
+++ b/src/components/explore/DistributionComparisonGraph.svelte
@@ -14,11 +14,11 @@
 
   export let density = [];
 
-  let isCategoricalProbe = $store.probe.details && $store.probe.details.kind === 'categorical';
-  let bins =
-    isCategoricalProbe
-      ? activeCategoricalProbeLabels
-      : density.map((d) => d.bin);
+  let isCategoricalProbe =
+    $store.probe.details && $store.probe.details.kind === 'categorical';
+  let bins = isCategoricalProbe
+    ? activeCategoricalProbeLabels
+    : density.map((d) => d.bin);
 
   export let xTickFormatter = (t) =>
     !isCategoricalProbe

--- a/src/components/explore/DistributionComparisonGraph.svelte
+++ b/src/components/explore/DistributionComparisonGraph.svelte
@@ -14,14 +14,14 @@
 
   export let density = [];
 
-  let probeKind = $store.probe.details.kind;
+  let isCategoricalProbe = $store.probe.details && $store.probe.details.kind === 'categorical';
   let bins =
-    probeKind === 'categorical'
+    isCategoricalProbe
       ? activeCategoricalProbeLabels
       : density.map((d) => d.bin);
 
   export let xTickFormatter = (t) =>
-    probeKind !== 'categorical'
+    !isCategoricalProbe
       ? Intl.NumberFormat('en', { notation: 'compact' }).format(t)
       : t;
   export let yTickFormatter = (t) =>


### PR DESCRIPTION
This fixes the bug introduced in https://github.com/mozilla/glam/pull/2779, which searches for a field that's not present into Glean metrics' metadata.