### PR TITLE
Support and route legacy and new static labeled_counter rows

### DIFF
--- a/src/config/glean-base.js
+++ b/src/config/glean-base.js
@@ -2,7 +2,7 @@ import { produce } from 'immer';
 import {
   transformBooleanHistogramToCategoricalHistogram,
   transformAPIResponse,
-  transformLabeledCounterToCategoricalHistogramSampleCount,
+  transformLabeledCounterToCategorical,
 } from '../utils/transform-data';
 import { stripDefaultValues } from '../utils/urls';
 import sharedDefaults, { extractBucketMetadata } from './shared';
@@ -281,46 +281,48 @@ export default {
 
       // Attach labels to histogram if appropriate type.
       if (probeView === 'categorical') {
-        let labels = {
-          ...appStore.getState().probe.labels,
-        };
+        // boolean/labeled_boolean arrive with integer bins (0/1/2) that must be
+        // mapped to category names. labeled_counter is served by the ETL as a
+        // categorical histogram already keyed by label, so it needs no mapping.
         if (metricType === 'boolean' || metricType === 'labeled_boolean') {
           const dataAndLabels =
             transformBooleanHistogramToCategoricalHistogram(data);
           data = dataAndLabels.data;
-          labels = dataAndLabels.labels;
-        }
-        if (metricType === 'labeled_counter') {
-          data = transformLabeledCounterToCategoricalHistogramSampleCount(
-            data,
-            labels
+          const { labels } = dataAndLabels;
+          data = produce(data, (draft) =>
+            draft.map((point) => ({
+              ...point,
+              histogram: Object.entries(point.histogram).reduce(
+                (acc, [bin, value]) => {
+                  const intBin = Math.floor(bin);
+                  if (intBin in labels) {
+                    acc[labels[intBin]] = value;
+                  }
+                  return acc;
+                },
+                {}
+              ),
+              non_norm_histogram: Object.entries(
+                point.non_norm_histogram
+              ).reduce((acc, [bin, value]) => {
+                const intBin = Math.floor(bin);
+                if (intBin in labels) {
+                  acc[labels[intBin]] = value;
+                }
+                return acc;
+              }, {}),
+            }))
           );
+        } else if (metricType === 'labeled_counter') {
+          // Static labeled_counter: render against the declared labels. During
+          // the post-migration transition the response can mix new histogram-
+          // shaped rows with legacy scalar-shaped rows; transformLabeledCounter-
+          // ToCategorical routes each and merges them into one continuous series.
+          const { labels } = appStore.getState().probe;
+          if (Array.isArray(labels) && labels.length) {
+            data = transformLabeledCounterToCategorical(data, labels);
+          }
         }
-        data = produce(data, (draft) =>
-          draft.map((point) => ({
-            ...point,
-            histogram: Object.entries(point.histogram).reduce(
-              (acc, [bin, value]) => {
-                const intBin = Math.floor(bin);
-                if (intBin in labels) {
-                  acc[labels[intBin]] = value;
-                }
-                return acc;
-              },
-              {}
-            ),
-            non_norm_histogram: Object.entries(point.non_norm_histogram).reduce(
-              (acc, [bin, value]) => {
-                const intBin = Math.floor(bin);
-                if (intBin in labels) {
-                  acc[labels[intBin]] = value;
-                }
-                return acc;
-              },
-              {}
-            ),
-          }))
-        );
       }
       data = transformAPIResponse[viewType](data, aggregationLevel, metricType);
       return {

--- a/src/utils/transform-data.js
+++ b/src/utils/transform-data.js
@@ -249,18 +249,15 @@ export const transformAPIResponse = {
 };
 
 /**
- * Transforms labeled counter data into a categorical histogram format.
- * This transformation would ideally be done on the ETL, but given the amount
- * of work involved in changing the ETL, we are doing it here.
+ * Pivots LEGACY (pre-ETL-migration) scalar-shaped labeled_counter rows into a
+ * categorical histogram, one point per build. Each bar is the label's share of
+ * submitted samples (`sample_count(label) / Σ sample_count`). Output is keyed by
+ * the declared labels (extra/`__other__` keys dropped) so it lines up with the
+ * new histogram-shaped rows on a single category axis.
  *
- * @description
- * 1. Filters the transformed data to include only points with `client_agg_type` equal to 'sum'.
- * 2. Calculates the total number of samples per build (`samplesPerBuild`).
- * 3. Reverses the `labels` object to map labels back to their metric keys (`revertedLabels`).
- * 4. Initializes histograms for each label with zero values (`initHistograms`).
- * 5. Constructs normalized and non-normalized histograms for each build (`histogramsPerBuild`).
- * 6. Transforms the input data by adding histogram data, sample counts, and a constant metric key.
- * 7. Ensures the returned array contains unique entries for each `build_id`.
+ * This only handles old aggregates produced before static labeled_counters moved
+ * to the histogram pipeline; new rows are served pre-aggregated and skip this.
+ * It can be removed once all in-window versions have been recomputed.
  */
 export const transformLabeledCounterToCategoricalHistogramSampleCount = (
   data,
@@ -270,26 +267,18 @@ export const transformLabeledCounterToCategoricalHistogramSampleCount = (
   const filteredData = data.filter((point) => point.client_agg_type === 'sum');
   const samplesPerBuild = filteredData.reduce(
     (acc, { build_id, sample_count }) => {
-      if (!acc[build_id]) {
-        acc[build_id] = 0;
-      }
-      acc[build_id] += sample_count;
+      acc[build_id] = (acc[build_id] || 0) + sample_count;
       return acc;
     },
     {}
   );
-
   const maxSampleCountPerBuild = filteredData.reduce(
     (acc, { build_id, sample_count }) => {
-      if (!acc[build_id]) {
-        acc[build_id] = 0;
-      }
-      acc[build_id] = Math.max(acc[build_id], sample_count);
+      acc[build_id] = Math.max(acc[build_id] || 0, sample_count);
       return acc;
     },
     {}
   );
-
   const clientsPerBuild = filteredData.reduce(
     (acc, { build_id, total_users }) => {
       acc[build_id] = (acc[build_id] || 0) + total_users;
@@ -297,20 +286,10 @@ export const transformLabeledCounterToCategoricalHistogramSampleCount = (
     },
     {}
   );
-
-  const revertedLabels = Object.entries(labels).reduce((acc, [key, value]) => {
-    acc[value] = key;
-    return acc;
-  }, {});
-
-  const initHistograms = Object.keys(labels).reduce(
-    (innerAcc, key) => ({
-      ...innerAcc,
-      [key]: 0,
-    }),
+  const initHistograms = labels.reduce(
+    (acc, label) => ({ ...acc, [label]: 0 }),
     {}
   );
-
   const histogramsPerBuild = filteredData.reduce(
     (acc, { build_id, metric_key, sample_count }) => {
       if (!acc[build_id]) {
@@ -319,14 +298,15 @@ export const transformLabeledCounterToCategoricalHistogramSampleCount = (
           non_normalized: { ...initHistograms },
         };
       }
-      acc[build_id].normalized[revertedLabels[metric_key]] =
-        sample_count / Math.max(samplesPerBuild[build_id], 1);
-      acc[build_id].non_normalized[revertedLabels[metric_key]] = sample_count;
+      if (metric_key in acc[build_id].normalized) {
+        acc[build_id].normalized[metric_key] =
+          sample_count / Math.max(samplesPerBuild[build_id], 1);
+        acc[build_id].non_normalized[metric_key] = sample_count;
+      }
       return acc;
     },
     {}
   );
-
   const transformed = produce(filteredData, (draft) =>
     draft.map((point) => ({
       ...point,
@@ -334,16 +314,61 @@ export const transformLabeledCounterToCategoricalHistogramSampleCount = (
       non_norm_histogram: histogramsPerBuild[point.build_id].non_normalized,
       total_users: clientsPerBuild[point.build_id],
       sample_count: maxSampleCountPerBuild[point.build_id],
-      metric_key: 'single',
     }))
   );
-
-  const uniqueTransformed = transformed.filter(
+  return transformed.filter(
     (point, index, self) =>
       index === self.findIndex((p) => p.build_id === point.build_id)
   );
+};
 
-  return uniqueTransformed;
+/**
+ * Routes static labeled_counter rows to the correct categorical transform and
+ * merges them into a single series, rendering against the declared `labels`.
+ *
+ * - New rows are served pre-aggregated as label-keyed histograms
+ *   (`client_agg_type === 'summed_histogram'`) and are reconciled against the
+ *   declared labels (missing labels filled with 0, non-declared keys dropped).
+ * - Legacy scalar-shaped rows are pivoted via
+ *   transformLabeledCounterToCategoricalHistogramSampleCount.
+ *
+ * Both are emitted with one metric_key/client_agg_type so the chart renders a
+ * continuous category axis. During the post-migration transition both shapes can
+ * be present at once (refresh recomputes only the latest few versions; no
+ * backfill), so this routes per row rather than assuming a single shape.
+ */
+export const transformLabeledCounterToCategorical = (data, labels) => {
+  const toDeclaredLabels = (histogram) => {
+    const hist = histogram || {};
+    return labels.reduce((acc, label) => {
+      acc[label] = label in hist ? hist[label] : 0;
+      return acc;
+    }, {});
+  };
+
+  const newPoints = data
+    .filter((point) => point.client_agg_type === 'summed_histogram')
+    .map((point) => ({
+      ...point,
+      histogram: toDeclaredLabels(point.histogram),
+      non_norm_histogram: toDeclaredLabels(point.non_norm_histogram),
+    }));
+
+  const legacyRows = data.filter(
+    (point) => point.client_agg_type !== 'summed_histogram'
+  );
+  const legacyPoints = legacyRows.length
+    ? transformLabeledCounterToCategoricalHistogramSampleCount(
+        legacyRows,
+        labels
+      )
+    : [];
+
+  return [...legacyPoints, ...newPoints].map((point) => ({
+    ...point,
+    metric_key: '',
+    client_agg_type: 'summed_histogram',
+  }));
 };
 
 export const transformBooleanHistogramToCategoricalHistogram = (data) => {

--- a/tests/transform-data.test.js
+++ b/tests/transform-data.test.js
@@ -8,6 +8,7 @@ import {
   checkForHistogram,
   checkForPercentiles,
   checkForTotalUsers,
+  transformLabeledCounterToCategorical,
 } from '../src/utils/transform-data';
 
 describe('transform parameters must be either a function or falsy', () => {
@@ -149,5 +150,129 @@ describe('makeLabel', () => {
   it('uses build_date as label for build_id if present', () => {
     const t = transform(makeLabel.build_id)(data);
     expect(t[0].label).toEqual(new Date(2020, 6 - 1, 18, 17, 6, 0));
+  });
+});
+
+describe('transformLabeledCounterToCategorical', () => {
+  const LABELS = ['success', 'fail', 'timeout'];
+
+  // A new-style row: served pre-aggregated as a label-keyed histogram.
+  const newRow = (buildId, histogram, nonNormHistogram, totalUsers) => ({
+    build_id: buildId,
+    version: buildId,
+    metric_key: '',
+    client_agg_type: 'summed_histogram',
+    total_users: totalUsers,
+    histogram,
+    non_norm_histogram: nonNormHistogram,
+  });
+
+  // A legacy scalar-shaped row: one per (build, label), with sample counts.
+  const legacyRow = (buildId, metricKey, sampleCount, totalUsers, agg) => ({
+    build_id: buildId,
+    version: buildId,
+    metric_key: metricKey,
+    client_agg_type: agg || 'sum',
+    sample_count: sampleCount,
+    total_users: totalUsers,
+  });
+
+  it('returns [] for empty input', () => {
+    expect(transformLabeledCounterToCategorical([], LABELS)).toEqual([]);
+  });
+
+  it('reconciles new rows to the declared labels (fill missing, drop extras)', () => {
+    // success present, fail/timeout missing, __other__ is not a declared label.
+    const data = [
+      newRow(
+        'B1',
+        { success: 0.6, __other__: 0.3 },
+        { success: 6000, __other__: 3000 },
+        1000
+      ),
+    ];
+    const [point] = transformLabeledCounterToCategorical(data, LABELS);
+    expect(point.histogram).toEqual({ success: 0.6, fail: 0, timeout: 0 });
+    expect(point.non_norm_histogram).toEqual({
+      success: 6000,
+      fail: 0,
+      timeout: 0,
+    });
+    expect(point.metric_key).toBe('');
+    expect(point.client_agg_type).toBe('summed_histogram');
+  });
+
+  it('handles a new row whose histogram is an empty string', () => {
+    const data = [newRow('B1', '', '', 0)];
+    const [point] = transformLabeledCounterToCategorical(data, LABELS);
+    expect(point.histogram).toEqual({ success: 0, fail: 0, timeout: 0 });
+  });
+
+  it('pivots legacy scalar rows to sample-count proportions, one point per build', () => {
+    const data = [
+      legacyRow('B2', 'success', 600, 500),
+      legacyRow('B2', 'fail', 300, 300),
+      legacyRow('B2', 'timeout', 100, 200),
+    ];
+    const out = transformLabeledCounterToCategorical(data, LABELS);
+    expect(out).toHaveLength(1);
+    expect(out[0].histogram).toEqual({
+      success: 0.6,
+      fail: 0.3,
+      timeout: 0.1,
+    });
+    expect(out[0].non_norm_histogram).toEqual({
+      success: 600,
+      fail: 300,
+      timeout: 100,
+    });
+    expect(out[0].total_users).toBe(1000); // sum of per-label total_users
+    expect(out[0].metric_key).toBe('');
+    expect(out[0].client_agg_type).toBe('summed_histogram');
+  });
+
+  it('routes a mix of new and legacy rows, each through its own path', () => {
+    const data = [
+      newRow(
+        'B1',
+        { success: 0.7, fail: 0.2, timeout: 0.1 },
+        { success: 7000, fail: 2000, timeout: 1000 },
+        1000
+      ),
+      legacyRow('B2', 'success', 600, 500),
+      legacyRow('B2', 'fail', 400, 400), // timeout absent -> 0
+    ];
+    const out = transformLabeledCounterToCategorical(data, LABELS);
+    expect(out).toHaveLength(2);
+    const byBuild = Object.fromEntries(out.map((p) => [p.build_id, p]));
+    // new row: values taken straight from the served histogram
+    expect(byBuild.B1.histogram).toEqual({
+      success: 0.7,
+      fail: 0.2,
+      timeout: 0.1,
+    });
+    // legacy row: values computed from sample_count, missing label zero-filled
+    expect(byBuild.B2.histogram).toEqual({
+      success: 0.6,
+      fail: 0.4,
+      timeout: 0,
+    });
+    // both unified into one series
+    out.forEach((p) => {
+      expect(p.metric_key).toBe('');
+      expect(p.client_agg_type).toBe('summed_histogram');
+    });
+  });
+
+  it('ignores legacy non-sum agg rows when pivoting', () => {
+    const data = [
+      legacyRow('B3', 'success', 800, 700),
+      legacyRow('B3', 'fail', 200, 300),
+      // a 'count' row that must not affect the categorical output
+      legacyRow('B3', 'success', 999, 700, 'count'),
+    ];
+    const out = transformLabeledCounterToCategorical(data, LABELS);
+    expect(out).toHaveLength(1);
+    expect(out[0].histogram).toEqual({ success: 0.8, fail: 0.2, timeout: 0 });
   });
 });


### PR DESCRIPTION
fixes https://github.com/mozilla/glam/issues/3524

Static (with a static set of labels) `labeled_counter` is Glean's replacement for Legacy Telemetry's `histogram_categorical`. Because it's a `counter` it was being aggregated along with other counters, which leads to low-signal visualizations on GLAM. This PR aggregates static `labeled_counter`s in the `distribution` path. 

ETL fix: https://github.com/mozilla/bigquery-etl/pull/9622