### PR TITLE
feat: V2 migration CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,13 +69,18 @@ jobs:
       - run:
           name: Deploy to Google Artifact Registry
           command: | #shell
+            
+            # Exit w/ error if non-main branch is tagged with format 0.0.0
+            # per discssion w/ dev team we expect non-main branches to have alpha, beta, rc (etc) tags for stage release
+            [ ! "${CIRCLE_BRANCH}" == "main" ] && [[ "${CIRCLE_TAG}" =~ ^(?:[0-9]+\.?){1,3}$ ]] && echo "Non main branch tagged as prod release which is not allowed" && exit 1;
+
             gcloud auth configure-docker us-docker.pkg.dev --quiet;
             DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-glam-prod/glam-prod/glam";
-            [ ! -z "${CIRCLE_SHA1}" ] && docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_SHA1}"
-            [ ! -z "${CIRCLE_BRANCH}" ] && docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_BRANCH}"
+            [ ! -z "${CIRCLE_SHA1}" ] && docker tag app:build "${DOCKER_IMAGE}:commit-${CIRCLE_SHA1}"
+            [ ! -z "${CIRCLE_BRANCH}" ] && docker tag app:build "${DOCKER_IMAGE}:branch-${CIRCLE_BRANCH}"
             [ ! -z "${CIRCLE_TAG}" ] &&  docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_TAG}"
             [ "${CIRCLE_BRANCH}" == "main" ] && docker tag app:build "${DOCKER_IMAGE}:latest"
-
+          
             # push all tags associated with the image
             docker push -a "${DOCKER_IMAGE}"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Create a version.json
-          command: |
+          command: | #shell
             # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/main/docs/version_object.md
             printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
             "$CIRCLE_SHA1" \
@@ -26,12 +26,12 @@ jobs:
           name:
             Build Docker images for
             $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-          command: |
+          command: | #shell
             docker build --target frontend -t app-frontend:build .
             docker build -t app:build .
       - run:
           name: docker save
-          command: |
+          command: | #shell
             mkdir -p /tmp/cache
             docker save -o /tmp/cache/app-frontend.tar "app-frontend:build"
             docker save -o /tmp/cache/app.tar "app:build"
@@ -139,11 +139,11 @@ jobs:
           command: docker load -i /tmp/cache/app.tar
       - run: # TODO: remove this step after migration
           name: Login to Dockerhub
-          command: |
+          command: | #shell
             echo "${DOCKER_PASSWORD}" | docker login -u="${DOCKER_USER}" --password-stdin
       - run: # TODO: remove this step after migration
           name: Deploy to Dockerhub
-          command: |
+          command: | #shell
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               # tag the CI-built docker image with latest & the latest git commit SHA
               docker tag app:build ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:latest
@@ -194,7 +194,7 @@ jobs:
       # /moz-fx-glam-prod/glam-prod/glam@sha256:705f53c5511c5803c6ea58896a93a97a30dc8defdef19c5d2243c3171a13be25
       - run:
           name: Prepare environment variables for OIDC authentication
-          command: |
+          command: | #shell
             echo 'export GOOGLE_PROJECT_ID="moz-fx-experimenter-prod-6cd5"' >> "$BASH_ENV"
             echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
             echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       # - run: echo "Authenticating as $(echo $GCP_SERVICE_ACCOUNT_EMAIL | sed -e 's/@/ at /gi')"
       - run:
           name: Prepare environment variables for OIDC authentication
-          command: |
+          command: | #shell
             echo 'export GOOGLE_PROJECT_ID="moz-fx-glam-prod"' >> "$BASH_ENV"
             echo "export OIDC_WIP_ID=$GCPV2_WORKLOAD_IDENTITY_POOL_ID" >> "$BASH_ENV"
             echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
@@ -67,7 +67,7 @@ jobs:
           use_oidc: true
       - run:
           name: Deploy to Google Artifact Registry
-          command: |
+          command: | #shell
             gcloud auth configure-docker us-docker.pkg.dev --quiet;
             DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-glam-prod/glam-prod/glam";
             [ ! -z "${CIRCLE_SHA1}" ] && docker tag app:build "${DOCKER_IMAGE}:${CIRCLE_SHA1}"
@@ -105,7 +105,7 @@ jobs:
           command: docker load -i /tmp/cache/app.tar
       - run:
           name: Lint Python Code
-          command:
+          command: 
             docker-compose -f docker-compose.test.yml run --rm server make lint
       - run:
           name: Test Python Code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ jobs:
       - run:
           name: Restore Docker image cache
           command: docker load -i /tmp/cache/app.tar
-      # - run: echo "Authenticating as $(echo $GCP_SERVICE_ACCOUNT_EMAIL | sed -e 's/@/ at /gi')"
       - run:
           name: Prepare environment variables for OIDC authentication
           command: | #shell
@@ -63,8 +62,10 @@ jobs:
             echo "export OIDC_WIP_PROVIDER_ID=$GCPV2_CIRCLECI_WORKLOAD_IDENTITY_PROVIDER" >> "$BASH_ENV"
             echo "export GOOGLE_PROJECT_NUMBER=$GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER" >> "$BASH_ENV"
             echo "export OIDC_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL" >> "$BASH_ENV"
+
       - gcp-cli/setup:
           use_oidc: true
+
       - run:
           name: Deploy to Google Artifact Registry
           command: | #shell


### PR DESCRIPTION
- Code clean up from v2 migration, and other housekeeping
- Simplifies adding and pushing tags on images
- GAR tag+upload is blocked if a main-line semver tag is applied to a non-main branch

Image uploading and promotion workflow is intended to be as follows per request/discussion w/ @edugfilho 
- Dev will track the latest commit on the `main` branch for dev (by way of the `:latest` tag in GAR). Images are also tagged with `branch` and `commit` info incase there is a need to have dev fetch a working branch or specific past commit.
- Stage will be configured to track all releases with release candidate and similar semver tags e.g. v1.1-rc0, v1.2.3-rc4, also allowed `alpha` and `beta` tags
- Prod will be configured to track will track all stable tagged releases e.g v1.1, v4.5.6 

In order to prevent accidental production releases, the `gar-upload` step checks if the branch is the main branch AND the tag value is a non-qualified semver. If this condition is true the step logs the unexpected behavior and exits before taking any other actions incl. uploading images.

We expect the convention to be that stage releases ought to be merged to `main` first and then promoted as a release candidate by way of an `rc` tag (e.g. 1.1.1-rc1) but are not guarding against cases where that does not happen that at this time. In case a branch needed to get deployed to stage, tagging any commit with the qualifier `alpha` or `beta` would allow that while staying within semver norms.