### PR TITLE
Fix timespan, timing_distribution formatting according to time unit

### DIFF
--- a/src/components/explore/ProbeExplorer.svelte
+++ b/src/components/explore/ProbeExplorer.svelte
@@ -155,9 +155,15 @@
   export let yScaleType;
   export let yDomain;
   export let densityMetricType;
+  const NANOSECOND_METRIC_TYPES = [
+    'timing_distribution',
+    'labeled_timing_distribution',
+    'timespan',
+  ];
   export let yTickFormatter = formatCompact;
-  if (data[0].metric_type === 'timing_distribution') {
-    yTickFormatter = formatFromNanoseconds;
+  if (NANOSECOND_METRIC_TYPES.includes(data[0].metric_type)) {
+    const probeTimeUnit = $store.probe.time_unit;
+    yTickFormatter = (v) => formatFromNanoseconds(v, probeTimeUnit);
   }
   export let summaryNumberFormatter = yTickFormatter;
   export let comparisonKeyFormatter = (v) => v;

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -26,7 +26,24 @@ export const timecode = timeFormat('%H:%M:%S');
 export const formatBuildIDToOnlyDate = (b) => ymd(b);
 export const formatToBuildID = timeFormat('%Y%m%d%H%M%S');
 
-export const formatFromNanoseconds = (v) => {
+// Glean's supported time_units for timing_distribution / labeled_timing_distribution
+// / timespan. Values are always recorded in nanoseconds; time_unit is the unit
+// the metric author asked the value to be reported in.
+const TIME_UNITS_FROM_NS = {
+  nanosecond: { divisor: 1, suffix: 'ns' },
+  microsecond: { divisor: 1e3, suffix: 'μs' },
+  millisecond: { divisor: 1e6, suffix: 'ms' },
+  second: { divisor: 1e9, suffix: 's' },
+  minute: { divisor: 6e10, suffix: 'min' },
+  hour: { divisor: 3.6e12, suffix: 'h' },
+  day: { divisor: 8.64e13, suffix: 'd' },
+};
+
+export const formatFromNanoseconds = (v, timeUnit) => {
+  const unit = TIME_UNITS_FROM_NS[timeUnit];
+  if (unit) {
+    return `${formatCompact(v / unit.divisor)} ${unit.suffix}`;
+  }
   if (v < 1e3) {
     return `${format(',d')(v)} ns`;
   }


### PR DESCRIPTION
Fixes https://github.com/mozilla/glam/issues/2641

This makes the front-end aware of time unit and renders them accordingly. I decided to leave the data carrying raw values (nanoseconds) because it's less work, it's documented and prevents bugs such as rounding errors during aggregations.