### PR TITLE
fix: interpolate empty histograms + tooltip

### DIFF
--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -115,9 +115,10 @@
 
     return data.map((item) => {
       const histogram = item[histogramAccessor];
-      const interpVals = histogram
-        ? getInterpPercBtnRanksForHistogram(histogram, percentiles)
-        : percentiles;
+      const interpVals =
+        histogram && histogram.length
+          ? getInterpPercBtnRanksForHistogram(histogram, percentiles)
+          : percentiles;
       const { [percentileAccessor]: _, ...rest } = item;
       return {
         ...rest,

--- a/src/components/explore/QuantileExplorerView.svelte
+++ b/src/components/explore/QuantileExplorerView.svelte
@@ -206,7 +206,7 @@
                   </h3>
                   <span
                     use:tooltipAction={{
-                      text: 'Generates percentiles using the Between Closest Ranks Linear Interpolation. This can show an innacurate representation of the data if the underlying distribution is not continuous and/or the data between bins is not uniformly distributed.',
+                      text: 'Generates percentiles using the Between Closest Ranks Linear Interpolation. This can show an inaccurate representation of the data if the underlying distribution is not continuous and/or the data within bins is not uniformly distributed.',
                       location: 'top',
                     }}
                     class="data-graphic__element-title__icon"


### PR DESCRIPTION
Adds to https://github.com/mozilla/glam/pull/2995
Fixes: https://github.com/mozilla/glam/issues/2985