### PR TITLE
Fix Interpolate layout

### DIFF
--- a/src/components/explore/AggregationsOverTimeGraph.svelte
+++ b/src/components/explore/AggregationsOverTimeGraph.svelte
@@ -291,6 +291,7 @@
 
 <style>
   .chart-title {
+    flex: 1;
     display: flex;
     justify-content: space-between;
     padding: 0 1rem;
@@ -310,14 +311,17 @@
 {/if}
 
 <div on:contextmenu|preventDefault={onRightClick}>
-  <div class="chart-title">
-    <ChartTitle
-      {description}
-      left={aggregationsOverTimeGraph.left}
-      right={aggregationsOverTimeGraph.right}
-    >
-      {title}
-    </ChartTitle>
+  <div style="display: flex;">
+    <div class="chart-title">
+      <ChartTitle
+        {description}
+        left={aggregationsOverTimeGraph.left}
+        right={aggregationsOverTimeGraph.right}
+      >
+        {title}
+      </ChartTitle>
+    </div>
+    <slot name="smoother" />
   </div>
 
   <DataGraphic

--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -422,7 +422,6 @@
         </div>
       </div>
     {:else}
-      <slot name="smoother" />
       <AggregationsOverTimeGraph
         title={aggregationsOverTimeTitle}
         description={aggregationsOverTimeDescription}
@@ -449,6 +448,7 @@
         {smoothnessLevel}
       >
         <slot name="additional-plot-elements" />
+        <div slot="smoother"><slot name="smoother" /></div>
       </AggregationsOverTimeGraph>
     {/if}
   </div>

--- a/src/components/explore/QuantileExplorerView.svelte
+++ b/src/components/explore/QuantileExplorerView.svelte
@@ -109,7 +109,7 @@
   .interpolator {
     display: flex;
     align-items: initial;
-    padding-bottom: 10px;
+    padding-right: 50px;
     place-content: center;
   }
 
@@ -196,13 +196,13 @@
                 {yDomain}
                 {smoothnessLevel}
               >
-                <div slot="smoother" class="interpolator">
+                <div slot="smoother"class="interpolator">
                   <input
                     id="toggleSmooth"
                     type="checkbox"
                     bind:checked={smoothnessLevel}
                   />
-                  <label for="toggleSmooth">Interpolate</label>
+                  <h3 for="toggleSmooth" class="data-graphic__element-title">Interpolate</h3>
                   <span
                     use:tooltipAction={{
                       text: 'Applies a moving average to smooth out short-term fluctuations on percentile values.',


### PR DESCRIPTION
Moves the `Interpolate` checkbox to a better (but maybe not the best) place.
![Screenshot 2024-10-21 at 1 19 00 PM](https://github.com/user-attachments/assets/f38ed760-a643-4996-86e1-b1f1359bf7e5)
