### PR TITLE
DENG 8233: Fix categorical view for Labeled Counters with static list

### DIFF
--- a/src/components/explore/AggregationsOverTimeGraph.svelte
+++ b/src/components/explore/AggregationsOverTimeGraph.svelte
@@ -163,10 +163,9 @@
     'scalar',
     'quantity',
     'counter',
-    'labeled_counter',
   ];
 
-  const desktopLinearMetrics = ['histogram-linear', 'keyed-scalar', 'scalar'];
+  const desktopLinearMetrics = ['histogram-linear', 'keyed-scalar', 'scalar', 'labeled_counter'];
 
   const getYTicks = (ranges) => {
     // exponential and linear graphs

--- a/src/components/explore/AggregationsOverTimeGraph.svelte
+++ b/src/components/explore/AggregationsOverTimeGraph.svelte
@@ -165,7 +165,12 @@
     'counter',
   ];
 
-  const desktopLinearMetrics = ['histogram-linear', 'keyed-scalar', 'scalar', 'labeled_counter'];
+  const desktopLinearMetrics = [
+    'histogram-linear',
+    'keyed-scalar',
+    'scalar',
+    'labeled_counter',
+  ];
 
   const getYTicks = (ranges) => {
     // exponential and linear graphs

--- a/src/config/glean-base.js
+++ b/src/config/glean-base.js
@@ -1,7 +1,7 @@
 import produce from 'immer';
 import {
   transformAPIResponse,
-  transformLabeledCounterToCategoricalHistogram,
+  transformLabeledCounterToCategoricalHistogramSampleCount,
 } from '../utils/transform-data';
 import { stripDefaultValues } from '../utils/urls';
 import sharedDefaults, { extractBucketMetadata } from './shared';
@@ -181,7 +181,7 @@ export default {
           ...appStore.getState().probe.labels,
         };
         if (metricType === 'labeled_counter') {
-          data = transformLabeledCounterToCategoricalHistogram(data, labels);
+          data = transformLabeledCounterToCategoricalHistogramSampleCount(data, labels);
         }
         data = produce(data, (draft) =>
           draft.map((point) => ({

--- a/src/config/glean-base.js
+++ b/src/config/glean-base.js
@@ -181,7 +181,10 @@ export default {
           ...appStore.getState().probe.labels,
         };
         if (metricType === 'labeled_counter') {
-          data = transformLabeledCounterToCategoricalHistogramSampleCount(data, labels);
+          data = transformLabeledCounterToCategoricalHistogramSampleCount(
+            data,
+            labels
+          );
         }
         data = produce(data, (draft) =>
           draft.map((point) => ({

--- a/src/utils/transform-data.js
+++ b/src/utils/transform-data.js
@@ -257,7 +257,10 @@ export const transformAPIResponse = {
  * 6. Transforms the input data by adding histogram data, sample counts, and a constant metric key.
  * 7. Ensures the returned array contains unique entries for each `build_id`.
  */
-export const transformLabeledCounterToCategoricalHistogramSampleCount = (data, labels) => {
+export const transformLabeledCounterToCategoricalHistogramSampleCount = (
+  data,
+  labels
+) => {
   /* eslint-disable camelcase */
   const filteredData = data.filter((point) => point.client_agg_type === 'sum');
   const samplesPerBuild = filteredData.reduce(

--- a/src/utils/transform-data.js
+++ b/src/utils/transform-data.js
@@ -249,25 +249,27 @@ export const transformAPIResponse = {
  * of work involved in changing the ETL, we are doing it here.
  *
  * @description
- * 1. Calculates the total number of users per build (`clientsPerBuild`).
- * 2. Reverses the `labels` object to map labels back to their metric keys (`revertedLabels`).
- * 3. Initializes histograms for each label with zero values (`initHistograms`).
- * 4. Constructs normalized and non-normalized histograms for each build (`histogramsPerBuild`).
- * 5. Transforms the input data by adding histogram data, total users, and a constant metric key.
- * 6. Filters the transformed data to include only points with `client_agg_type` equal to 'count'.
+ * 1. Filters the transformed data to include only points with `client_agg_type` equal to 'sum'.
+ * 2. Calculates the total number of samples per build (`samplesPerBuild`).
+ * 3. Reverses the `labels` object to map labels back to their metric keys (`revertedLabels`).
+ * 4. Initializes histograms for each label with zero values (`initHistograms`).
+ * 5. Constructs normalized and non-normalized histograms for each build (`histogramsPerBuild`).
+ * 6. Transforms the input data by adding histogram data, sample counts, and a constant metric key.
  * 7. Ensures the returned array contains unique entries for each `build_id`.
  */
-export const transformLabeledCounterToCategoricalHistogram = (data, labels) => {
+export const transformLabeledCounterToCategoricalHistogramSampleCount = (data, labels) => {
   /* eslint-disable camelcase */
-  const clientsPerBuild = data
-    .filter((point) => point.client_agg_type === 'count')
-    .reduce((acc, { build_id, total_users }) => {
+  const filteredData = data.filter((point) => point.client_agg_type === 'sum');
+  const samplesPerBuild = filteredData.reduce(
+    (acc, { build_id, sample_count }) => {
       if (!acc[build_id]) {
         acc[build_id] = 0;
       }
-      acc[build_id] += total_users;
+      acc[build_id] += sample_count;
       return acc;
-    }, {});
+    },
+    {}
+  );
 
   const revertedLabels = Object.entries(labels).reduce((acc, [key, value]) => {
     acc[value] = key;
@@ -282,8 +284,8 @@ export const transformLabeledCounterToCategoricalHistogram = (data, labels) => {
     {}
   );
 
-  const histogramsPerBuild = data.reduce(
-    (acc, { build_id, metric_key, total_users }) => {
+  const histogramsPerBuild = filteredData.reduce(
+    (acc, { build_id, metric_key, sample_count }) => {
       if (!acc[build_id]) {
         acc[build_id] = {
           normalized: { ...initHistograms },
@@ -291,22 +293,22 @@ export const transformLabeledCounterToCategoricalHistogram = (data, labels) => {
         };
       }
       acc[build_id].normalized[revertedLabels[metric_key]] =
-        total_users / clientsPerBuild[build_id];
-      acc[build_id].non_normalized[revertedLabels[metric_key]] = total_users;
+        sample_count / samplesPerBuild[build_id];
+      acc[build_id].non_normalized[revertedLabels[metric_key]] = sample_count;
       return acc;
     },
     {}
   );
 
-  const transformed = produce(data, (draft) =>
+  const transformed = produce(filteredData, (draft) =>
     draft.map((point) => ({
       ...point,
       histogram: histogramsPerBuild[point.build_id].normalized,
       non_norm_histogram: histogramsPerBuild[point.build_id].non_normalized,
-      total_users: clientsPerBuild[point.build_id],
+      total_users: samplesPerBuild[point.build_id],
       metric_key: 'single',
     }))
-  ).filter((point) => point.client_agg_type === 'count');
+  );
 
   const uniqueTransformed = transformed.filter(
     (point, index, self) =>


### PR DESCRIPTION
Fixes a bug on transformLabeledCounterToCategoricalHistogram and changes the calculation to use `sample_count` instead of `client_count` (renamed to transformLabeledCounterToCategoricalHistogramSampleCount) 