### PR TITLE
Nonexistent product lands on Not Found page

### DIFF
--- a/src/routing/Router.svelte
+++ b/src/routing/Router.svelte
@@ -41,6 +41,20 @@
   function useComponent(componentToUse, view) {
     return function handle({ params: { product, section, probeName } }) {
       const storeValue = get(store);
+      const productIsValid =
+        !product || Object.prototype.hasOwnProperty.call(productConfig, product);
+
+      if (!productIsValid) {
+        component = NotFound;
+        store.setField('route', {
+          product,
+          section: 'not-found',
+          probeName,
+          view: 'not-found',
+        });
+        return;
+      }
+
       component = componentToUse;
 
       // Issue #355: Update the probe here, whenever the path changes, to ensure

--- a/src/routing/Router.svelte
+++ b/src/routing/Router.svelte
@@ -42,7 +42,8 @@
     return function handle({ params: { product, section, probeName } }) {
       const storeValue = get(store);
       const productIsValid =
-        !product || Object.prototype.hasOwnProperty.call(productConfig, product);
+        !product ||
+        Object.prototype.hasOwnProperty.call(productConfig, product);
 
       if (!productIsValid) {
         component = NotFound;


### PR DESCRIPTION
Checks `product` param against `productConfig` obj and redirect nonexistent products to `NotFound` page