### PR TITLE
added lock icon due to special permissions requirement for users to participate in datatools matrix channel

### DIFF
--- a/src/components/regions/Footer.svelte
+++ b/src/components/regions/Footer.svelte
@@ -44,7 +44,7 @@
       <a href="https://www.mozilla.org/privacy/websites/#cookies">Cookies</a>
     </li>
     <li>
-      <a href="https://matrix.to/#/#datatools:mozilla.org">Matrix</a>
+      <a href="https://matrix.to/#/#datatools:mozilla.org">Matrix🔒</a>
     </li>
     <li>
       <a href="https://app.slack.com/client/T027LFU12/CB1EQ437S">Slack🔒</a>

--- a/src/routing/wrappers/Layout.svelte
+++ b/src/routing/wrappers/Layout.svelte
@@ -57,7 +57,7 @@
         href="https://matrix.to/#/#datatools:mozilla.org"
       >
         <img src="/static/logo.svg" width="18" height="18" alt="Mozilla logo" />
-        feedback
+        feedback🔒
       </a>
     </div>
   </header>


### PR DESCRIPTION
added lock icon, as attempting to join datatools matrix channel results in error 403 message: "MatrixError: [403] You are not invited to this room. (https://mozilla.modular.im/_matrix/client/v3/join/%23datatools%3Amozilla.org?server_name=mozilla.org&via=mozilla.org)"
and user can only click "OK" then and remains unable to send messages in that matrix channel.