### PR TITLE
Search for Darwin when Mac is selected

### DIFF
--- a/src/config/glean.js
+++ b/src/config/glean.js
@@ -42,7 +42,7 @@ export const FIREFOX_ON_GLEAN = {
       values: [
         { key: '*', label: 'All OSes' },
         { key: 'Windows', label: 'Windows' },
-        { key: 'Mac', label: 'Mac' },
+        { key: 'Darwin', label: 'Mac' },
         { key: 'Linux', label: 'Linux' },
       ],
       defaultValue: '*',


### PR DESCRIPTION
Found this while testing other stuff. GLAM erroneously reporting no data for Mac metric all along because in the data it's called Darwin.