### PR TITLE
Don't include Glean metrics on landing page to avoid api calls for metadata

### DIFF
--- a/glam/api/views.py
+++ b/glam/api/views.py
@@ -790,22 +790,19 @@ def _get_fx_most_used_probes(days=30, limit=9):
     legacy_table_name = (
         f"`{GLAM_BQ_PROD_PROJECT}.glam_etl.glam_desktop_nightly_aggregates`"
     )
-    fog_table_name = f"`{GLAM_BQ_PROD_PROJECT}.glam_etl.glam_fog_nightly_aggregates`"
 
     query = f"""
         WITH fx_metrics AS (
-            SELECT * EXCEPT(
-                    non_norm_histogram,
-                    non_norm_percentiles)
-                FROM
-                    {legacy_table_name}
-            UNION ALL (
-                SELECT * EXCEPT(
-                    app_id,
-                    channel,
-                    ping_type)
-                FROM
-                    {fog_table_name})),
+            SELECT
+                metric,
+                metric_key,
+                metric_type,
+                version,
+                os,
+                build_id,
+                histogram
+            FROM
+                {legacy_table_name}),
         selected_version AS (
             SELECT
                 ARRAY_AGG(DISTINCT version


### PR DESCRIPTION
This PR fixes a bug in which no probe is shown on the landing page. 
The root cause was actually a confusion related to `UNION ALL`  with `SELECT *` where the columns matched types but were not the "same" columns.

After iterating on the solution for a while I also found out that if we want to include Glean metrics in this mix then GLAM would need to make an api call to Glean Dictionary for every metric included in the resultset, so I decided to remove Glean metrics from this feature for the time being, especially because it's not a very important feature of GLAM.
