### PR TITLE
Labeled Counter client counts calc uses max instead of sum

### DIFF
--- a/src/utils/transform-data.js
+++ b/src/utils/transform-data.js
@@ -279,12 +279,24 @@ export const transformLabeledCounterToCategoricalHistogramSampleCount = (
     {}
   );
 
+  const maxSampleCountPerBuild = filteredData.reduce(
+    (acc, { build_id, sample_count }) => {
+      if (!acc[build_id]) {
+        acc[build_id] = 0;
+      }
+      acc[build_id] = Math.max(acc[build_id], sample_count);
+      return acc;
+    },
+    {}
+  );
+
   const clientsPerBuild = filteredData.reduce(
     (acc, { build_id, total_users }) => {
       if (!acc[build_id]) {
         acc[build_id] = 0;
       }
-      acc[build_id] += total_users;
+      // Gets the max total_users for each build
+      acc[build_id] = Math.max(acc[build_id], total_users);
       return acc;
     },
     {}
@@ -325,7 +337,7 @@ export const transformLabeledCounterToCategoricalHistogramSampleCount = (
       histogram: histogramsPerBuild[point.build_id].normalized,
       non_norm_histogram: histogramsPerBuild[point.build_id].non_normalized,
       total_users: clientsPerBuild[point.build_id],
-      sample_count: samplesPerBuild[point.build_id],
+      sample_count: maxSampleCountPerBuild[point.build_id],
       metric_key: 'single',
     }))
   );


### PR DESCRIPTION
Since we started treating [static labelled counters as categorical](https://github.com/mozilla/glam/pull/3082), we've been dealing with the issue of counting clients for each build in the front-end. Since there are many aggregation types (min, max, count, sum and avg) and keys for each metric/build, we started with a SUM, but checking against the Legacy counterparts (see comparison below), the calculated counts were much higher. This PR changes the approach to a MAX, which also makes sense and brings the counts closer to Legacy for now.

Comparison:

[javascript_gc_parallel_mark_used](http://localhost:3000/fog/probe/javascript_gc_parallel_mark_used/explore?activeBuckets=%5B%22true%22%2C%22false%22%5D&ref=2025052521)
vs
[gc_parallel_mark](https://glam.telemetry.mozilla.org/firefox/probe/gc_parallel_mark/explore?activeBuckets=%5B%22yes%22%2C%22no%22%5D&ref=20250525210424)

and

[javascript_gc_reason](https://glam.telemetry.mozilla.org/fog/probe/javascript_gc_reason/explore?activeBuckets=%5B%22INTER_SLICE_GC%22%2C%22BG_TASK_FINISHED%22%2C%22CC_FINISHED%22%2C%22TOO_MUCH_MALLOC%22%2C%22ALLOC_TRIGGER%22%2C%22FULL_GC_TIMER%22%2C%22PAGE_HIDE%22%2C%22USER_INACTIVE%22%2C%22LOAD_END%22%2C%22TOO_MUCH_JIT_CODE%22%5D&ref=2025052703)
vs
[gc_reason_2](https://glam.telemetry.mozilla.org/firefox/probe/gc_reason_2/explore?activeBuckets=%5B%2247%22%2C%2215%22%2C%2236%22%2C%2249%22%2C%2252%22%2C%2238%22%2C%226%22%2C%2240%22%2C%225%22%2C%228%22%5D&process=parent)