### PR TITLE
Seperate GAR upload step, rename deploy to legacy-deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,42 @@ jobs:
             - /tmp/cache/app-frontend.tar
             - /tmp/cache/app.tar
 
+  gar-upload:
+    docker:
+      - image: cimg/base:stable
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASSWORD
+    steps:
+      - setup_remote_docker
+      - restore_cache:
+          key: v1-{{.Environment.CIRCLE_SHA1}}
+      - run:
+          name: Prepare environment variables for OIDC authentication
+          command: |
+            echo 'export GOOGLE_PROJECT_ID="moz-fx-glam-prod"' >> "$BASH_ENV"
+            echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
+            echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
+            echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
+            echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
+      - gcp-cli/setup:
+          use_oidc: true
+      - run:
+          name: Deploy to Google Artifact Registry
+          command: |
+            DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-glam-prod/glam-prod/glam"
+            docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_SHA1}"
+            docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_BRANCH}"
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+              # tag the CI-built docker image with latest & the latest git commit SHA
+              docker tag "${DOCKER_IMAGE}:${CIRCLE_SHA1}" "${DOCKER_IMAGE}:latest"
+            elif  [ ! -z "${CIRCLE_TAG}" ]; then
+              # tag the CI-built docker image with the Git Release or CircleCI Tag (they are the same thing)
+              docker tag "${DOCKER_IMAGE}:${CIRCLE_SHA1}" "${DOCKER_IMAGE}:${CIRCLE_TAG}"
+            fi
+            # push all tags associated with the image
+            docker push -a "${DOCKER_IMAGE}"
+
   frontend-tests:
     docker:
       - image: cimg/base:stable
@@ -86,7 +122,7 @@ jobs:
             cp .env-dist .env
             make build -v ${PWD}:/app
 
-  deploy:
+  legacy-deploy:
     docker:
       - image: cimg/base:stable
         auth:
@@ -117,31 +153,7 @@ jobs:
               docker tag app:build "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}"
               docker push ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}
             fi
-      - run:
-          name: Prepare environment variables for OIDC authentication
-          command: |
-            echo 'export GOOGLE_PROJECT_ID="moz-fx-glam-prod"' >> "$BASH_ENV"
-            echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
-            echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
-            echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
-            echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
-      - gcp-cli/setup:
-          use_oidc: true
-      - run:
-          name: Deploy to Google Artifact Registry
-          command: |
-            DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-glam-prod/glam-prod/glam"
-            docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_SHA1}"
-            docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_BRANCH}"
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              # tag the CI-built docker image with latest & the latest git commit SHA
-              docker tag "${DOCKER_IMAGE}:${CIRCLE_SHA1}" "${DOCKER_IMAGE}:latest"
-            elif  [ ! -z "${CIRCLE_TAG}" ]; then
-              # tag the CI-built docker image with the Git Release or CircleCI Tag (they are the same thing)
-              docker tag "${DOCKER_IMAGE}:${CIRCLE_SHA1}" "${DOCKER_IMAGE}:${CIRCLE_TAG}"
-            fi
-            # push all tags associated with the image
-            docker push -a "${DOCKER_IMAGE}"
+
 
   proxy-build-and-publish: # TODO move this to shared openresty repo
     executor: gcp-gcr/default
@@ -187,8 +199,6 @@ jobs:
             echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
             echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
 
-      - gcp-cli/setup:
-          use_oidc: true
 
       - gcp-gcr/build-image:
           workspace-root: dockerfiles/proxy
@@ -228,6 +238,9 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - gar-upload:
+          requires:
+            - build
       - frontend-tests:
           requires:
             - build
@@ -246,7 +259,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - deploy:
+      - legacy-deploy:
           requires:
             - frontend-tests
             - backend-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,9 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASSWORD
     steps:
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
+      - restore_cache:
+          key: v1-{{.Environment.CIRCLE_SHA1}}
       - run:
           name: Prepare environment variables for OIDC authentication
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,8 @@ workflows:
             tags:
               only: /.*/
       - gar-upload:
+          context:
+            - gcpv2-workload-identity
           requires:
             - build
       - frontend-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Restore Docker image cache
           command: docker load -i /tmp/cache/app.tar
-      - run: 'echo "Authenticating as ${echo $GCP_SERVICE_ACCOUNT_EMAIL | sed -e "s/@/ at /gi"}"'
+      - run: echo "Authenticating as $(echo $GCP_SERVICE_ACCOUNT_EMAIL | sed -e 's/@/ at /gi')"
       - run:
           name: Prepare environment variables for OIDC authentication
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Create a version.json
           command: |
@@ -47,12 +48,8 @@ jobs:
           username: $DOCKER_USER
           password: $DOCKER_PASSWORD
     steps:
-      - setup_remote_docker
-      - restore_cache:
-          key: v1-{{.Environment.CIRCLE_SHA1}}
-      - run:
-          name: Restore Docker image cache
-          command: docker load -i /tmp/cache/app.tar
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Prepare environment variables for OIDC authentication
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       - run:
           name: Restore Docker image cache
           command: docker load -i /tmp/cache/app.tar
+      - run: 'echo "Authenticating as ${echo $GCP_SERVICE_ACCOUNT_EMAIL | sed -e "s/@/ at /gi"}"'
       - run:
           name: Prepare environment variables for OIDC authentication
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ jobs:
       - restore_cache:
           key: v1-{{.Environment.CIRCLE_SHA1}}
       - run:
+          name: Restore Docker image cache
+          command: docker load -i /tmp/cache/app.tar
+      - run:
           name: Prepare environment variables for OIDC authentication
           command: |
             echo 'export GOOGLE_PROJECT_ID="moz-fx-glam-prod"' >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ jobs:
       - restore_cache:
           key: v1-{{.Environment.CIRCLE_SHA1}}
       - run:
+          name: Restore Docker image cache
+          command: docker load -i /tmp/cache/app.tar
+      - run:
           name: Prepare environment variables for OIDC authentication
           command: |
             echo 'export GOOGLE_PROJECT_ID="moz-fx-glam-prod"' >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
       - run:
           name: Deploy to Google Artifact Registry
           command: |
+            gcloud auth configure-docker us-docker.pkg.dev --quiet
             DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-glam-prod/glam-prod/glam"
             docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_SHA1}"
             docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_BRANCH}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - restore_cache:
-          key: v1-{{.Environment.CIRCLE_SHA1}}
-      - run:
-          name: Restore Docker image cache
-          command: docker load -i /tmp/cache/app.tar
       - run:
           name: Create a version.json
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - restore_cache:
+          key: v1-{{.Environment.CIRCLE_SHA1}}
+      - run:
+          name: Restore Docker image cache
+          command: docker load -i /tmp/cache/app.tar
       - run:
           name: Create a version.json
           command: |


### PR DESCRIPTION
Changing CI to make my own troubleshooting easier, and move this closer to end-state at once.

All images will get uploaded to GAR, tags will be used to differentiate stage vs prod releases from master.
Dev can be handled a few ways, will depend on chats w/ Eduardo (GLAM Dev) on how he wants it to work