### PR TITLE
Add Additional Delivery to Google Artifact Repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ jobs:
     executor: gcp-gcr/default
     environment:
       GOOGLE_PROJECT_ID: moz-fx-dataops-images-global
+      GLAM_PROJECT_ID: moz-fx-glam-prod
     steps:
       - checkout
       - gcp-gcr/gcr-auth
@@ -185,22 +186,23 @@ jobs:
             echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
             echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
             echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
+
       - gcp-cli/setup:
           use_oidc: true
-          
+
       - gcp-gcr/build-image:
           workspace-root: dockerfiles/proxy
           path: dockerfiles/proxy
           docker-context: dockerfiles/proxy
           registry-url: us-docker.pkg.dev
-          google-project-id: moz-fx-glam-prod
+          google-project-id: GLAM_PROJECT_ID
           repository: glam-prod
           image: auth0-proxy
           tag: $CIRCLE_SHA1
 
       - gcp-gcr/push-image:
           registry-url: us-docker.pkg.dev
-          google-project-id: moz-fx-glam-prod
+          google-project-id: GLAM_PROJECT_ID
           repository: glam-prod
           image: auth0-proxy
           tag: $CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  gcp-cli: circleci/gcp-cli@3.1.1
   gcp-gcr: circleci/gcp-gcr@0.16.2
 
 jobs:
@@ -98,11 +99,11 @@ jobs:
       - run:
           name: Restore Docker image cache
           command: docker load -i /tmp/cache/app.tar
-      - run:
+      - run: # TODO: remove this step after migration
           name: Login to Dockerhub
           command: |
             echo "${DOCKER_PASSWORD}" | docker login -u="${DOCKER_USER}" --password-stdin
-      - run:
+      - run: # TODO: remove this step after migration
           name: Deploy to Dockerhub
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
@@ -116,8 +117,28 @@ jobs:
               docker tag app:build "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}"
               docker push ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}
             fi
+      - run:
+          name: Prepare environment variables for OIDC authentication
+          command: |
+            echo 'export GOOGLE_PROJECT_ID="moz-fx-experimenter-prod-6cd5"' >> "$BASH_ENV"
+            echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
+            echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
+            echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
+            echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
+      - gcp-cli/setup:
+          use_oidc: true
+      - run:
+          name: Deploy to Google Artifact Registry
+          command: |
+            gcloud auth configure-docker us-docker.pkg.dev --quiet
+            DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/experimenter"
+            docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
+            docker push "${DOCKER_IMAGE}:latest"
+            GIT_SHA=$(git rev-parse --short HEAD)
+            docker tag experimenter:deploy ${DOCKER_IMAGE}:${GIT_SHA}
+            docker push ${DOCKER_IMAGE}:${GIT_SHA}
 
-  proxy-build-and-publish:
+  proxy-build-and-publish: # TODO move this to shared openresty repo
     executor: gcp-gcr/default
     environment:
       GOOGLE_PROJECT_ID: moz-fx-dataops-images-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - run:
           name: Prepare environment variables for OIDC authentication
           command: |
-            echo 'export GOOGLE_PROJECT_ID="moz-fx-experimenter-prod-6cd5"' >> "$BASH_ENV"
+            echo 'export GOOGLE_PROJECT_ID="moz-fx-glam-prod"' >> "$BASH_ENV"
             echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
             echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
             echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   gcp-cli: circleci/gcp-cli@3.1.1
-  gcp-gcr: circleci/gcp-gcr@0.16.2
+  gcp-gcr: circleci/gcp-gcr@0.16.7
 
 jobs:
   build:
@@ -130,13 +130,18 @@ jobs:
       - run:
           name: Deploy to Google Artifact Registry
           command: |
-            gcloud auth configure-docker us-docker.pkg.dev --quiet
-            DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/experimenter"
-            docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
-            docker push "${DOCKER_IMAGE}:latest"
-            GIT_SHA=$(git rev-parse --short HEAD)
-            docker tag experimenter:deploy ${DOCKER_IMAGE}:${GIT_SHA}
-            docker push ${DOCKER_IMAGE}:${GIT_SHA}
+            DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-glam-prod/glam-prod/glam"
+            docker tag app:build ${DOCKER_IMAGE}:${CIRCLE_SHA1}
+            docker tag app:build ${DOCKER_IMAGE}:${CIRCLE_BRANCH}
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+              # tag the CI-built docker image with latest & the latest git commit SHA
+              docker tag ${DOCKER_IMAGE}:${CIRCLE_SHA1} ${DOCKER_IMAGE}:latest
+            elif  [ ! -z "${CIRCLE_TAG}" ]; then
+              # tag the CI-built docker image with the Git Release or CircleCI Tag (they are the same thing)
+              docker tag ${DOCKER_IMAGE}:${CIRCLE_SHA1} ${DOCKER_IMAGE}:${CIRCLE_TAG}"
+            fi
+            # push all tags associated with the image
+            docker push -a ${DOCKER_IMAGE}:${CIRCLE_SHA1}
 
   proxy-build-and-publish: # TODO move this to shared openresty repo
     executor: gcp-gcr/default
@@ -168,6 +173,38 @@ jobs:
           registry-url: gcr.io
           tag: $CIRCLE_TAG
           google-project-id: GOOGLE_PROJECT_ID
+
+      # this could be done by re-tagging the existing image but for ease of migration
+      # I'm duplicating it fully with the intent of removing the above steps entirely
+      # /moz-fx-glam-prod/glam-prod/glam@sha256:705f53c5511c5803c6ea58896a93a97a30dc8defdef19c5d2243c3171a13be25
+      - run:
+          name: Prepare environment variables for OIDC authentication
+          command: |
+            echo 'export GOOGLE_PROJECT_ID="moz-fx-experimenter-prod-6cd5"' >> "$BASH_ENV"
+            echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
+            echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
+            echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
+            echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
+      - gcp-cli/setup:
+          use_oidc: true
+          
+      - gcp-gcr/build-image:
+          workspace-root: dockerfiles/proxy
+          path: dockerfiles/proxy
+          docker-context: dockerfiles/proxy
+          registry-url: us-docker.pkg.dev
+          google-project-id: moz-fx-glam-prod
+          repository: glam-prod
+          image: auth0-proxy
+          tag: $CIRCLE_SHA1
+
+      - gcp-gcr/push-image:
+          registry-url: us-docker.pkg.dev
+          google-project-id: moz-fx-glam-prod
+          repository: glam-prod
+          image: auth0-proxy
+          tag: $CIRCLE_SHA1
+
 
   proxy-rollback-auth:
     executor: gcp-gcr/default


### PR DESCRIPTION
Adds GAR (Google Artifact Repository) as a second delivery source for GLAM images

Functionality was test in a temporary branch, which produced [this artifact](https://console.cloud.google.com/artifacts/docker/moz-fx-glam-prod/us/glam-prod/glam?project=moz-fx-glam-prod) 

The pipeline steps here are intentionally not DRY'd up between the existing GCR delivery as those steps can simply be deleted after V2 Migration is complete. Additionally GAR delivery was added for both the main glam app container and the auth0 proxy which creates some additional cruft during the transition